### PR TITLE
Fix/property search pagination

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -474,6 +474,7 @@ export enum SortKey {
 
 export interface ListingFilterRequest {
   provinceId?: number | string
+  provinceCodes?: string[]
   districtId?: number
   wardId?: number | string
   isLegacy?: boolean
@@ -530,6 +531,7 @@ export interface ListingFilterRequest {
  */
 export interface ListingSearchApiRequest {
   provinceId?: number | string
+  provinceCodes?: string[]
   districtId?: number
   wardId?: number | string
   isLegacy?: boolean

--- a/src/utils/property/mapListingResponse.ts
+++ b/src/utils/property/mapListingResponse.ts
@@ -31,8 +31,9 @@ export function mapBackendToFrontendResponse(
 export function mapFrontendToBackendRequest(
   frontendFilter: Partial<ListingFilterRequest>,
 ): ListingSearchApiRequest {
-  return {
+  const payload = {
     provinceId: frontendFilter?.provinceId,
+    provinceCodes: frontendFilter?.provinceCodes,
     districtId: frontendFilter?.districtId,
     wardId: frontendFilter?.wardId,
     isLegacy: frontendFilter?.isLegacy,
@@ -55,8 +56,8 @@ export function mapFrontendToBackendRequest(
     serviceFee: frontendFilter?.serviceFee,
     amenityIds: frontendFilter?.amenityIds,
     keyword: frontendFilter?.keyword,
-    page: frontendFilter?.page,
-    size: frontendFilter?.size,
+    page: frontendFilter?.page ?? 0,
+    size: frontendFilter?.size ?? 10,
     status: frontendFilter?.status,
     userId: frontendFilter?.userId,
     sortBy: frontendFilter?.sortBy,
@@ -65,4 +66,6 @@ export function mapFrontendToBackendRequest(
     userLatitude: frontendFilter?.userLatitude,
     userLongitude: frontendFilter?.userLongitude,
   }
+
+  return payload
 }

--- a/src/utils/queryParams/index.ts
+++ b/src/utils/queryParams/index.ts
@@ -181,13 +181,16 @@ export function getFiltersFromQuery(
   // Location - parse based on isLegacy flag
   const provinceIdParam = parseStringParam(query, 'provinceId')
   if (provinceIdParam) {
-    // If isLegacy is explicitly true, parse as number; otherwise keep as string (for new address)
     if (filters.isLegacy === true) {
       filters.provinceId = Number(provinceIdParam)
     } else {
-      // For new address or when isLegacy is not set, keep as string
       filters.provinceId = provinceIdParam
     }
+  }
+
+  const provinceCodeParam = parseStringParam(query, 'provinceCode')
+  if (provinceCodeParam) {
+    filters.provinceCodes = provinceCodeParam.split(',')
   }
 
   filters.districtId = parseNumberParam(query, 'districtId')


### PR DESCRIPTION
This pull request updates how location filters are handled and improves default pagination behavior in the listing search utilities. The main focus is to support new province code-based filtering and to ensure pagination parameters have sensible defaults.

**Location filter enhancements:**

* Added support for `provinceCodes` in both the frontend-to-backend request mapping (`mapFrontendToBackendRequest`) and query parameter parsing (`getFiltersFromQuery`), allowing filtering by multiple province codes. [[1]](diffhunk://#diff-9f7394c62e62d7705ea3d6bfae5f9909047ae2d95fb13fafcf52ada1194f7a66L34-R36) [[2]](diffhunk://#diff-e524dfb168ebede6779122a39fdf5dfe25c3a12583553c69750fd759d379e4bcL184-R195)

**Pagination improvements:**

* Set default values for `page` (default to 0) and `size` (default to 10) in the backend request mapping if they are not provided by the frontend, ensuring consistent pagination behavior.

**Code organization:**

* Refactored the payload construction in `mapFrontendToBackendRequest` for clarity and maintainability.