### PR TITLE
fix: add proper query caching to prevent unnecessary refetching

### DIFF
--- a/src/components/organisms/accountManagement/index.tsx
+++ b/src/components/organisms/accountManagement/index.tsx
@@ -70,9 +70,8 @@ const AccountManagement: NextPage<AccountManagementProps> = ({
     queryKey: ['sellernet', 'personal-edit-profile'],
     queryFn: () => UserService.getProfile(),
     enabled: Boolean(user),
-    staleTime: 0,
-    gcTime: 0,
-    refetchOnMount: 'always',
+    staleTime: 2 * 60 * 1000, // 2 minutes
+    gcTime: 5 * 60 * 1000, // 5 minutes
     retry: false,
   })
 

--- a/src/hooks/useListings/useGetDraft.ts
+++ b/src/hooks/useListings/useGetDraft.ts
@@ -13,7 +13,7 @@ export const useGetDraft = (draftId: string | number | null) => {
       return ListingService.getDraft(draftId)
     },
     enabled: !!draftId,
-    staleTime: 0, // No cache for draft data
-    gcTime: 0, // Previously cacheTime, no cache retention
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 2 * 60 * 1000, // 2 minutes
   })
 }

--- a/src/hooks/useListings/useGetMyDrafts.ts
+++ b/src/hooks/useListings/useGetMyDrafts.ts
@@ -19,7 +19,7 @@ export const useGetMyDrafts = () => {
       const drafts = response.data as unknown as DraftListingResponse[]
       return mapDraftsArrayBackendToFrontend(drafts)
     },
-    staleTime: 0, // No cache for draft data
-    gcTime: 0, // Previously cacheTime, no cache retention
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 2 * 60 * 1000, // 2 minutes
   })
 }

--- a/src/hooks/useListings/useSimilarProperties.ts
+++ b/src/hooks/useListings/useSimilarProperties.ts
@@ -54,29 +54,9 @@ export const useSimilarProperties = (options: UseSimilarPropertiesOptions) => {
         size: limit,
       }
 
-      console.log('🔍 Fetching similar properties with request:', {
-        listingId,
-        searchRequest,
-        locationInfo: {
-          wardId,
-          districtId,
-          provinceId,
-        },
-      })
-
       const response = await ListingService.search(searchRequest)
 
-      console.log('📦 Similar properties API response:', {
-        code: response.code,
-        totalListings: response.data?.listings?.length,
-        totalCount: response.data?.totalCount,
-      })
-
       if (response.code !== '999999' || !response.data) {
-        console.error(
-          '❌ Failed to fetch similar properties:',
-          response.message,
-        )
         throw new Error(
           response.message || 'Failed to fetch similar properties',
         )
@@ -86,12 +66,6 @@ export const useSimilarProperties = (options: UseSimilarPropertiesOptions) => {
       const filteredListings = response.data.listings.filter(
         (listing) => listing.listingId !== Number(listingId),
       )
-
-      console.log('✅ Similar properties filtered:', {
-        totalFetched: response.data.listings.length,
-        afterFilter: filteredListings.length,
-        currentListingId: listingId,
-      })
 
       return filteredListings.slice(0, limit)
     },

--- a/src/hooks/useMembership/index.ts
+++ b/src/hooks/useMembership/index.ts
@@ -52,8 +52,8 @@ export const useMyMembership = (userId: string | undefined) => {
       return data || null
     },
     enabled: !!userId,
-    staleTime: 0, // No cache - always stale
-    gcTime: 0, // No cache - don't keep data
+    staleTime: 2 * 60 * 1000, // 2 minutes
+    gcTime: 5 * 60 * 1000, // 5 minutes
     retry: false, // Do not retry on failure
   })
 }

--- a/src/hooks/useMembership/useMembershipUpgrade.ts
+++ b/src/hooks/useMembership/useMembershipUpgrade.ts
@@ -53,8 +53,8 @@ export const useUpgradePreview = (
       return data || null
     },
     enabled: !!userId && !!targetMembershipId,
-    staleTime: 0, // No cache - always fresh
-    gcTime: 1 * 60 * 1000, // Keep in cache for 1 minute
+    staleTime: 60 * 1000, // 1 minute
+    gcTime: 2 * 60 * 1000, // 2 minutes
   })
 }
 

--- a/src/hooks/usePush/index.ts
+++ b/src/hooks/usePush/index.ts
@@ -21,8 +21,8 @@ export function usePushQuota() {
   return useQuery({
     queryKey: ['quota', 'PUSH'],
     queryFn: () => QuotaService.checkPushQuota(),
-    staleTime: 0, // Always fetch fresh data
-    gcTime: 1000 * 60, // Cache for 1 minute
+    staleTime: 60 * 1000, // 1 minute
+    gcTime: 2 * 60 * 1000, // 2 minutes
   })
 }
 
@@ -97,8 +97,8 @@ export function useAllQuotas() {
   return useQuery({
     queryKey: ['quota', 'all'],
     queryFn: () => QuotaService.checkAllQuotas(),
-    staleTime: 0,
-    gcTime: 1000 * 60,
+    staleTime: 60 * 1000, // 1 minute
+    gcTime: 2 * 60 * 1000, // 2 minutes
   })
 }
 
@@ -115,8 +115,8 @@ export function useQuota(benefitType: string) {
   return useQuery({
     queryKey: ['quota', benefitType],
     queryFn: () => QuotaService.checkQuota(benefitType),
-    staleTime: 0,
-    gcTime: 1000 * 60,
+    staleTime: 60 * 1000, // 1 minute
+    gcTime: 2 * 60 * 1000, // 2 minutes
     enabled: !!benefitType,
   })
 }

--- a/src/hooks/useRecentlyViewed/index.ts
+++ b/src/hooks/useRecentlyViewed/index.ts
@@ -37,11 +37,8 @@ export const useRecentlyViewed = () => {
       return []
     },
     enabled: isAuthenticated,
-    staleTime: 0,
-    gcTime: 0,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime: 2 * 60 * 1000, // 2 minutes
+    gcTime: 5 * 60 * 1000, // 5 minutes
   })
 
   // Sync mutation - sync localStorage with server

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,10 +12,9 @@ import { fetchNewestNews } from '@/api/services/news.service'
 import type { NewsItem } from '@/api/types/news.type'
 import { useQuery } from '@tanstack/react-query'
 
-const NO_CACHE_QUERY_CONFIG = {
-  staleTime: 0,
-  gcTime: 0,
-  refetchOnMount: 'always' as const,
+const HOMEPAGE_QUERY_CONFIG = {
+  staleTime: 5 * 60 * 1000, // 5 minutes
+  gcTime: 10 * 60 * 1000, // 10 minutes
 }
 
 const TOP_PROVINCE_IDS = [
@@ -43,7 +42,7 @@ const Home: NextPageWithLayout = () => {
       return response?.data || []
     },
     enabled: isClientSide,
-    ...NO_CACHE_QUERY_CONFIG,
+    ...HOMEPAGE_QUERY_CONFIG,
   })
 
   const { data: categoryStats } = useQuery<CategoryStatsItem[]>({
@@ -56,7 +55,7 @@ const Home: NextPageWithLayout = () => {
       return response?.data || []
     },
     enabled: isClientSide,
-    ...NO_CACHE_QUERY_CONFIG,
+    ...HOMEPAGE_QUERY_CONFIG,
   })
 
   const { data: latestNews } = useQuery<NewsItem[]>({
@@ -66,7 +65,7 @@ const Home: NextPageWithLayout = () => {
       return response?.success && response?.data ? response.data : []
     },
     enabled: isClientSide,
-    ...NO_CACHE_QUERY_CONFIG,
+    ...HOMEPAGE_QUERY_CONFIG,
   })
 
   return (

--- a/src/pages/properties/seller/[userId].tsx
+++ b/src/pages/properties/seller/[userId].tsx
@@ -24,11 +24,9 @@ const DEFAULT_PAGE_SIZE = 12
 const PAGE_SIZE_OPTIONS = ['6', '12', '24']
 const VIP_SECTION_ORDER: VipType[] = ['DIAMOND', 'GOLD', 'SILVER', 'NORMAL']
 
-const NO_CACHE_QUERY_CONFIG = {
-  staleTime: 0,
-  gcTime: 0,
-  refetchOnMount: 'always' as const,
-  refetchOnWindowFocus: true,
+const SELLER_QUERY_CONFIG = {
+  staleTime: 5 * 60 * 1000, // 5 minutes
+  gcTime: 10 * 60 * 1000, // 10 minutes
 }
 
 const SellerDetailPage: NextPageWithLayout = () => {
@@ -131,7 +129,7 @@ const SellerDetailPage: NextPageWithLayout = () => {
         placeholderData: (
           previousData: SellerVipSectionQueryData | undefined,
         ) => previousData,
-        ...NO_CACHE_QUERY_CONFIG,
+        ...SELLER_QUERY_CONFIG,
       }
     }),
   })
@@ -155,7 +153,7 @@ const SellerDetailPage: NextPageWithLayout = () => {
     },
     enabled: Boolean(userId),
     retry: 1,
-    ...NO_CACHE_QUERY_CONFIG,
+    ...SELLER_QUERY_CONFIG,
   })
 
   const {
@@ -179,7 +177,7 @@ const SellerDetailPage: NextPageWithLayout = () => {
     },
     enabled: Boolean(userId),
     retry: 1,
-    ...NO_CACHE_QUERY_CONFIG,
+    ...SELLER_QUERY_CONFIG,
   })
 
   const sectionMap = React.useMemo(() => {

--- a/src/pages/seller/create-post/index.tsx
+++ b/src/pages/seller/create-post/index.tsx
@@ -34,9 +34,8 @@ const CreatePostPage: NextPageWithLayout = () => {
     queryFn: () => UserService.getProfile(),
     enabled: isAuthenticated,
     retry: false,
-    staleTime: 0,
-    gcTime: 0,
-    refetchOnMount: 'always',
+    staleTime: 2 * 60 * 1000, // 2 minutes
+    gcTime: 5 * 60 * 1000, // 5 minutes
   })
 
   const hasPhoneNumber = React.useMemo(() => {


### PR DESCRIPTION
- Replace staleTime: 0 / gcTime: 0 with reasonable cache durations
- Homepage queries: 5min stale, 10min cache
- User data queries: 2min stale, 5min cache
- Draft queries: 30s stale, 2min cache
- Quota queries: 1min stale, 2min cache
- Remove debug console.logs from useSimilarProperties