### PR TITLE
fix: resolve premature logout by refreshing expired token on app reload

### DIFF
--- a/src/configs/axios/interceptors.ts
+++ b/src/configs/axios/interceptors.ts
@@ -16,28 +16,40 @@ import {
   isTokenExpired,
 } from './helpers'
 
+// Deduplication: prevent multiple concurrent refresh calls from racing
+let refreshPromise: Promise<string | null> | null = null
+
 const refreshToken = async (): Promise<string | null> => {
-  try {
-    const refreshTokenValue = getRefreshToken()
-    if (!refreshTokenValue) return null
+  // If a refresh is already in progress, wait for it instead of firing another
+  if (refreshPromise) return refreshPromise
 
-    const result = await AuthService.refreshToken(refreshTokenValue)
-    const { data, success } = result
+  refreshPromise = (async () => {
+    try {
+      const refreshTokenValue = getRefreshToken()
+      if (!refreshTokenValue) return null
 
-    if (!success) return null
+      const result = await AuthService.refreshToken(refreshTokenValue)
+      const { data, success } = result
 
-    if (typeof document !== 'undefined') {
-      cookieManager.setAuthTokens(data)
+      if (!success) return null
+
+      if (typeof document !== 'undefined') {
+        cookieManager.setAuthTokens(data)
+      }
+
+      return data.accessToken
+    } catch (error) {
+      // Only log in development
+      if (process.env.NODE_ENV === 'development') {
+        console.error('Token refresh failed:', error)
+      }
+      return null
+    } finally {
+      refreshPromise = null
     }
+  })()
 
-    return data.accessToken
-  } catch (error) {
-    // Only log in development
-    if (process.env.NODE_ENV === 'development') {
-      console.error('Token refresh failed:', error)
-    }
-    return null
-  }
+  return refreshPromise
 }
 
 const handleTokenRefresh = async (

--- a/src/contexts/auth/index.tsx
+++ b/src/contexts/auth/index.tsx
@@ -12,6 +12,9 @@ import { AuthTokens } from '@/configs/axios/types'
 import { useValidToken } from '@/hooks/useAuth'
 import { decodeToken } from '@/utils/decode-jwt'
 import { clearLegacyAuthStorage } from '@/utils/authLocalStorage'
+import { isTokenExpired } from '@/configs/axios/helpers'
+import { AuthService } from '@/api/services/auth.service'
+import { cookieManager } from '@/utils/cookies'
 import { toast } from 'sonner'
 import { useTranslations } from 'next-intl'
 
@@ -86,7 +89,7 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
 
       // Read latest state from the store (avoid stale closure)
       const currentState = useAuthStore.getState()
-      const tokens = currentState.getStoredTokens()
+      let tokens = currentState.getStoredTokens()
 
       try {
         // If localStorage says authenticated but no cookies → logout
@@ -98,9 +101,34 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
 
         // If we have tokens, validate them
         if (tokens?.accessToken) {
-          const result = await validToken(tokens.accessToken)
+          // If access token is expired, try refreshing before calling introspect
+          let activeAccessToken = tokens.accessToken
+          if (
+            isTokenExpired(activeAccessToken) &&
+            tokens.refreshToken &&
+            !isTokenExpired(tokens.refreshToken)
+          ) {
+            try {
+              const refreshResult = await AuthService.refreshToken(
+                tokens.refreshToken,
+              )
+              if (refreshResult.success && refreshResult.data) {
+                cookieManager.setAuthTokens(refreshResult.data)
+                activeAccessToken = refreshResult.data.accessToken
+                tokens = { ...tokens, ...refreshResult.data }
+              } else {
+                logout()
+                return
+              }
+            } catch {
+              logout()
+              return
+            }
+          }
+
+          const result = await validToken(activeAccessToken)
           if (result.success && 'data' in result && result.data?.valid) {
-            const { user } = decodeToken(tokens.accessToken)
+            const { user } = decodeToken(activeAccessToken)
             login(user, tokens)
           } else {
             logout()


### PR DESCRIPTION
- Add token refresh attempt in AuthProvider before introspect validation
- Add deduplication for concurrent refresh calls to prevent race conditions