### PR TITLE
feat(media): add R2 presigned upload helper and align type contracts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,16 @@ const nextConfig: NextConfig = {
             protocol: 'https',
             hostname: 'picsum.photos',
           },
+          // Cloudflare R2 — phase 1 public dev URL
+          {
+            protocol: 'https',
+            hostname: 'pub-444e165e3cc34721a5620508f66c58b0.r2.dev',
+          },
+          // Cloudflare R2 — phase 2 custom CDN domain (provisioned later)
+          {
+            protocol: 'https',
+            hostname: 'cdn.smartrent.io.vn',
+          },
         ]
       : [
           {
@@ -41,6 +51,14 @@ const nextConfig: NextConfig = {
           {
             protocol: 'https',
             hostname: 'picsum.photos',
+          },
+          {
+            protocol: 'https',
+            hostname: 'pub-444e165e3cc34721a5620508f66c58b0.r2.dev',
+          },
+          {
+            protocol: 'https',
+            hostname: 'cdn.smartrent.io.vn',
           },
         ],
     qualities: [75, 85, 90, 100],

--- a/src/api/services/media.service.ts
+++ b/src/api/services/media.service.ts
@@ -1,5 +1,5 @@
+import axios, { type AxiosProgressEvent } from 'axios'
 import { apiRequest } from '@/configs/axios/instance'
-import type { AxiosProgressEvent } from 'axios'
 import { PATHS } from '@/api/paths'
 import type { ApiResponse } from '@/configs/axios/types'
 import type {
@@ -7,9 +7,33 @@ import type {
   CreateUploadUrlRequest,
   CreateUploadUrlResponse,
   MediaItem,
+  MediaPurpose,
+  MediaType,
   SaveExternalMediaRequest,
   UploadMediaRequest,
 } from '@/api/types/media.type'
+
+/**
+ * Metadata required to upload a file via the R2 presigned URL flow.
+ * `listingId` is required when `purpose === 'LISTING'` and forbidden when
+ * `purpose === 'AVATAR'` (BE will reject mismatches).
+ */
+export interface UploadViaPresignInput {
+  file: File
+  mediaType: MediaType
+  purpose: MediaPurpose
+  listingId?: number
+  title?: string
+  description?: string
+  altText?: string
+  isPrimary?: boolean
+  sortOrder?: number
+}
+
+export interface UploadViaPresignOptions {
+  onUploadProgress?: (e: AxiosProgressEvent) => void
+  signal?: AbortSignal
+}
 
 export class MediaService {
   static async createUploadUrl(
@@ -23,7 +47,7 @@ export class MediaService {
   }
 
   static async confirmUpload(
-    mediaId: string | number,
+    mediaId: number,
     payload: ConfirmUploadRequest,
   ): Promise<ApiResponse<MediaItem>> {
     const url = PATHS.MEDIA.CONFIRM_UPLOAD.replace(':mediaId', String(mediaId))
@@ -70,21 +94,17 @@ export class MediaService {
     })
   }
 
-  static async getById(
-    mediaId: string | number,
-  ): Promise<ApiResponse<MediaItem>> {
+  static async getById(mediaId: number): Promise<ApiResponse<MediaItem>> {
     const url = PATHS.MEDIA.BY_ID.replace(':mediaId', String(mediaId))
     return apiRequest<MediaItem>({ url, method: 'GET' })
   }
 
-  static async delete(mediaId: string | number): Promise<ApiResponse<string>> {
+  static async delete(mediaId: number): Promise<ApiResponse<string>> {
     const url = PATHS.MEDIA.DELETE.replace(':mediaId', String(mediaId))
     return apiRequest<string>({ url, method: 'DELETE' })
   }
 
-  static async getDownloadUrl(
-    mediaId: string | number,
-  ): Promise<ApiResponse<string>> {
+  static async getDownloadUrl(mediaId: number): Promise<ApiResponse<string>> {
     const url = PATHS.MEDIA.DOWNLOAD_URL.replace(':mediaId', String(mediaId))
     return apiRequest<string>({ url, method: 'GET' })
   }
@@ -94,9 +114,69 @@ export class MediaService {
   }
 
   static async getByListingId(
-    listingId: string | number,
+    listingId: number,
   ): Promise<ApiResponse<MediaItem[]>> {
     const url = PATHS.MEDIA.BY_LISTING.replace(':listingId', String(listingId))
     return apiRequest<MediaItem[]>({ url, method: 'GET' })
+  }
+
+  /**
+   * Upload a file directly to Cloudflare R2 via a presigned URL.
+   *
+   * Three steps:
+   *   1. Ask BE for a presigned PUT URL (`createUploadUrl`).
+   *   2. PUT the raw file bytes to R2 using a bare axios call so we don't
+   *      attach the Bearer token, baseURL, or trigger response interceptors —
+   *      R2 would otherwise reject the signature or our 401 handler would
+   *      log the user out.
+   *   3. Notify BE that the upload finished (`confirmUpload`), which marks
+   *      the media record ACTIVE and returns the final MediaItem.
+   *
+   * Bypasses Vercel's 4.5MB serverless body limit since the file never
+   * touches the backend.
+   */
+  static async uploadViaPresign(
+    input: UploadViaPresignInput,
+    opts?: UploadViaPresignOptions,
+  ): Promise<ApiResponse<MediaItem>> {
+    const { file, mediaType, purpose } = input
+
+    // Step 1: request presigned URL
+    const presignResponse = await MediaService.createUploadUrl({
+      mediaType,
+      purpose,
+      filename: file.name,
+      contentType: file.type,
+      fileSize: file.size,
+      listingId: input.listingId,
+      title: input.title,
+      description: input.description,
+      altText: input.altText,
+      isPrimary: input.isPrimary,
+      sortOrder: input.sortOrder,
+    })
+
+    if (!presignResponse.success || !presignResponse.data) {
+      throw new Error(presignResponse.message || 'Failed to obtain upload URL')
+    }
+
+    const { mediaId, uploadUrl } = presignResponse.data
+
+    // Step 2: PUT file bytes directly to R2.
+    // Use raw axios (NOT axiosClient) to avoid:
+    //   - Bearer token header (R2 would reject signature)
+    //   - baseURL prefix
+    //   - response interceptor that triggers logout on 401
+    await axios.put(uploadUrl, file, {
+      headers: { 'Content-Type': file.type },
+      onUploadProgress: opts?.onUploadProgress,
+      signal: opts?.signal,
+      // Allow large files; axios defaults to 10MB content limit otherwise.
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+    })
+
+    // Step 3: confirm upload — BE verifies via HeadObject and marks ACTIVE.
+    return MediaService.confirmUpload(mediaId, { contentType: file.type })
   }
 }

--- a/src/api/types/media.type.ts
+++ b/src/api/types/media.type.ts
@@ -1,9 +1,10 @@
 export type MediaType = 'IMAGE' | 'VIDEO'
-export type MediaSourceType = 'UPLOADED' | 'EXTERNAL'
+export type MediaSourceType = 'UPLOAD' | 'EXTERNAL'
 export type MediaStatus = 'PENDING' | 'ACTIVE' | 'DELETED'
+export type MediaPurpose = 'LISTING' | 'AVATAR'
 
 export interface MediaItem {
-  mediaId: string
+  mediaId: number
   listingId: number
   userId: string
   mediaType: MediaType
@@ -28,9 +29,10 @@ export interface MediaItem {
 // Step 1: request upload URL
 export interface CreateUploadUrlRequest {
   mediaType: MediaType
+  purpose: MediaPurpose
   filename: string
   contentType: string
-  fileSize: string | number
+  fileSize: number
   listingId?: number
   title?: string
   description?: string
@@ -40,7 +42,7 @@ export interface CreateUploadUrlRequest {
 }
 
 export interface CreateUploadUrlResponse {
-  mediaId: string
+  mediaId: number
   uploadUrl: string
   expiresIn: number
   storageKey: string

--- a/src/api/types/user.type.ts
+++ b/src/api/types/user.type.ts
@@ -11,4 +11,5 @@ export interface UserApi {
   contactPhoneNumber: string
   contactPhoneVerified: boolean
   avatarUrl?: string
+  avatarMediaId?: number
 }

--- a/src/components/molecules/createPostMedia/uploadVideo.tsx
+++ b/src/components/molecules/createPostMedia/uploadVideo.tsx
@@ -108,7 +108,7 @@ const UploadVideo: React.FC<UploadVideoProps> = ({ video }) => {
           mediaId: mediaId ? Number(mediaId) : undefined,
           mediaType: 'VIDEO',
           isPrimary: true,
-          sourceType: 'UPLOADED',
+          sourceType: 'UPLOAD',
         })
       }
       updateVideoUploadProgress(100)
@@ -154,7 +154,7 @@ const UploadVideo: React.FC<UploadVideoProps> = ({ video }) => {
   const isBlobUrl = videoUrl.startsWith('blob:')
   const isExternalVideo = video?.sourceType === 'EXTERNAL'
   const isUploadedVideo =
-    video?.sourceType === 'UPLOADED' && videoUrl && !isBlobUrl
+    video?.sourceType === 'UPLOAD' && videoUrl && !isBlobUrl
   const showVideoPreview = videoUrl && (isBlobUrl || isUploadedVideo)
 
   return (

--- a/src/components/organisms/createPostSections/mediaSection.tsx
+++ b/src/components/organisms/createPostSections/mediaSection.tsx
@@ -39,7 +39,7 @@ const MediaSection: React.FC<MediaSectionProps> = ({
     (item) =>
       item.mediaType === 'VIDEO' &&
       item.isPrimary === true &&
-      (item.sourceType === 'UPLOAD' || item.sourceType === 'UPLOADED'),
+      item.sourceType === 'UPLOAD',
   )
   const hasUploadedVideo = !!uploadedVideo
 

--- a/src/utils/recentlyViewed/mapper.ts
+++ b/src/utils/recentlyViewed/mapper.ts
@@ -238,7 +238,7 @@ export const mapRecentlyViewedToListing = (
                 mediaId: 0,
                 listingId: Number(recentlyViewed.listingId),
                 mediaType: 'IMAGE' as const,
-                sourceType: 'UPLOADED',
+                sourceType: 'UPLOAD',
                 url: recentlyViewed.thumbnail,
                 isPrimary: true,
                 sortOrder: 0,


### PR DESCRIPTION
- Add MediaService.uploadViaPresign() that gets a presigned URL, PUTs the file directly to Cloudflare R2 (bypassing the Vercel 4.5MB body limit), and confirms the upload with the backend.
- Use raw axios for the R2 PUT to avoid attaching the Bearer token, the app baseURL, or triggering the 401 logout interceptor.
- Add MediaPurpose ('LISTING' | 'AVATAR') and require it on CreateUploadUrlRequest to match the backend contract.
- Align media type with backend: mediaId is number, sourceType is 'UPLOAD'.
- Add avatarMediaId to UserApi for the upcoming JSON profile update flow.
- Whitelist the R2 public dev hostname and the future cdn.smartrent.io.vn custom domain in next.config images.remotePatterns so phase-2 swap is config-only.