### PR TITLE
feat(news): redesign news listing page with featured article, sidebar and load-more

### DIFF
--- a/src/components/molecules/newsCard/index.tsx
+++ b/src/components/molecules/newsCard/index.tsx
@@ -76,7 +76,7 @@ const NewsCard: React.FC<NewsCardProps> = ({
     >
       <Card
         className={classNames(
-          'overflow-hidden transition-all duration-200',
+          'overflow-hidden transition-all duration-200 py-0',
           'hover:shadow-md hover:border-primary/30',
           'h-full',
           {

--- a/src/components/templates/newsListTemplate/index.tsx
+++ b/src/components/templates/newsListTemplate/index.tsx
@@ -1,46 +1,184 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { useListContext } from '@/contexts/list'
+import classNames from 'classnames'
+import { useListContext, List } from '@/contexts/list'
 import { NewsItem } from '@/api/types/news.type'
+import { NewsService } from '@/api/services/news.service'
 import { Typography } from '@/components/atoms/typography'
+import ImageAtom from '@/components/atoms/imageAtom'
+import { Badge } from '@/components/atoms/badge'
+import { Skeleton } from '@/components/atoms/skeleton'
+import { Card } from '@/components/atoms/card'
 import NewsFilterBar from '@/components/molecules/newsFilterBar'
-import NewsListContent from '@/components/molecules/newsListContent'
+import NewsCard from '@/components/molecules/newsCard'
+import { basePath, DEFAULT_IMAGE } from '@/constants'
+import { PUBLIC_ROUTES } from '@/constants/route'
+import {
+  getCategoryConfig,
+  formatAuthorDisplayName,
+  formatPublishedDate,
+  formatViewCount,
+} from '@/utils/news'
+import { Calendar, Eye, User, TrendingUp } from 'lucide-react'
 import type { ListingFilterRequest } from '@/api/types/property.type'
 
-// ─── Sub-components ──────────────────────────────────────
+// ─── Featured Article (first item – large horizontal card) ───────────────────
 
-/** Page title + subtitle */
-const NewsPageHeader: React.FC = () => {
+const FeaturedArticle: React.FC<{ news: NewsItem }> = ({ news }) => {
   const t = useTranslations('newsPage')
+  const tCategories = useTranslations('newsPage.categories')
+
+  const imageUrl = news.thumbnailUrl || `${basePath}${DEFAULT_IMAGE}`
+  const newsUrl = `${PUBLIC_ROUTES.NEWS}/${news.slug}`
+  const categoryConfig = getCategoryConfig(news.category, tCategories)
+  const displayAuthor = formatAuthorDisplayName(
+    news.authorName,
+    t('authorFallback'),
+  )
+  const displayDate =
+    formatPublishedDate(news.publishedAt) || t('dateUnavailable')
+
   return (
-    <header className='mb-8'>
-      <Typography variant='h1' className='text-2xl md:text-3xl font-bold mb-2'>
-        {t('title')}
-      </Typography>
-      <Typography variant='p' className='text-muted-foreground'>
-        {t('subtitle')}
-      </Typography>
-    </header>
+    <Link href={newsUrl} className='group block pb-6 border-b border-border'>
+      <div className='flex flex-col sm:flex-row gap-5'>
+        {/* Thumbnail */}
+        <div className='relative w-full sm:w-[52%] aspect-[16/9] rounded-xl overflow-hidden flex-shrink-0'>
+          <ImageAtom
+            src={imageUrl}
+            alt={news.title}
+            width={800}
+            height={450}
+            className='w-full h-full object-cover transition-transform duration-300 group-hover:scale-105'
+          />
+          <div className='absolute top-3 left-3'>
+            <Badge
+              variant='outline'
+              className={classNames(
+                'text-xs font-medium backdrop-blur-sm bg-background/80',
+                categoryConfig.className,
+              )}
+            >
+              {categoryConfig.label}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className='flex flex-col justify-between flex-1 sm:py-1'>
+          <div>
+            <Typography
+              variant='h2'
+              className='text-xl sm:text-2xl font-bold leading-tight line-clamp-3 group-hover:text-primary transition-colors mb-3'
+            >
+              {news.title}
+            </Typography>
+            <Typography
+              variant='p'
+              className='text-muted-foreground text-sm line-clamp-3 leading-relaxed'
+            >
+              {news.summary}
+            </Typography>
+          </div>
+          <div className='flex flex-wrap items-center gap-3 text-xs text-muted-foreground mt-4 pt-3 border-t border-border'>
+            <span className='inline-flex items-center gap-1.5'>
+              <User className='w-3.5 h-3.5' />
+              {displayAuthor}
+            </span>
+            <span className='inline-flex items-center gap-1.5'>
+              <Calendar className='w-3.5 h-3.5' />
+              {displayDate}
+            </span>
+            <span className='inline-flex items-center gap-1.5'>
+              <Eye className='w-3.5 h-3.5' />
+              {formatViewCount(news.viewCount)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
   )
 }
 
-/** Result count line */
-const NewsResultCount: React.FC = () => {
-  const t = useTranslations('newsPage')
-  const { pagination, isLoading } = useListContext<NewsItem>()
+// ─── Sidebar: Most Viewed Item ────────────────────────────────────────────────
 
-  if (isLoading) return null
+const MostViewedItem: React.FC<{ news: NewsItem }> = ({ news }) => {
+  const imageUrl = news.thumbnailUrl || `${basePath}${DEFAULT_IMAGE}`
+  const newsUrl = `${PUBLIC_ROUTES.NEWS}/${news.slug}`
 
   return (
-    <div className='mb-4'>
-      <Typography variant='p' className='text-muted-foreground text-sm'>
-        {t('resultCount', { count: pagination.totalCount })}
-      </Typography>
+    <Link
+      href={newsUrl}
+      className='group flex gap-3 items-start py-3 border-b border-border last:border-b-0'
+    >
+      <div className='relative w-[72px] h-[52px] flex-shrink-0 rounded-lg overflow-hidden'>
+        <ImageAtom
+          src={imageUrl}
+          alt={news.title}
+          width={72}
+          height={52}
+          className='w-full h-full object-cover'
+        />
+      </div>
+      <div className='flex-1 min-w-0'>
+        <p className='text-sm font-medium leading-snug line-clamp-2 group-hover:text-primary transition-colors'>
+          {news.title}
+        </p>
+        <span className='inline-flex items-center gap-1 text-xs text-muted-foreground mt-1'>
+          <Eye className='w-3 h-3' />
+          {formatViewCount(news.viewCount)}
+        </span>
+      </div>
+    </Link>
+  )
+}
+
+// ─── Skeletons ────────────────────────────────────────────────────────────────
+
+const FeaturedSkeleton = () => (
+  <div className='flex flex-col sm:flex-row gap-5 pb-6 border-b border-border'>
+    <Skeleton className='w-full sm:w-[52%] aspect-[16/9] rounded-xl' />
+    <div className='flex-1 space-y-3 py-1'>
+      <Skeleton className='h-7 w-full' />
+      <Skeleton className='h-7 w-4/5' />
+      <Skeleton className='h-4 w-full mt-2' />
+      <Skeleton className='h-4 w-full' />
+      <Skeleton className='h-4 w-2/3' />
     </div>
-  )
-}
+  </div>
+)
 
-// ─── Main template ───────────────────────────────────────
+const ArticleSkeleton = () => (
+  <div className='flex gap-4 py-4 border-b border-border'>
+    <Skeleton className='w-[150px] h-[100px] rounded-lg flex-shrink-0' />
+    <div className='flex-1 space-y-2 py-1'>
+      <Skeleton className='h-3.5 w-1/4' />
+      <Skeleton className='h-5 w-full' />
+      <Skeleton className='h-4 w-3/4' />
+      <Skeleton className='h-3.5 w-1/2 mt-1' />
+    </div>
+  </div>
+)
+
+const SidebarSkeleton = () => (
+  <div>
+    {Array.from({ length: 5 }).map((_, i) => (
+      <div
+        key={i}
+        className='flex gap-3 py-3 border-b border-border last:border-b-0'
+      >
+        <Skeleton className='w-[72px] h-[52px] rounded-lg flex-shrink-0' />
+        <div className='flex-1 space-y-2'>
+          <Skeleton className='h-3.5 w-full' />
+          <Skeleton className='h-3.5 w-3/4' />
+          <Skeleton className='h-3 w-1/4' />
+        </div>
+      </div>
+    ))}
+  </div>
+)
+
+// ─── Main template ────────────────────────────────────────────────────────────
 
 interface NewsListTemplateProps {
   selectedCategory?: string
@@ -59,27 +197,51 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
   onTagClear,
   onListReady,
 }) => {
-  const [layout, setLayout] = useState<'grid' | 'list'>('grid')
-  const { updateFilters } = useListContext<NewsItem>()
+  const t = useTranslations('newsPage')
+  const { items, isLoading, updateFilters } = useListContext<NewsItem>()
+  const [layout, setLayout] = useState<'grid' | 'list'>('list')
+  const [mostViewed, setMostViewed] = useState<NewsItem[]>([])
+  const [isSidebarLoading, setIsSidebarLoading] = useState(true)
 
-  // Expose context actions to the page so category change triggers fetch
+  // Expose context actions to the page
   useEffect(() => {
     onListReady?.({ updateFilters })
   }, [onListReady, updateFilters])
 
-  /** Clear category when empty state triggers a full reset */
-  const handleResetAllFilters = useCallback(() => {
-    onCategoryChange?.(undefined)
-    onTagClear?.()
-  }, [onCategoryChange, onTagClear])
+  // Fetch most-viewed: grab a batch and sort client-side by viewCount
+  useEffect(() => {
+    NewsService.getList({ page: 1, size: 20 }).then((res) => {
+      if (res.success && res.data?.news) {
+        const sorted = [...res.data.news]
+          .sort((a, b) => (b.viewCount || 0) - (a.viewCount || 0))
+          .slice(0, 7)
+        setMostViewed(sorted)
+      }
+      setIsSidebarLoading(false)
+    })
+  }, [])
+
+  const featuredItem = items[0]
+  const listItems = items.slice(1)
+  const isInitialLoading = isLoading && items.length === 0
 
   return (
-    <>
-      {/* Page header */}
-      <NewsPageHeader />
+    <div className='px-4 sm:px-6'>
+      {/* Header */}
+      <header className='mb-6'>
+        <Typography
+          variant='h1'
+          className='text-2xl md:text-3xl font-bold mb-1'
+        >
+          {t('title')}
+        </Typography>
+        <Typography variant='p' className='text-muted-foreground text-sm'>
+          {t('subtitle')}
+        </Typography>
+      </header>
 
       {/* Filter bar */}
-      <div className='mb-6'>
+      <div className='mb-7'>
         <NewsFilterBar
           layout={layout}
           onLayoutChange={setLayout}
@@ -90,17 +252,84 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
         />
       </div>
 
-      {/* Result count */}
-      <NewsResultCount />
+      {/* Two-column layout */}
+      <div className='flex flex-col lg:flex-row gap-8'>
+        {/* ── Main column ── */}
+        <div className='flex-1 min-w-0'>
+          {isInitialLoading ? (
+            <>
+              <FeaturedSkeleton />
+              {Array.from({ length: 4 }).map((_, i) => (
+                <ArticleSkeleton key={i} />
+              ))}
+            </>
+          ) : (
+            <>
+              {/* Featured article */}
+              {featuredItem && (
+                <div className='mb-0'>
+                  <FeaturedArticle news={featuredItem} />
+                </div>
+              )}
 
-      {/* News list */}
-      <main>
-        <NewsListContent
-          layout={layout}
-          onResetAllFilters={handleResetAllFilters}
-        />
-      </main>
-    </>
+              {/* Remaining articles */}
+              <div>
+                {listItems.map((news) => (
+                  <div
+                    key={news.newsId}
+                    className='py-4 border-b border-border last:border-b-0'
+                  >
+                    <NewsCard news={news} layout='horizontal' />
+                  </div>
+                ))}
+              </div>
+
+              {/* Append-loading skeleton */}
+              {isLoading && items.length > 0 && (
+                <div>
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <ArticleSkeleton key={i} />
+                  ))}
+                </div>
+              )}
+
+              {/* Xem thêm */}
+              <div className='mt-8 flex justify-center'>
+                <List.LoadMore
+                  variant='default'
+                  className='px-10 bg-blue-600 hover:bg-blue-700 text-white border-0'
+                  labelIdleKey='newsPage.viewMore'
+                  labelLoadingKey='newsPage.loadingMore'
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* ── Sidebar ── */}
+        <aside className='w-full lg:w-[300px] xl:w-[320px] flex-shrink-0'>
+          <div className='sticky top-20'>
+            <Card className='py-0 overflow-hidden'>
+              <div className='flex items-center gap-2 px-4 py-3 border-b border-border bg-muted/40'>
+                <TrendingUp className='w-4 h-4 text-primary flex-shrink-0' />
+                <Typography variant='h4' className='font-semibold text-sm'>
+                  Bài viết đọc nhiều nhất
+                </Typography>
+              </div>
+              <div className='px-4'>
+                {isSidebarLoading ? (
+                  <SidebarSkeleton />
+                ) : (
+                  mostViewed.map((news) => (
+                    <MostViewedItem key={news.newsId} news={news} />
+                  ))
+                )}
+              </div>
+            </Card>
+          </div>
+        </aside>
+      </div>
+    </div>
   )
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2989,6 +2989,7 @@
       "tip3": "Check for spelling mistakes in your search"
     },
     "loadingMore": "Loading more articles...",
+    "viewMore": "View more",
     "notFound": "Article not found",
     "notFoundDescription": "The article you're looking for doesn't exist or has been removed.",
     "backToNews": "Back to News",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2990,6 +2990,7 @@
       "tip3": "Kiểm tra lỗi chính tả trong tìm kiếm của bạn"
     },
     "loadingMore": "Đang tải thêm...",
+    "viewMore": "Xem thêm",
     "notFound": "Không tìm thấy bài viết",
     "notFoundDescription": "Bài viết bạn đang tìm kiếm không tồn tại hoặc đã bị xóa.",
     "backToNews": "Quay lại Tin tức",

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -29,7 +29,7 @@ type NewsPageClientInit = {
 }
 
 const DEFAULT_NEWS_PAGE = 1
-const DEFAULT_NEWS_SIZE = 20
+const DEFAULT_NEWS_SIZE = 10
 
 const parseQueryString = (value: unknown): string | undefined => {
   const raw = Array.isArray(value) ? value[0] : value
@@ -49,7 +49,8 @@ const parsePositiveNumber = (value: unknown, fallback: number): number => {
 const parseNewsClientInit = (
   query: Record<string, unknown>,
 ): NewsPageClientInit => {
-  const page = parsePositiveNumber(query.page, DEFAULT_NEWS_PAGE)
+  // Always start from page 1 — load-more is client-side accumulation,
+  // page number in URL is not a valid entry point
   const size = parsePositiveNumber(query.size, DEFAULT_NEWS_SIZE)
   const category = parseQueryString(query.category)
   const keyword = parseQueryString(query.keyword)
@@ -57,14 +58,14 @@ const parseNewsClientInit = (
 
   return {
     initialFilters: {
-      page,
+      page: DEFAULT_NEWS_PAGE,
       size,
       ...(keyword ? { keyword } : {}),
       ...(tag ? { tag } : {}),
     },
     initialPagination: {
       totalCount: 0,
-      currentPage: page,
+      currentPage: DEFAULT_NEWS_PAGE,
       pageSize: size,
       totalPages: 0,
     },
@@ -105,9 +106,8 @@ const NewsPage: NextPageWithLayout = () => {
       lastPushedFiltersRef.current = filtersKey
 
       const queryParams: Record<string, string | null> = {}
-      if (filters.page && filters.page > 1) {
-        queryParams.page = filters.page.toString()
-      }
+      // Do NOT push page number — load-more accumulates items client-side,
+      // putting ?page=N in the URL causes re-init on refresh at page N with no prior pages
       if (category) {
         queryParams.category = category
       }
@@ -126,7 +126,7 @@ const NewsPage: NextPageWithLayout = () => {
           ),
         },
         undefined,
-        { shallow: true, scroll: true },
+        { shallow: true, scroll: false },
       )
     },
     [router],


### PR DESCRIPTION

- Redesign newsListTemplate with 2-column layout: main article list + most-viewed sidebar
- First article renders as large featured card (50% image, big title, summary)
- Remaining articles render as horizontal cards with py-4 vertical spacing
- Sidebar shows top 7 most-viewed articles (fetched and sorted client-side by viewCount)
- Replace pagination with load-more (append) using List.LoadMore + blue Xem them button
- Fix List.LoadMore disappearing: stop pushing page number to URL in pushFiltersToQuery
- Always initialize from page 1 regardless of stale page param in URL
- Fix scroll-to-top on load-more: router.push scroll false
- Fix newsCard thumbnail whitespace: override Card default py-6 with py-0
- Resolve heroPromoCarousel merge conflict: keep object-cover object-top
- Default news page size changed from 20 to 10
- Add newsPage.viewMore i18n keys (vi + en)