### PR TITLE
feat(news): redesign filter bar with sticky tabs, inline search, and …

### DIFF
--- a/src/components/atoms/imageAtom/index.tsx
+++ b/src/components/atoms/imageAtom/index.tsx
@@ -13,6 +13,7 @@ type ImageAtomProps = {
   width?: number
   height?: number
   priority?: boolean
+  fill?: boolean
 }
 
 const ImageAtom: NextPage<ImageAtomProps> = ({
@@ -24,11 +25,28 @@ const ImageAtom: NextPage<ImageAtomProps> = ({
   width,
   height,
   priority = false,
+  fill = false,
 }) => {
   const [hasError, setHasError] = useState(false)
 
   const fallbackSrc = defaultImage ?? ''
   const imageSrc = hasError ? fallbackSrc : (src ?? fallbackSrc)
+
+  if (fill) {
+    return (
+      <Image
+        src={imageSrc}
+        alt={alt}
+        fill
+        className={clsx(className, 'object-cover')}
+        priority={priority}
+        placeholder={placeholderSrc ? 'blur' : 'empty'}
+        blurDataURL={placeholderSrc}
+        onError={() => !hasError && setHasError(true)}
+        loading={priority ? undefined : 'lazy'}
+      />
+    )
+  }
 
   if (width && height) {
     return (

--- a/src/components/atoms/newsGridItem/index.tsx
+++ b/src/components/atoms/newsGridItem/index.tsx
@@ -85,23 +85,22 @@ const NewsGridItem: React.FC<NewsGridItemProps> = ({
     >
       <Card
         className={classNames(
-          'overflow-hidden transition-all duration-200 h-full flex flex-col',
+          'overflow-hidden transition-all duration-200 h-full flex flex-col py-0',
           'hover:shadow-md hover:border-primary/30',
         )}
       >
         {/* Thumbnail */}
         <div
           className={classNames(
-            'relative overflow-hidden bg-muted',
+            'relative overflow-hidden bg-muted flex-shrink-0',
             isFeatured ? 'aspect-[4/3] sm:aspect-[16/10]' : 'aspect-[16/10]',
           )}
         >
           <ImageAtom
             src={imageUrl}
             alt={title}
-            width={isFeatured ? 600 : 320}
-            height={isFeatured ? 375 : 200}
-            className='w-full h-full object-cover transition-transform duration-300 group-hover:scale-105'
+            fill
+            className='object-cover transition-transform duration-300 group-hover:scale-105'
           />
           <div
             className={classNames(

--- a/src/components/molecules/newsCard/index.tsx
+++ b/src/components/molecules/newsCard/index.tsx
@@ -96,9 +96,8 @@ const NewsCard: React.FC<NewsCardProps> = ({
           <ImageAtom
             src={imageUrl}
             alt={title}
-            width={isHorizontal ? 200 : 400}
-            height={isHorizontal ? 120 : 225}
-            className='w-full h-full object-cover transition-transform duration-300 group-hover:scale-105'
+            fill
+            className='object-cover transition-transform duration-300 group-hover:scale-105'
           />
 
           {/* Category Badge */}

--- a/src/components/molecules/newsFilterBar/index.tsx
+++ b/src/components/molecules/newsFilterBar/index.tsx
@@ -1,16 +1,12 @@
 import React, { useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 import { useListContext } from '@/contexts/list'
-import { Button } from '@/components/atoms/button'
-import { Input } from '@/components/atoms/input'
 import { Badge } from '@/components/atoms/badge'
 import { NewsCategory, NewsItem } from '@/api/types/news.type'
-import { Search, X, LayoutGrid, List } from 'lucide-react'
+import { X } from 'lucide-react'
 import classNames from 'classnames'
 
 interface NewsFilterBarProps {
-  layout: 'grid' | 'list'
-  onLayoutChange: (layout: 'grid' | 'list') => void
   selectedCategory?: string
   onCategoryChange?: (category: string | undefined) => void
   selectedTag?: string
@@ -18,8 +14,6 @@ interface NewsFilterBarProps {
 }
 
 const NewsFilterBar: React.FC<NewsFilterBarProps> = ({
-  layout,
-  onLayoutChange,
   selectedCategory,
   onCategoryChange,
   selectedTag,
@@ -27,8 +21,7 @@ const NewsFilterBar: React.FC<NewsFilterBarProps> = ({
 }) => {
   const t = useTranslations('newsPage')
   const tCategories = useTranslations('newsPage.categories')
-  const { filters, setKeyword, activeFilterCount, resetFilters } =
-    useListContext<NewsItem>()
+  const { activeFilterCount, resetFilters } = useListContext<NewsItem>()
 
   const categories = useMemo(
     () => [
@@ -44,14 +37,6 @@ const NewsFilterBar: React.FC<NewsFilterBarProps> = ({
     [t, tCategories],
   )
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setKeyword(e.target.value)
-  }
-
-  const handleCategoryClick = (category: NewsCategory | undefined) => {
-    onCategoryChange?.(category)
-  }
-
   const handleClearFilters = () => {
     resetFilters()
     onCategoryChange?.(undefined)
@@ -62,82 +47,46 @@ const NewsFilterBar: React.FC<NewsFilterBarProps> = ({
     activeFilterCount + (selectedCategory ? 1 : 0) + (selectedTag ? 1 : 0)
 
   return (
-    <div className='space-y-4'>
-      {/* Search and Layout Toggle Row */}
-      <div className='flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between'>
-        {/* Search Input */}
-        <div className='relative flex-1 max-w-md'>
-          <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground' />
-          <Input
-            type='text'
-            placeholder={t('searchPlaceholder')}
-            value={filters.keyword || ''}
-            onChange={handleSearchChange}
-            className='pl-9 pr-9'
-          />
-          {filters.keyword && (
+    <div>
+      {/* Sticky tab bar */}
+      <div className='sticky top-12 sm:top-16 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 bg-background/95 backdrop-blur-sm border-b border-border'>
+        <div className='flex items-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+          {categories.map((cat) => {
+            const isActive = selectedCategory === cat.value
+            return (
+              <button
+                key={cat.value || 'all'}
+                type='button'
+                onClick={() => onCategoryChange?.(cat.value)}
+                className={classNames(
+                  'flex-shrink-0 px-3 sm:px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap leading-none',
+                  isActive
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30',
+                )}
+              >
+                {cat.label}
+              </button>
+            )
+          })}
+
+          {/* Clear button inline with tabs */}
+          {totalActiveFilters > 0 && (
             <button
-              onClick={() => setKeyword('')}
-              className='absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'
+              type='button'
+              onClick={handleClearFilters}
+              className='flex-shrink-0 flex items-center gap-1 px-3 py-3 text-sm text-muted-foreground hover:text-foreground border-b-2 border-transparent whitespace-nowrap'
             >
-              <X className='h-4 w-4' />
+              <X className='h-3.5 w-3.5' />
+              {t('clearFilters')}
             </button>
           )}
         </div>
-
-        {/* Layout Toggle (Desktop) */}
-        <div className='hidden sm:flex items-center gap-1 border rounded-lg p-1'>
-          <Button
-            variant={layout === 'grid' ? 'default' : 'ghost'}
-            size='sm'
-            onClick={() => onLayoutChange('grid')}
-            className='h-8 w-8 p-0'
-          >
-            <LayoutGrid className='h-4 w-4' />
-          </Button>
-          <Button
-            variant={layout === 'list' ? 'default' : 'ghost'}
-            size='sm'
-            onClick={() => onLayoutChange('list')}
-            className='h-8 w-8 p-0'
-          >
-            <List className='h-4 w-4' />
-          </Button>
-        </div>
       </div>
 
-      {/* Category Pills */}
-      <div className='flex flex-wrap gap-2'>
-        {categories.map((cat) => (
-          <Button
-            key={cat.value || 'all'}
-            variant={selectedCategory === cat.value ? 'default' : 'outline'}
-            size='sm'
-            onClick={() => handleCategoryClick(cat.value)}
-            className={classNames('transition-all', {
-              'border-primary': selectedCategory === cat.value,
-            })}
-          >
-            {cat.label}
-          </Button>
-        ))}
-
-        {/* Clear Filters */}
-        {totalActiveFilters > 0 && (
-          <Button
-            variant='ghost'
-            size='sm'
-            onClick={handleClearFilters}
-            className='text-muted-foreground'
-          >
-            <X className='h-4 w-4 mr-1' />
-            {t('clearFilters')}
-          </Button>
-        )}
-      </div>
-
+      {/* Active tag badge */}
       {selectedTag && (
-        <div className='flex items-center gap-2'>
+        <div className='flex items-center gap-2 mt-3'>
           <span className='text-sm text-muted-foreground'>
             {t('activeTag')}
           </span>

--- a/src/components/organisms/latestNewsSection/index.tsx
+++ b/src/components/organisms/latestNewsSection/index.tsx
@@ -17,6 +17,7 @@ import {
   formatViewCount,
 } from '@/utils/news'
 import classNames from 'classnames'
+import { cn } from '@/lib/utils'
 
 interface LatestNewsSectionProps {
   news: NewsItem[]
@@ -65,6 +66,22 @@ const LatestNewsSection: React.FC<LatestNewsSectionProps> = ({
     return null
   }
 
+  const featured = news[0]
+  const rest = news.slice(1, 5)
+
+  const featuredCategoryConfig = featured
+    ? getCategoryConfig(featured.category, tCategories)
+    : null
+  const featuredUrl = featured ? `${PUBLIC_ROUTES.NEWS}/${featured.slug}` : ''
+  const featuredImageUrl =
+    featured?.thumbnailUrl || `${basePath}${DEFAULT_IMAGE}`
+  const featuredAuthor = featured
+    ? formatAuthorDisplayName(featured.authorName, tNews('authorFallback'))
+    : ''
+  const featuredDate = featured
+    ? formatPublishedDate(featured.publishedAt) || tNews('dateUnavailable')
+    : ''
+
   return (
     <section className='mb-8 sm:mb-10'>
       {/* Header */}
@@ -77,116 +94,163 @@ const LatestNewsSection: React.FC<LatestNewsSectionProps> = ({
             {t('subtitle')}
           </Typography>
         </div>
-        <Link href={PUBLIC_ROUTES.NEWS} passHref legacyBehavior>
-          <Button variant='outline' className='mt-4 sm:mt-0'>
+        <Link href={PUBLIC_ROUTES.NEWS}>
+          <Button
+            variant='ghost'
+            className='group gap-1 px-0 sm:px-3 text-primary hover:text-primary/80'
+          >
             {t('viewAll')}
-            <ArrowRight className='ml-2 h-4 w-4' />
+            <ArrowRight className='w-4 h-4 transition-transform group-hover:translate-x-0.5' />
           </Button>
         </Link>
       </div>
 
-      {/* News Grid */}
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 md:gap-6'>
-        {news.map((item) => {
-          const categoryConfig = getCategoryConfig(item.category, tCategories)
-          const newsUrl = `${PUBLIC_ROUTES.NEWS}/${item.slug}`
-          const imageUrl = item.thumbnailUrl || `${basePath}${DEFAULT_IMAGE}`
-          const displayAuthor = formatAuthorDisplayName(
-            item.authorName,
-            tNews('authorFallback'),
-          )
-          const displayPublishedAt =
-            formatPublishedDate(item.publishedAt) || tNews('dateUnavailable')
-
-          return (
-            <Link
-              key={item.newsId}
-              href={newsUrl}
-              className={classNames(
-                'group block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl',
+      {/* News Layout: featured (left ~60%) + 2×2 grid (right ~40%) */}
+      <div className='flex flex-col lg:flex-row gap-4 md:gap-6'>
+        {/* Featured Card */}
+        {featured && featuredCategoryConfig && (
+          <Link
+            href={featuredUrl}
+            className='group block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl lg:flex-[3]'
+          >
+            <Card
+              className={cn(
+                'overflow-hidden transition-all duration-200 h-full flex flex-col py-0',
+                'hover:shadow-md hover:border-primary/30',
               )}
             >
-              <Card
-                className={classNames(
-                  'overflow-hidden transition-all duration-200 h-full flex flex-col',
-                  'hover:shadow-md hover:border-primary/30',
-                )}
-              >
-                {/* Image */}
-                <div className='relative aspect-video overflow-hidden bg-muted'>
-                  <ImageAtom
-                    src={imageUrl}
-                    alt={item.title}
-                    width={400}
-                    height={225}
-                    className='w-full h-full object-cover transition-transform duration-300 group-hover:scale-105'
-                  />
-
-                  {/* Category Badge */}
-                  <div className='absolute top-3 left-3'>
-                    <Badge
-                      variant='outline'
-                      className={classNames(
-                        'text-xs font-medium',
-                        categoryConfig.className,
-                      )}
-                    >
-                      {categoryConfig.label}
-                    </Badge>
-                  </div>
+              <div className='relative overflow-hidden bg-muted flex-shrink-0 aspect-[16/10]'>
+                <ImageAtom
+                  src={featuredImageUrl}
+                  alt={featured.title}
+                  fill
+                  className='object-cover transition-transform duration-300 group-hover:scale-105'
+                />
+                <div className='absolute top-3 left-3'>
+                  <Badge
+                    variant='outline'
+                    className={classNames(
+                      'text-xs font-medium',
+                      featuredCategoryConfig.className,
+                    )}
+                  >
+                    {featuredCategoryConfig.label}
+                  </Badge>
                 </div>
+              </div>
+              <CardContent className='flex flex-col flex-1 p-4'>
+                <Typography
+                  variant='h4'
+                  className='font-semibold group-hover:text-primary transition-colors text-xl mb-3 line-clamp-2'
+                >
+                  {featured.title}
+                </Typography>
+                <Typography
+                  variant='p'
+                  className='text-muted-foreground line-clamp-2 text-sm mb-3 flex-1'
+                >
+                  {featured.summary}
+                </Typography>
+                <div className='flex flex-wrap items-center gap-2 text-xs text-muted-foreground pt-3 border-t mt-auto'>
+                  <span className='inline-flex items-center gap-1'>
+                    <User className='w-3 h-3' />
+                    <span className='truncate max-w-[80px]'>
+                      {featuredAuthor}
+                    </span>
+                  </span>
+                  <span className='inline-flex items-center gap-1'>
+                    <Calendar className='w-3 h-3' />
+                    {featuredDate}
+                  </span>
+                  <span className='inline-flex items-center gap-1'>
+                    <Eye className='w-3 h-3' />
+                    {formatViewCount(featured.viewCount)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        )}
 
-                {/* Content */}
-                <CardContent className='flex flex-col flex-1 p-4'>
-                  {/* Title */}
-                  <Typography
-                    variant='h4'
-                    className={classNames(
-                      'font-semibold line-clamp-2 group-hover:text-primary transition-colors',
-                      'text-base mb-2',
+        {/* Right 2×2 Grid */}
+        {rest.length > 0 && (
+          <div className='lg:flex-[2] grid grid-cols-2 gap-4'>
+            {rest.map((item) => {
+              const categoryConfig = getCategoryConfig(
+                item.category,
+                tCategories,
+              )
+              const newsUrl = `${PUBLIC_ROUTES.NEWS}/${item.slug}`
+              const imageUrl =
+                item.thumbnailUrl || `${basePath}${DEFAULT_IMAGE}`
+              const displayAuthor = formatAuthorDisplayName(
+                item.authorName,
+                tNews('authorFallback'),
+              )
+              const displayPublishedAt =
+                formatPublishedDate(item.publishedAt) ||
+                tNews('dateUnavailable')
+              return (
+                <Link
+                  key={item.newsId}
+                  href={newsUrl}
+                  className='group block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl'
+                >
+                  <Card
+                    className={cn(
+                      'overflow-hidden transition-all duration-200 h-full flex flex-col py-0',
+                      'hover:shadow-md hover:border-primary/30',
                     )}
                   >
-                    {item.title}
-                  </Typography>
-
-                  {/* Summary */}
-                  <Typography
-                    variant='p'
-                    className={classNames(
-                      'text-muted-foreground line-clamp-2',
-                      'text-sm mb-3 flex-1',
-                    )}
-                  >
-                    {item.summary}
-                  </Typography>
-
-                  {/* Meta Info */}
-                  <div className='flex flex-wrap items-center gap-2 text-xs text-muted-foreground pt-3 border-t'>
-                    {/* Author */}
-                    <span className='inline-flex items-center gap-1'>
-                      <User className='w-3 h-3' />
-                      <span className='truncate max-w-[80px]'>
-                        {displayAuthor}
-                      </span>
-                    </span>
-
-                    {/* Date */}
-                    <span className='inline-flex items-center gap-1'>
-                      <Calendar className='w-3 h-3' />
-                      {displayPublishedAt}
-                    </span>
-
-                    {/* View Count */}
-                    <span className='inline-flex items-center gap-1'>
-                      <Eye className='w-3 h-3' />
-                      {formatViewCount(item.viewCount)}
-                    </span>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          )
-        })}
+                    <div className='relative overflow-hidden bg-muted flex-shrink-0 aspect-video'>
+                      <ImageAtom
+                        src={imageUrl}
+                        alt={item.title}
+                        fill
+                        className='object-cover transition-transform duration-300 group-hover:scale-105'
+                      />
+                      <div className='absolute top-2 left-2'>
+                        <Badge
+                          variant='outline'
+                          className={classNames(
+                            'text-xs font-medium',
+                            categoryConfig.className,
+                          )}
+                        >
+                          {categoryConfig.label}
+                        </Badge>
+                      </div>
+                    </div>
+                    <CardContent className='flex flex-col flex-1 p-3'>
+                      <Typography
+                        variant='h4'
+                        className='font-semibold group-hover:text-primary transition-colors text-sm line-clamp-2 mb-auto'
+                      >
+                        {item.title}
+                      </Typography>
+                      <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground mt-2'>
+                        <span className='inline-flex items-center gap-1'>
+                          <User className='w-3 h-3' />
+                          <span className='truncate max-w-[60px]'>
+                            {displayAuthor}
+                          </span>
+                        </span>
+                        <span className='inline-flex items-center gap-1'>
+                          <Calendar className='w-3 h-3' />
+                          {displayPublishedAt}
+                        </span>
+                        <span className='inline-flex items-center gap-1'>
+                          <Eye className='w-3 h-3' />
+                          {formatViewCount(item.viewCount)}
+                        </span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              )
+            })}
+          </div>
+        )}
       </div>
     </section>
   )

--- a/src/components/organisms/topInterestSection/index.tsx
+++ b/src/components/organisms/topInterestSection/index.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { Button } from '@/components/atoms/button'
 import { PUBLIC_ROUTES } from '@/constants/route'
 import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
 import {
   Carousel,
   CarouselContent,
@@ -93,8 +94,12 @@ const TopInterestSection: React.FC<TopInterestSectionProps> = ({
           </h2>
         </div>
         <Link href={PUBLIC_ROUTES.LISTING_LISTING}>
-          <Button variant='ghost' size='sm' className='text-sm'>
+          <Button
+            variant='ghost'
+            className='group gap-1 px-0 sm:px-3 text-primary hover:text-primary/80'
+          >
             {t('viewAll')}
+            <ArrowRight className='w-4 h-4 transition-transform group-hover:translate-x-0.5' />
           </Button>
         </Link>
       </div>

--- a/src/components/templates/homepage/index.tsx
+++ b/src/components/templates/homepage/index.tsx
@@ -101,7 +101,7 @@ const HomepageTemplate: React.FC<HomepageTemplateProps> = ({
               )}
               {(hasLoadedOnce || !hasNext) && (
                 <Link href={getLoadMoreHref()}>
-                  <Button className='px-6'>{t('common.loadMore')} ➜</Button>
+                  <Button className='px-6'>{t('common.loadMore')}</Button>
                 </Link>
               )}
             </div>

--- a/src/components/templates/newsListTemplate/index.tsx
+++ b/src/components/templates/newsListTemplate/index.tsx
@@ -10,6 +10,7 @@ import ImageAtom from '@/components/atoms/imageAtom'
 import { Badge } from '@/components/atoms/badge'
 import { Skeleton } from '@/components/atoms/skeleton'
 import { Card } from '@/components/atoms/card'
+import { Input } from '@/components/atoms/input'
 import NewsFilterBar from '@/components/molecules/newsFilterBar'
 import NewsCard from '@/components/molecules/newsCard'
 import { basePath, DEFAULT_IMAGE } from '@/constants'
@@ -20,8 +21,123 @@ import {
   formatPublishedDate,
   formatViewCount,
 } from '@/utils/news'
-import { Calendar, Eye, User, TrendingUp } from 'lucide-react'
+import {
+  Calendar,
+  Eye,
+  User,
+  TrendingUp,
+  MapPin,
+  Search,
+  X,
+} from 'lucide-react'
 import type { ListingFilterRequest } from '@/api/types/property.type'
+import Image from 'next/image'
+import { PROVINCE_CODE, PROVINCE_ID } from '@/utils/mapper'
+
+// ─── Static city data for sidebar ────────────────────────────────────────────
+
+const SIDEBAR_CITIES = [
+  {
+    id: PROVINCE_ID.HANOI,
+    code: PROVINCE_CODE.HANOI,
+    name: 'Hà Nội',
+    image: '/images/ha-noi.jpg',
+  },
+  {
+    id: PROVINCE_ID.HO_CHI_MINH,
+    code: PROVINCE_CODE.HO_CHI_MINH,
+    name: 'Hồ Chí Minh',
+    image: '/images/ho-chi-minh.jpg',
+  },
+  {
+    id: PROVINCE_ID.DA_NANG,
+    code: PROVINCE_CODE.DA_NANG,
+    name: 'Đà Nẵng',
+    image: '/images/da-nang.jpg',
+  },
+  {
+    id: PROVINCE_ID.BINH_DUONG,
+    code: PROVINCE_CODE.BINH_DUONG,
+    name: 'Bình Dương',
+    image: '/images/binh-duong.png',
+  },
+  {
+    id: PROVINCE_ID.DONG_NAI,
+    code: PROVINCE_CODE.DONG_NAI,
+    name: 'Đồng Nai',
+    image: '/images/dong-nai.jpg',
+  },
+]
+
+// ─── Sidebar: Location widget ─────────────────────────────────────────────────
+
+const LocationWidget: React.FC = () => {
+  const topCities = SIDEBAR_CITIES.slice(0, 2)
+  const restCities = SIDEBAR_CITIES.slice(2)
+
+  return (
+    <Card className='py-0 overflow-hidden mt-4'>
+      <div className='flex items-center gap-2 px-4 py-3 border-b border-border bg-muted/40'>
+        <MapPin className='w-4 h-4 text-primary flex-shrink-0' />
+        <Typography variant='h4' className='font-semibold text-sm'>
+          Thị trường BĐS theo địa điểm
+        </Typography>
+      </div>
+
+      {/* Top 2 cities – larger image cards */}
+      <div className='grid grid-cols-2 gap-2 p-3'>
+        {topCities.map((city) => (
+          <Link
+            key={city.id}
+            href={`${PUBLIC_ROUTES.LISTING_LISTING}?provinceId=${city.id}&provinceCode=${city.code}`}
+            className='group block relative rounded-lg overflow-hidden'
+          >
+            <div className='relative h-[90px]'>
+              <Image
+                src={city.image}
+                alt={city.name}
+                fill
+                className='object-cover transition-transform duration-300 group-hover:scale-105'
+                sizes='150px'
+              />
+              <div className='absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent' />
+              <span className='absolute bottom-2 left-2 right-2 text-white text-xs font-semibold leading-tight drop-shadow'>
+                {city.name}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {/* Remaining cities – compact list */}
+      <div className='px-3 pb-3 space-y-2'>
+        {restCities.map((city) => (
+          <Link
+            key={city.id}
+            href={`${PUBLIC_ROUTES.LISTING_LISTING}?provinceId=${city.id}&provinceCode=${city.code}`}
+            className='group flex items-center gap-2.5 rounded-lg hover:bg-muted/60 transition-colors p-1'
+          >
+            <div className='relative w-10 h-10 flex-shrink-0 rounded-md overflow-hidden'>
+              <Image
+                src={city.image}
+                alt={city.name}
+                fill
+                className='object-cover'
+                sizes='40px'
+              />
+            </div>
+            <Typography
+              variant='small'
+              className='text-sm font-medium group-hover:text-primary transition-colors'
+            >
+              {city.name}
+            </Typography>
+          </Link>
+        ))}
+      </div>
+    </Card>
+  )
+}
 
 // ─── Featured Article (first item – large horizontal card) ───────────────────
 
@@ -198,8 +314,8 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
   onListReady,
 }) => {
   const t = useTranslations('newsPage')
-  const { items, isLoading, updateFilters } = useListContext<NewsItem>()
-  const [layout, setLayout] = useState<'grid' | 'list'>('list')
+  const { items, isLoading, updateFilters, filters, setKeyword } =
+    useListContext<NewsItem>()
   const [mostViewed, setMostViewed] = useState<NewsItem[]>([])
   const [isSidebarLoading, setIsSidebarLoading] = useState(true)
 
@@ -227,24 +343,46 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
 
   return (
     <div className='px-4 sm:px-6'>
-      {/* Header */}
-      <header className='mb-6'>
-        <Typography
-          variant='h1'
-          className='text-2xl md:text-3xl font-bold mb-1'
-        >
-          {t('title')}
-        </Typography>
-        <Typography variant='p' className='text-muted-foreground text-sm'>
-          {t('subtitle')}
-        </Typography>
+      {/* Header: title + subtitle (left) + search bar (right) */}
+      <header className='mb-4'>
+        <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3'>
+          <div>
+            <Typography
+              variant='h1'
+              className='text-2xl md:text-3xl font-bold mb-1'
+            >
+              {t('title')}
+            </Typography>
+            <Typography variant='p' className='text-muted-foreground text-sm'>
+              {t('subtitle')}
+            </Typography>
+          </div>
+          {/* Search — right-aligned on desktop */}
+          <div className='relative sm:w-64 lg:w-72 flex-shrink-0'>
+            <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none' />
+            <Input
+              type='text'
+              placeholder={t('searchPlaceholder')}
+              value={filters.keyword || ''}
+              onChange={(e) => setKeyword(e.target.value)}
+              className='pl-9 pr-9'
+            />
+            {filters.keyword && (
+              <button
+                type='button'
+                onClick={() => setKeyword('')}
+                className='absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'
+              >
+                <X className='h-4 w-4' />
+              </button>
+            )}
+          </div>
+        </div>
       </header>
 
-      {/* Filter bar */}
-      <div className='mb-7'>
+      {/* Sticky category tab bar */}
+      <div className='mb-6'>
         <NewsFilterBar
-          layout={layout}
-          onLayoutChange={setLayout}
           selectedCategory={selectedCategory}
           onCategoryChange={onCategoryChange}
           selectedTag={selectedTag}
@@ -308,7 +446,7 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
 
         {/* ── Sidebar ── */}
         <aside className='w-full lg:w-[300px] xl:w-[320px] flex-shrink-0'>
-          <div className='sticky top-20'>
+          <div className='sticky top-20 space-y-0'>
             <Card className='py-0 overflow-hidden'>
               <div className='flex items-center gap-2 px-4 py-3 border-b border-border bg-muted/40'>
                 <TrendingUp className='w-4 h-4 text-primary flex-shrink-0' />
@@ -326,6 +464,8 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
                 )}
               </div>
             </Card>
+
+            <LocationWidget />
           </div>
         </aside>
       </div>

--- a/src/contexts/list/index.context.tsx
+++ b/src/contexts/list/index.context.tsx
@@ -205,8 +205,13 @@ const useListFetch = <T,>(
     let isCancelled = false
 
     const fetchData = async () => {
-      // Clear items when not appending (filter change)
-      if (!shouldAppendRef.current) {
+      // Capture the flag BEFORE any await so the value is frozen for this fetch.
+      // React 18 automatic batching defers setState callbacks until after the
+      // entire async function finishes — meaning finally{} runs first and resets
+      // shouldAppendRef.current to false before the setItems callback executes.
+      const shouldAppend = shouldAppendRef.current
+
+      if (!shouldAppend) {
         setItems([])
       }
 
@@ -219,9 +224,7 @@ const useListFetch = <T,>(
 
         const { listings, pagination: paginationData } = response.data
         setItems((prev) =>
-          shouldAppendRef.current
-            ? ([...prev, ...listings] as T[])
-            : (listings as T[]),
+          shouldAppend ? ([...prev, ...listings] as T[]) : (listings as T[]),
         )
         setPagination(paginationData)
       } catch (error) {


### PR DESCRIPTION
- Replace outline pill buttons with underline tab navigation (sticky below nav)
- Move search bar inline with page title/subtitle header
- Remove unused layout toggle (grid/list switch)
- Fix load-more append bug in ListContext (capture shouldAppendRef before await)
- Add LocationWidget to news sidebar
- Fix thumbnail spacing in news cards using Image fill prop
- Align "Xem tất cả" button style across sections