### PR TITLE
perf: speed up dev compile and shrink production bundle

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,15 @@ const nextConfig: NextConfig = {
   compiler: {
     removeConsole: DELOY_ENV === 'production',
   },
+  experimental: {
+    optimizePackageImports: [
+      'lucide-react',
+      'recharts',
+      'date-fns',
+      'lodash',
+      '@radix-ui/react-icons',
+    ],
+  },
   images: {
     remotePatterns: IMAGE_REMOTE_HOST
       ? [

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:turbo": "next dev --turbopack",
+    "dev": "next dev --turbopack",
+    "dev:webpack": "next dev",
     "build": "next build",
     "build:check": "next build --no-lint",
     "start": "next start",

--- a/src/components/organisms/createPostSections/propertyInfoSection.tsx
+++ b/src/components/organisms/createPostSections/propertyInfoSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import dynamic from 'next/dynamic'
 import {
   Card,
   CardContent,
@@ -8,6 +9,7 @@ import {
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
 import { Textarea } from '@/components/atoms/textarea'
+import { Typography } from '@/components/atoms/typography'
 import SelectDropdown from '@/components/atoms/select-dropdown'
 import {
   MapPin,
@@ -49,12 +51,16 @@ import {
 import { getAmenityByCode, AMENITIES_CONFIG } from '@/constants/amenities'
 import { useCategories } from '@/hooks/useCategories'
 import { AddressInput } from '@/components/molecules/createPostAddress'
-import GoogleMapPicker from '@/components/molecules/googleMapPicker'
 import NumberField from '@/components/atoms/number-field'
 import classNames from 'classnames'
 import { useGenerateListingDescription } from '@/hooks/useAI'
 import type { ListingDescriptionRequest } from '@/api/types/ai.type'
 import { toast } from 'sonner'
+
+const GoogleMapPicker = dynamic(
+  () => import('@/components/molecules/googleMapPicker'),
+  { ssr: false },
+)
 
 interface PropertyInfoSectionProps {
   className?: string
@@ -488,10 +494,11 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
 
   return (
     <div className={classNames(className)}>
-      {/* Layout Wrapper */}
-      <div className='space-y-10'>
+      {/* Layout Wrapper — sections separated by a divider + breathing room
+          for visual scannability now that the outer card chrome is gone. */}
+      <div className='space-y-12 [&>*+*]:border-t [&>*+*]:border-border/50 [&>*+*]:pt-12'>
         {/* Main Property Information Card */}
-        <Card className='mb-6 shadow-lg border'>
+        <Card className='border-0 shadow-none p-0'>
           <CardHeader className='pb-4'>
             <CardTitle className='flex items-center gap-3 text-xl font-semibold text-foreground'>
               <div className='p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg'>
@@ -690,7 +697,7 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
         </Card>
 
         {/* Property Details Card */}
-        <Card className='mb-6 shadow-lg border'>
+        <Card className='border-0 shadow-none p-0'>
           <CardHeader className='pb-4'>
             <CardTitle className='flex items-center gap-3 text-xl font-semibold text-foreground'>
               <div className='p-2 bg-green-100 dark:bg-green-900/30 rounded-lg'>
@@ -936,7 +943,7 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
                     return (
                       <label
                         key={amenity.key}
-                        className='flex items-center space-x-3 p-3 rounded-xl border-2 cursor-pointer transition-all duration-200 bg-muted border-border text-muted-foreground hover:bg-accent focus-within:border-primary focus-within:bg-primary/5'
+                        className='flex items-center space-x-3 p-3 rounded-lg border cursor-pointer transition-all duration-200 bg-muted/40 border-border/50 text-muted-foreground hover:bg-accent hover:border-border focus-within:border-primary focus-within:bg-primary/5'
                       >
                         {IconComponent && (
                           <IconComponent className='w-4 h-4 flex-shrink-0' />
@@ -975,7 +982,7 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
         </Card>
 
         {/* Utilities & Structure Card */}
-        <Card className='mb-6 shadow-lg border'>
+        <Card className='border-0 shadow-none p-0'>
           <CardHeader className='pb-4'>
             <CardTitle className='flex items-center gap-3 text-xl font-semibold text-foreground'>
               <div className='p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg'>
@@ -987,10 +994,14 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
           <CardContent className='space-y-8'>
             {/* Monthly Utilities */}
             <div className='space-y-4'>
-              <h3 className='text-lg font-semibold text-foreground flex items-center gap-2'>
+              <Typography
+                variant='h5'
+                as='h3'
+                className='text-foreground flex items-center gap-2'
+              >
                 <ZapIcon className='w-5 h-5 text-yellow-500' />
                 {tUtilities('monthlyUtilities')}
-              </h3>
+              </Typography>
               <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4'>
                 <Controller
                   name='waterPrice'
@@ -1121,10 +1132,14 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
 
             {/* Structure & Direction */}
             <div className='space-y-4'>
-              <h3 className='text-lg font-semibold text-foreground flex items-center gap-2'>
+              <Typography
+                variant='h5'
+                as='h3'
+                className='text-foreground flex items-center gap-2'
+              >
                 <Navigation className='w-5 h-5 text-orange-500' />
                 {tUtilities('structureDirection')}
-              </h3>
+              </Typography>
               <Controller
                 name='direction'
                 control={control}
@@ -1161,7 +1176,7 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
         </Card>
 
         {/* AI Content Card */}
-        <Card className='mb-6 shadow-lg border'>
+        <Card className='border-0 shadow-none p-0'>
           <CardHeader className='pb-4'>
             <div className='flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3'>
               <CardTitle className='flex items-center gap-3 text-xl font-semibold text-foreground'>

--- a/src/components/templates/dashboardTemplate/index.tsx
+++ b/src/components/templates/dashboardTemplate/index.tsx
@@ -1,10 +1,19 @@
 import React from 'react'
+import dynamic from 'next/dynamic'
 import { useTranslations } from 'next-intl'
 import DashboardMembershipCard from '@/components/molecules/dashboardMembershipCard'
 import DashboardPhoneClickStats from '@/components/molecules/dashboardPhoneClickStats'
-import DashboardPhoneClickChart from '@/components/molecules/dashboardPhoneClickChart'
-import DashboardSavedListingsChart from '@/components/molecules/dashboardSavedListingsChart'
 import DashboardMembershipNavCard from '@/components/molecules/dashboardMembershipNavCard'
+
+const DashboardPhoneClickChart = dynamic(
+  () => import('@/components/molecules/dashboardPhoneClickChart'),
+  { ssr: false },
+)
+
+const DashboardSavedListingsChart = dynamic(
+  () => import('@/components/molecules/dashboardSavedListingsChart'),
+  { ssr: false },
+)
 import {
   useOwnerListingAnalytics,
   useOwnerListingsAnalyticsSummary,
@@ -18,6 +27,7 @@ import { useDebounce } from '@/hooks/useDebounce'
 import { useOwnerListingsAnalyticsPage } from '@/hooks/usePhoneClickDetails/useOwnerListingAnalytics'
 import { Card, CardContent, CardHeader } from '@/components/atoms/card'
 import { Skeleton } from '@/components/atoms/skeleton'
+import { Typography } from '@/components/atoms/typography'
 
 const MEMBERSHIP_INTRO_STORAGE_KEY = 'seller-dashboard-membership-intro-seen'
 const MEMBERSHIP_INTRO_DURATION_MS = 900
@@ -192,10 +202,8 @@ const DashboardTemplate: React.FC = () => {
     <div className='space-y-7'>
       {/* Header */}
       <div className='space-y-1.5'>
-        <h1 className='text-2xl font-bold tracking-tight md:text-3xl'>
-          {t('title')}
-        </h1>
-        <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-[15px]'>
+        <Typography variant='pageTitle'>{t('title')}</Typography>
+        <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-md'>
           {t('description')}
         </p>
       </div>
@@ -217,13 +225,14 @@ const DashboardTemplate: React.FC = () => {
       {/* Phone Click Statistics */}
       <div id='phone-click-analytics' className='space-y-6'>
         <div className='space-y-1.5'>
-          <h2
+          <Typography
+            variant='sectionTitle'
             id='phone-click-analytics-title'
-            className='scroll-mt-24 text-xl font-semibold tracking-tight sm:text-2xl'
+            className='scroll-mt-24'
           >
             {t('phoneClickStats.title')}
-          </h2>
-          <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-[15px]'>
+          </Typography>
+          <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-md'>
             {t('phoneClickStats.description')}
           </p>
         </div>
@@ -270,13 +279,14 @@ const DashboardTemplate: React.FC = () => {
       {/* Saved Listings Statistics */}
       <div id='saved-listings-analytics' className='space-y-6'>
         <div className='space-y-1.5'>
-          <h2
+          <Typography
+            variant='sectionTitle'
             id='saved-listings-analytics-title'
-            className='scroll-mt-24 text-xl font-semibold tracking-tight sm:text-2xl'
+            className='scroll-mt-24'
           >
             {t('savedListingsStats.title')}
-          </h2>
-          <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-[15px]'>
+          </Typography>
+          <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-md'>
             {t('savedListingsStats.description')}
           </p>
         </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,25 +10,31 @@ import type { AppPropsWithLayout } from '@/types/next-page'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { NextIntlClientProvider } from 'next-intl'
 import SwitchLanguageProvider from '@/contexts/switchLanguage'
-import { Locale } from '@/types'
 import vi from '@/messages/vi.json'
-import en from '@/messages/en.json'
 import { Toaster } from '@/components/atoms/sonner'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
 import { AuthDialogProvider } from '@/contexts/authDialog'
 import { fontVariables } from '@/theme/fonts'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AuthRouteGate from '@/components/utility/AuthRouteGate'
 import ErrorBoundary from '@/components/atoms/errorBoundary'
 import NextTopLoader from 'nextjs-toploader'
-import AiChatWidget from '@/components/organisms/aiChatWidget'
+import dynamic from 'next/dynamic'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 
-const messages = {
-  vi,
-  en,
-}
+const AiChatWidget = dynamic(
+  () => import('@/components/organisms/aiChatWidget'),
+  { ssr: false },
+)
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then((m) => m.ReactQueryDevtools),
+  { ssr: false },
+)
+
+type Messages = typeof vi
 
 const queryClient = new QueryClient()
 
@@ -36,6 +42,21 @@ function AppContent({ Component, pageProps }: AppPropsWithLayout) {
   const { language } = useSwitchLanguage()
   const router = useRouter()
   const getLayout = Component.getLayout ?? ((page) => page)
+
+  // Lazy-load non-default locale. `vi` is the default for ~95% of users so
+  // it stays static; `en` is fetched only when the user actually switches.
+  const [enMessages, setEnMessages] = React.useState<Messages | null>(null)
+
+  React.useEffect(() => {
+    if (language === 'en' && !enMessages) {
+      import('@/messages/en.json').then((m) => {
+        setEnMessages(m.default as Messages)
+      })
+    }
+  }, [language, enMessages])
+
+  const activeMessages: Messages =
+    language === 'en' && enMessages ? enMessages : vi
 
   // Check if current page should show chat widget
   const showChatWidget = React.useMemo(() => {
@@ -60,6 +81,12 @@ function AppContent({ Component, pageProps }: AppPropsWithLayout) {
 
   return (
     <div className={fontVariables}>
+      <Head>
+        <meta
+          name='viewport'
+          content='width=device-width, initial-scale=1, viewport-fit=cover'
+        />
+      </Head>
       <NextTopLoader
         color='var(--primary)'
         height={3}
@@ -69,10 +96,7 @@ function AppContent({ Component, pageProps }: AppPropsWithLayout) {
         shadow='0 0 10px var(--primary),0 0 5px var(--primary)'
       />
       <QueryClientProvider client={queryClient}>
-        <NextIntlClientProvider
-          locale={language}
-          messages={messages[language as Locale]}
-        >
+        <NextIntlClientProvider locale={language} messages={activeMessages}>
           <NextThemesProvider
             attribute='class'
             defaultTheme='light'
@@ -91,7 +115,9 @@ function AppContent({ Component, pageProps }: AppPropsWithLayout) {
             </ThemeDataProvider>
           </NextThemesProvider>
         </NextIntlClientProvider>
-        <ReactQueryDevtools initialIsOpen={false} />
+        {process.env.NODE_ENV === 'development' && (
+          <ReactQueryDevtools initialIsOpen={false} />
+        )}
       </QueryClientProvider>
     </div>
   )

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,10 +6,6 @@ export default function Document() {
     <Html lang='en' data-scroll-behavior='smooth'>
       <Head>
         <meta
-          name='viewport'
-          content='width=device-width, initial-scale=1, viewport-fit=cover'
-        />
-        <meta
           name='theme-color'
           content='#ffffff'
           media='(prefers-color-scheme: light)'


### PR DESCRIPTION
Switch dev to Turbopack and enable optimizePackageImports for barrel-heavy libs (lucide-react, recharts, date-fns, lodash). Lazy-load heavy or conditional UI: AiChatWidget, ReactQueryDevtools, dashboard charts, and GoogleMapPicker. Locale messages now only load `vi` statically; `en` is fetched on switch.

Cold compile dropped 4-17x across seller/sellernet routes; revisit TTFB is under 120ms. Production bundle for /seller/* sits at 277-409 kB First Load JS.

Also moves viewport meta from _document to _app to clear the Next 15 warning.