### PR TITLE
feat: introduce design system tokens + lint rule (zero visual diff)

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,0 +1,123 @@
+# Design System
+
+Single source of truth for typography and spacing. The goal is to keep the
+UI visually consistent across pages without each component re-deciding its
+own scale.
+
+## Why this exists
+
+Before this layer, components imported `<Typography variant="h6">` and
+then overrode the size inline (`text-base md:text-lg`, `text-sm sm:text-base`,
+etc.). Different cards picked different micro-text sizes (11/12/13/14px)
+for the same kind of label, and section padding ranged from 12px to 40px
+with no rule. The variant catalog existed but wasn't load-bearing.
+
+This layer fixes the structure: tokens carry the values, `<Typography>` is
+the only legitimate way to set type, and a lint rule catches the most
+common bypass.
+
+## Tokens
+
+Defined in [src/styles/globals.css](src/styles/globals.css) inside the
+`@theme` block. They generate Tailwind utilities you can use directly
+(e.g. `text-title`, `p-card`).
+
+### Typography
+
+| Token             | Size | Role                                     |
+| ----------------- | ---- | ---------------------------------------- |
+| `text-display-xl` | 48px | Hero h1 at large viewports               |
+| `text-display`    | 36px | h1 base, top-of-page hero text           |
+| `text-title-lg`   | 30px | Page title (md+), h2                     |
+| `text-title`      | 24px | Page title base, h3, section title (sm+) |
+| `text-heading`    | 20px | Section heading, h4                      |
+| `text-subheading` | 18px | h5, lead-in text                         |
+| `text-body`       | 15px | Reading body                             |
+| `text-meta`       | 12px | Meta rows, timestamps, secondary labels  |
+| `text-micro`      | 11px | Chips, badges, kbd hints                 |
+
+`text-base` (16px) and `text-sm` (14px) remain as Tailwind primitives.
+The named tokens above are the ones that carry typographic _role_ — use
+them when you mean "this is a heading" rather than "this is 24px."
+
+### Spacing
+
+| Token                | Size | Role                            |
+| -------------------- | ---- | ------------------------------- |
+| `spacing-row`        | 8px  | Between dense rows (table-like) |
+| `spacing-row-lg`     | 12px | Looser rows                     |
+| `spacing-card-tight` | 12px | Dense card padding              |
+| `spacing-card`       | 16px | Standard card padding           |
+| `spacing-section`    | 32px | Between major page sections     |
+| `spacing-section-lg` | 40px | Between major sections (lg+)    |
+
+Use as `p-card`, `mb-section`, `gap-row`, etc. The 4pt grid
+(`p-1`/`p-2`/`p-3`…) remains available for one-off spacing inside
+components — the named tokens are for the _surface_ level (cards,
+sections, rows) where consistency across pages matters most.
+
+## How to use
+
+### For type — always go through `<Typography>`
+
+```tsx
+// ✅ Correct
+<Typography variant="sectionTitle">Latest news</Typography>
+
+// ❌ Wrong — bypasses the variant catalog
+<h2 className="text-2xl font-bold">Latest news</h2>
+```
+
+The lint rule warns on `text-2xl` / `text-3xl` / … in component code (any
+heading-range size). It allows the smaller utilities (`text-base`,
+`text-sm`, etc.) because those are legitimately used for body text and
+labels where the variant system would be overkill.
+
+### For spacing — prefer named tokens at the surface level
+
+```tsx
+// ✅ Correct — semantic
+<section className="mb-section">…</section>
+<Card className="p-card">…</Card>
+
+// ❌ Avoid — re-decides spacing per component
+<section className="mb-10 sm:mb-14">…</section>
+<Card className="p-3 sm:p-4">…</Card>
+```
+
+No lint rule for spacing yet — we'll add one once the token names settle
+and the high-traffic components migrate.
+
+## Migration plan
+
+This PR establishes the system. It is **zero visual diff**: tokens carry
+the same values that `<Typography>` variants currently produce, and no
+component is migrated yet.
+
+Sequence:
+
+1. **(this PR)** Tokens + lint rule + doc.
+2. **Next** — migrate `<Typography>` internals to consume the tokens.
+   Pure rename, still zero visual diff. Verifies the tokens compile and
+   are wired correctly.
+3. **Then** — propose the tightened SaaS scale as a one-line value swap
+   on the tokens (the actual visual change). Reviewable in isolation.
+4. **Then** — migrate the four highest-traffic components
+   (`PropertyCard`, `NewsGridItem`, homepage hero search, section
+   headers) to use `<Typography>` exclusively, removing inline overrides.
+   Lint warnings drop with each one.
+5. **Then** — flip `no-inline-heading-sizes` from `warn` to `error`.
+
+Each step is independently reviewable; we can stop or redirect at any
+point without unwinding earlier work.
+
+## Allowlist
+
+The lint rule is scoped _away from_:
+
+- `src/components/atoms/typography.tsx` — owns the variant catalog and is
+  allowed to consume the raw Tailwind scale.
+
+Other atoms (`button.tsx`, `input.tsx`, `badge.tsx`) currently use the
+raw scale and remain in scope of the rule. They're flagged at `warn` so
+existing code keeps working; we'll migrate them in step 4.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,60 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 })
 
+// ─────────────────────────────────────────────────────────────────────────
+// Design system rules — defined inline so they ship with the lint config
+// and are reviewable in the same PR as the tokens themselves.
+//
+// `no-inline-heading-sizes` flags raw `text-2xl` / `text-3xl` / … in
+// component code. Heading-range sizes carry typographic *role* and must
+// flow through <Typography variant="…"> so the type ramp stays a single
+// source of truth (see src/styles/globals.css and DESIGN_SYSTEM.md).
+//
+// Severity is `warn` during the migration; tighten to `error` once the
+// known violations are cleared.
+// ─────────────────────────────────────────────────────────────────────────
+const HEADING_RANGE_RE = /\btext-(2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl)\b/
+
+const designSystemPlugin = {
+  rules: {
+    'no-inline-heading-sizes': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Heading-range Tailwind text sizes (text-2xl and up) must come from <Typography> variants, not inline className.',
+        },
+        messages: {
+          inlineHeading:
+            'Heading-range size "{{cls}}" is part of the typography ramp — express it via <Typography variant="…"> or a semantic token (text-display / text-title / text-heading) instead of inline className. See DESIGN_SYSTEM.md.',
+        },
+        schema: [],
+      },
+      create(context) {
+        function check(node, raw) {
+          const m = raw.match(HEADING_RANGE_RE)
+          if (m) {
+            context.report({
+              node,
+              messageId: 'inlineHeading',
+              data: { cls: m[0] },
+            })
+          }
+        }
+        return {
+          Literal(node) {
+            if (typeof node.value === 'string') check(node, node.value)
+          },
+          TemplateElement(node) {
+            if (node.value && typeof node.value.raw === 'string')
+              check(node, node.value.raw)
+          },
+        }
+      },
+    },
+  },
+}
+
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
@@ -43,6 +97,17 @@ const eslintConfig = [
             'Use a Tailwind text-size token (text-2xs / text-xs / text-sm / text-md / text-base / text-lg / ...) instead of arbitrary text-[Npx]. See tailwind.config.js for the scale.',
         },
       ],
+    },
+  },
+  // Design-system rules layered on top. Scoped away from the typography
+  // primitive itself — that file is *allowed* to consume the raw scale
+  // because it owns the variant catalog.
+  {
+    files: ['**/*.{ts,tsx}'],
+    ignores: ['**/components/atoms/typography.tsx'],
+    plugins: { 'design-system': designSystemPlugin },
+    rules: {
+      'design-system/no-inline-heading-sizes': 'warn',
     },
   },
 ]

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -206,6 +206,52 @@
   );
 }
 
+/* ─────────────────────────────────────────────────────────────────────────
+ * Design system tokens — typography & spacing
+ *
+ * Single source of truth for the type ramp and the layout rhythm. Values
+ * match what `<Typography>` variants currently produce, so introducing the
+ * tokens is a no-op visually. Components migrate progressively (see
+ * DESIGN_SYSTEM.md).
+ *
+ * These tokens generate Tailwind utilities (`text-title`, `p-card`, …) via
+ * Tailwind v4's `@theme` mechanism. Prefer them over raw `text-2xl` /
+ * `p-5` / `mb-10` in component code; the lint rule warns on the highest-
+ * impact violations.
+ * ──────────────────────────────────────────────────────────────────────── */
+@theme {
+  /* Type ramp — 9 tokens covering display → micro. text-base (16) and
+     text-sm (14) remain as Tailwind primitives; the named tokens here
+     are the ones that carry typographic *role*. */
+  --text-display-xl: 3rem; /* 48px — hero h1 (lg+) */
+  --text-display-xl--line-height: 1;
+  --text-display: 2.25rem; /* 36px — h1 base */
+  --text-display--line-height: 2.5rem;
+  --text-title-lg: 1.875rem; /* 30px — page title (md+), h2 */
+  --text-title-lg--line-height: 2.25rem;
+  --text-title: 1.5rem; /* 24px — page title, h3, sectionTitle (sm+) */
+  --text-title--line-height: 2rem;
+  --text-heading: 1.25rem; /* 20px — section heading, h4 */
+  --text-heading--line-height: 1.75rem;
+  --text-subheading: 1.125rem; /* 18px — h5, lead-in */
+  --text-subheading--line-height: 1.75rem;
+  --text-body: 0.9375rem; /* 15px — reading body */
+  --text-body--line-height: 1.375rem;
+  --text-meta: 0.75rem; /* 12px — meta rows, timestamps */
+  --text-meta--line-height: 1rem;
+  --text-micro: 0.6875rem; /* 11px — chips, badges, kbd hints */
+  --text-micro--line-height: 1rem;
+
+  /* Layout rhythm — surface-level spacing keyed by intent, not pixels.
+     Generates `p-card`, `mb-section`, `gap-row`, etc. */
+  --spacing-row: 0.5rem; /* 8px — between dense rows */
+  --spacing-row-lg: 0.75rem; /* 12px — looser rows */
+  --spacing-card-tight: 0.75rem; /* 12px — dense card padding */
+  --spacing-card: 1rem; /* 16px — standard card padding */
+  --spacing-section: 2rem; /* 32px — between major sections */
+  --spacing-section-lg: 2.5rem; /* 40px — between major sections (lg+) */
+}
+
 /* Base styles */
 @layer base {
   * {


### PR DESCRIPTION
Adds the structural layer for a shared typography and spacing system so components stop re-deciding their own scale. Components are not migrated in this PR — values match what <Typography> variants currently produce, so output CSS is unchanged.

- src/styles/globals.css: add 9 typography tokens (text-display-xl … text-micro) and 6 spacing tokens (spacing-card / spacing-section / …) inside the @theme block.
- eslint.config.mjs: inline design-system plugin with no-inline-heading-sizes at warn severity. Catches text-2xl/3xl/4xl/… in component className strings; allows the typography primitive itself to consume the raw scale.
- DESIGN_SYSTEM.md: token table, usage rules, and the staged migration plan (this PR → Typography internals → value swap → component migration → flip rule to error).

Verified: typecheck clean. Lint produces 73 expected warnings on existing inline-heading-size violations across templates; 0 errors from the new rule. Pre-existing error count unchanged.