### PR TITLE
Refactor/typography overrides cleanup

### DIFF
--- a/src/components/atoms/newsGridItem/index.tsx
+++ b/src/components/atoms/newsGridItem/index.tsx
@@ -132,7 +132,7 @@ const NewsGridItem: React.FC<NewsGridItemProps> = ({
             variant={isFeatured ? 'h3' : 'h4'}
             className={classNames(
               'font-semibold line-clamp-2 group-hover:text-primary transition-colors',
-              isFeatured ? 'text-lg sm:text-xl mb-2' : 'text-sm mb-1.5',
+              isFeatured ? 'mb-2' : 'mb-1.5',
             )}
           >
             {title}
@@ -140,12 +140,10 @@ const NewsGridItem: React.FC<NewsGridItemProps> = ({
 
           {showSummary && (
             <Typography
-              variant='p'
+              variant='muted'
               className={classNames(
-                'text-muted-foreground flex-1',
-                isFeatured
-                  ? 'text-sm sm:text-base line-clamp-3 mb-3'
-                  : 'text-xs line-clamp-2 mb-2',
+                'flex-1',
+                isFeatured ? 'line-clamp-3 mb-3' : 'line-clamp-2 mb-2',
               )}
             >
               {summary}

--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -59,10 +59,7 @@ const StatPill: React.FC<{
     <TooltipTrigger asChild>
       <div className='flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-muted/60 hover:bg-muted transition-colors duration-200'>
         <span className='text-primary'>{icon}</span>
-        <Typography
-          variant='small'
-          className='font-semibold text-sm text-foreground'
-        >
+        <Typography variant='small' className='font-semibold text-foreground'>
           {value}
         </Typography>
       </div>
@@ -367,7 +364,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                   <div className='text-center'>
                     <Typography
                       variant='small'
-                      className='text-xs font-bold text-muted-foreground'
+                      className='font-bold text-muted-foreground'
                     >
                       +{hiddenThumbnailCount}
                     </Typography>
@@ -523,9 +520,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               variant='h6'
               className={classNames(
                 'text-foreground group-hover/card:text-primary transition-colors duration-200 leading-tight font-semibold flex-1',
-                isCompact
-                  ? 'text-base md:text-lg line-clamp-2 min-h-[2.75rem]'
-                  : 'text-sm sm:text-base line-clamp-2',
+                isCompact ? 'line-clamp-2 min-h-[2.75rem]' : 'line-clamp-2',
               )}
             >
               {title}
@@ -575,10 +570,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               />
               <Typography
                 variant='small'
-                className={classNames(
-                  'text-muted-foreground line-clamp-1 leading-snug',
-                  isCompact ? 'text-sm' : 'text-xs sm:text-sm',
-                )}
+                className='text-muted-foreground line-clamp-1 leading-snug'
               >
                 {displayAddress}
               </Typography>
@@ -589,10 +581,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
           <div className='flex items-center justify-between gap-2'>
             <Typography
               variant='h5'
-              className={classNames(
-                'text-primary font-bold tracking-tight',
-                isCompact ? 'text-lg md:text-xl' : 'text-base sm:text-lg',
-              )}
+              className='text-primary font-bold tracking-tight'
             >
               {formatByLocale(price, priceUnit)}
             </Typography>
@@ -600,7 +589,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
             {area && isCompact && (
               <Typography
                 variant='small'
-                className='text-xs text-muted-foreground font-medium bg-muted/60 px-2 py-0.5 rounded-full'
+                className='text-muted-foreground font-medium bg-muted/60 px-2 py-0.5 rounded-full'
               >
                 {formatByLocale(Math.round(price / area), 'VND')}
                 /m²
@@ -666,7 +655,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               {description && (
                 <Typography
                   variant='small'
-                  className='text-sm text-muted-foreground/80 line-clamp-2 leading-relaxed'
+                  className='text-muted-foreground/80 line-clamp-2 leading-relaxed'
                 >
                   {description}
                 </Typography>
@@ -682,10 +671,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                   <TooltipTrigger asChild>
                     <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50 hover:bg-muted transition-colors'>
                       <Sofa className='w-3 h-3 sm:w-4 sm:h-4 text-primary flex-shrink-0' />
-                      <Typography
-                        variant='small'
-                        className='font-medium text-xs sm:text-sm'
-                      >
+                      <Typography variant='small' className='font-medium'>
                         {tCreatePost(getFurnishingTranslationKey(furnishing))}
                       </Typography>
                     </div>
@@ -703,10 +689,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                   <TooltipTrigger asChild>
                     <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50 hover:bg-muted transition-colors'>
                       <Compass className='w-3 h-3 sm:w-4 sm:h-4 text-primary flex-shrink-0' />
-                      <Typography
-                        variant='small'
-                        className='font-medium text-xs sm:text-sm'
-                      >
+                      <Typography variant='small' className='font-medium'>
                         {tCreatePost(getDirectionTranslationKey(direction))}
                       </Typography>
                     </div>
@@ -738,10 +721,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                   {userName && (
                     <Typography
                       variant='small'
-                      className={classNames(
-                        'font-medium truncate block',
-                        isCompact ? 'text-sm' : 'text-xs sm:text-sm',
-                      )}
+                      className='font-medium truncate block'
                     >
                       {userName}
                     </Typography>

--- a/src/components/organisms/locationBrowseSection/index.tsx
+++ b/src/components/organisms/locationBrowseSection/index.tsx
@@ -65,10 +65,7 @@ const LocationBrowseSection: React.FC<LocationBrowseSectionProps> = ({
       <section className='mb-10 sm:mb-14'>
         <div className='flex items-center gap-3 mb-5 sm:mb-6'>
           <div className='w-1 h-7 sm:h-8 rounded-full bg-primary' />
-          <Typography
-            variant='h2'
-            className='text-xl sm:text-2xl font-bold text-foreground'
-          >
+          <Typography variant='sectionTitle' className='text-foreground'>
             {t('title')}
           </Typography>
         </div>
@@ -86,10 +83,7 @@ const LocationBrowseSection: React.FC<LocationBrowseSectionProps> = ({
     <section className='mb-10 sm:mb-14'>
       <div className='flex items-center gap-3 mb-5 sm:mb-6'>
         <div className='w-1 h-7 sm:h-8 rounded-full bg-primary' />
-        <Typography
-          variant='h2'
-          className='text-xl sm:text-2xl font-bold text-foreground'
-        >
+        <Typography variant='sectionTitle' className='text-foreground'>
           {t('title')}
         </Typography>
       </div>

--- a/src/components/organisms/newsGridSection/index.tsx
+++ b/src/components/organisms/newsGridSection/index.tsx
@@ -132,16 +132,10 @@ const NewsGridSection: React.FC<NewsGridSectionProps> = ({
         <div className='flex items-start gap-3'>
           <div className='w-1 h-7 sm:h-8 rounded-full bg-primary mt-0.5' />
           <div>
-            <Typography
-              variant='h2'
-              className='text-xl sm:text-2xl font-bold text-foreground'
-            >
+            <Typography variant='sectionTitle' className='text-foreground'>
               {t('title')}
             </Typography>
-            <Typography
-              variant='p'
-              className='text-sm text-muted-foreground mt-1'
-            >
+            <Typography variant='muted' className='mt-1'>
               {t('subtitle')}
             </Typography>
           </div>


### PR DESCRIPTION
This pull request primarily focuses on standardizing typography usage and simplifying class names across several UI components. The main changes involve using consistent `Typography` variants, removing redundant text size classes, and cleaning up class name logic for improved maintainability and visual consistency.

**Typography standardization and variant updates:**

* Updated all section and card titles to use the `sectionTitle` variant for headings, replacing previous explicit `h2` variants and manual sizing. (`src/components/organisms/locationBrowseSection/index.tsx`, `src/components/organisms/newsGridSection/index.tsx`) [[1]](diffhunk://#diff-983e939c0de6b586ce6f1c61f6cbabb22d28a82e3ab1c9495195664c982e32d7L68-R68) [[2]](diffhunk://#diff-983e939c0de6b586ce6f1c61f6cbabb22d28a82e3ab1c9495195664c982e32d7L89-R86) [[3]](diffhunk://#diff-0744e7fe8b045eebf448efb6c2aeeb73a687844deaa817db11ae374a7d5ac596L135-R138)
* Changed summary and subtitle text to use the `muted` variant instead of `p`, ensuring consistent muted styling. (`src/components/atoms/newsGridItem/index.tsx`, `src/components/organisms/newsGridSection/index.tsx`) [[1]](diffhunk://#diff-ba36b4cadb57e5163a4b6bcbd21904863d6ee72332579f55796e49a7206daff7L135-R146) [[2]](diffhunk://#diff-0744e7fe8b045eebf448efb6c2aeeb73a687844deaa817db11ae374a7d5ac596L135-R138)

**Class name simplification and text sizing cleanup:**

* Removed explicit text size classes from `Typography` components where the variant already defines the size, reducing redundancy and potential inconsistencies. (`src/components/molecules/propertyCard/index.tsx`, `src/components/atoms/newsGridItem/index.tsx`) [[1]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L62-R62) [[2]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L370-R367) [[3]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L526-R523) [[4]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L578-R573) [[5]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L592-R592) [[6]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L669-R658) [[7]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L685-R674) [[8]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L706-R692) [[9]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L741-R724) [[10]](diffhunk://#diff-ba36b4cadb57e5163a4b6bcbd21904863d6ee72332579f55796e49a7206daff7L135-R146)
* Cleaned up conditional class names for featured items and compact card layouts, relying more on variant-based styling and less on manual class composition. (`src/components/atoms/newsGridItem/index.tsx`, `src/components/molecules/propertyCard/index.tsx`) [[1]](diffhunk://#diff-ba36b4cadb57e5163a4b6bcbd21904863d6ee72332579f55796e49a7206daff7L135-R146) [[2]](diffhunk://#diff-722b6a386b963e136fd039747ddfa53713b25950118810c3676989746989e8a0L526-R523)

These changes help ensure a more consistent and maintainable UI codebase by leveraging the `Typography` component’s variant system and reducing unnecessary class name complexity.