### PR TITLE
feat(design-system): tighten heading-tier token values

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -223,14 +223,14 @@
   /* Type ramp — 9 tokens covering display → micro. text-base (16) and
      text-sm (14) remain as Tailwind primitives; the named tokens here
      are the ones that carry typographic *role*. */
-  --text-display-xl: 3rem; /* 48px — hero h1 (lg+) */
-  --text-display-xl--line-height: 1;
-  --text-display: 2.25rem; /* 36px — h1 base */
-  --text-display--line-height: 2.5rem;
-  --text-title-lg: 1.875rem; /* 30px — page title (md+), h2 */
-  --text-title-lg--line-height: 2.25rem;
-  --text-title: 1.5rem; /* 24px — page title, h3, sectionTitle (sm+) */
-  --text-title--line-height: 2rem;
+  --text-display-xl: 2.25rem; /* 36px — hero h1 (lg+) */
+  --text-display-xl--line-height: 2.5rem;
+  --text-display: 1.875rem; /* 30px — h1 base */
+  --text-display--line-height: 2.25rem;
+  --text-title-lg: 1.625rem; /* 26px — page title (md+), h2 */
+  --text-title-lg--line-height: 2rem;
+  --text-title: 1.375rem; /* 22px — page title, h3, sectionTitle (sm+) */
+  --text-title--line-height: 1.75rem;
   --text-heading: 1.25rem; /* 20px — section heading, h4 */
   --text-heading--line-height: 1.75rem;
   --text-subheading: 1.125rem; /* 18px — h5, lead-in */


### PR DESCRIPTION
Step 3 of the design system migration — the value swap. Adjusts four typography tokens to a tighter scale that aligns with modern SaaS density without sacrificing hierarchy. Body, meta, and micro tokens are unchanged.

Token-by-token:

  --text-display-xl   48 → 36px   (h1 at lg+)
  --text-display      36 → 30px   (h1 base)
  --text-title-lg     30 → 26px   (h2, pageTitle md+)
  --text-title        24 → 22px   (h3, pageTitle base, sectionTitle sm+)
  --text-heading      20px        (unchanged — h4, sectionTitle base)
  --text-subheading   18px        (unchanged — h5, lead-in)

Verification — every adjacent rung is distinct:
  11 / 12 / 14 / 15 / 16 / 18 / 20 / 22 / 26 / 30 / 36
  No hierarchy collisions; pageTitle and sectionTitle both retain
  responsive growth.

The 22 / 26 sizes are non-Tailwind-standard but are common in modern type ramps (Linear, Apple HIG, Material 3 all ship these values). They exist precisely to slot between Tailwind's stock 20/24/30 rungs without collapsing to neighbors.

Visual impact (as of this PR's merge base):

  - All h1 callsites: zero immediate effect (every one has an inline text-* override that bypasses the variant; will land in step 4)
  - h2 callsites without overrides: 30 → 26
  - pageTitle: 24 → 22 base / 30 → 26 md+ — most visible shrink
  - h3 / NewsGridItem featured title: 24 → 22
  - sectionTitle (homepage section headers): 20 base / 24 → 22 sm+ — 2px shrink on desktop only
  - h4, h5, h6, body, broker rows, badges, captions, micro labels: unchanged

This PR depends on feat/design-system-tokens (defines the tokens) and benefits from feat/design-system-typography (variants consume the tokens) + refactor/typography-overrides-cleanup (callsites stop overriding). Reviewed locally as a stacked preview before push; hierarchy holds and no layout breakage observed.

Verified: typecheck clean. CSS-only edit (ESLint not applicable).