### PR TITLE
Feat/typography h1 page title migration

### DIFF
--- a/src/components/atoms/newsNotFound/index.tsx
+++ b/src/components/atoms/newsNotFound/index.tsx
@@ -14,7 +14,7 @@ const NewsNotFound: React.FC = () => {
       <div className='w-20 h-20 rounded-full bg-muted flex items-center justify-center mx-auto mb-6'>
         <Newspaper className='w-10 h-10 text-muted-foreground' />
       </div>
-      <Typography variant='h1' className='text-2xl font-bold mb-3'>
+      <Typography variant='pageTitle' className='mb-3'>
         {t('notFound')}
       </Typography>
       <Typography

--- a/src/components/molecules/newsDetailHeader/index.tsx
+++ b/src/components/molecules/newsDetailHeader/index.tsx
@@ -48,10 +48,7 @@ const NewsDetailHeader: React.FC<NewsDetailHeaderProps> = ({ news }) => {
       </div>
 
       {/* Title */}
-      <Typography
-        variant='h1'
-        className='text-2xl md:text-4xl font-extrabold mb-5 leading-tight tracking-tight'
-      >
+      <Typography variant='pageTitle' className='mb-5 leading-tight'>
         {news.title}
       </Typography>
 

--- a/src/components/organisms/apartmentDetail/PropertyHeader.tsx
+++ b/src/components/organisms/apartmentDetail/PropertyHeader.tsx
@@ -214,8 +214,8 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
       <div className='w-full'>
         {/* Title */}
         <Typography
-          variant='h1'
-          className='listing-title block w-full text-xl md:text-2xl lg:text-3xl font-bold leading-tight tracking-tight text-foreground'
+          variant='pageTitle'
+          className='listing-title block w-full text-foreground'
         >
           {title}
         </Typography>

--- a/src/components/templates/newsListTemplate/index.tsx
+++ b/src/components/templates/newsListTemplate/index.tsx
@@ -420,10 +420,7 @@ const NewsListTemplate: React.FC<NewsListTemplateProps> = ({
       <header className='mb-4'>
         <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3'>
           <div>
-            <Typography
-              variant='h1'
-              className='text-2xl md:text-3xl font-bold mb-1'
-            >
+            <Typography variant='pageTitle' className='mb-1'>
               {t('title')}
             </Typography>
             <Typography variant='p' className='text-muted-foreground text-sm'>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -223,14 +223,14 @@
   /* Type ramp — 9 tokens covering display → micro. text-base (16) and
      text-sm (14) remain as Tailwind primitives; the named tokens here
      are the ones that carry typographic *role*. */
-  --text-display-xl: 3rem; /* 48px — hero h1 (lg+) */
-  --text-display-xl--line-height: 1;
-  --text-display: 2.25rem; /* 36px — h1 base */
-  --text-display--line-height: 2.5rem;
-  --text-title-lg: 1.875rem; /* 30px — page title (md+), h2 */
-  --text-title-lg--line-height: 2.25rem;
-  --text-title: 1.5rem; /* 24px — page title, h3, sectionTitle (sm+) */
-  --text-title--line-height: 2rem;
+  --text-display-xl: 2.25rem; /* 36px — hero h1 (lg+) */
+  --text-display-xl--line-height: 2.5rem;
+  --text-display: 1.875rem; /* 30px — h1 base */
+  --text-display--line-height: 2.25rem;
+  --text-title-lg: 1.625rem; /* 26px — page title (md+), h2 */
+  --text-title-lg--line-height: 2rem;
+  --text-title: 1.375rem; /* 22px — page title, h3, sectionTitle (sm+) */
+  --text-title--line-height: 1.75rem;
   --text-heading: 1.25rem; /* 20px — section heading, h4 */
   --text-heading--line-height: 1.75rem;
   --text-subheading: 1.125rem; /* 18px — h5, lead-in */


### PR DESCRIPTION
This pull request standardizes the usage of the `Typography` component's `variant='pageTitle'` across multiple UI components and updates the global typography scale to use slightly smaller and more consistent font sizes for display and title text. These changes improve the visual hierarchy and maintain consistency throughout the application.

**Typography component updates:**

* Replaced all instances of `variant='h1'` with `variant='pageTitle'` in the following components for consistent heading styles: `NewsNotFound`, `NewsDetailHeader`, `PropertyHeader`, and `NewsListTemplate`. [[1]](diffhunk://#diff-d94c2aef3a5a0d98cf79d0ad8f7b8b39f5e617131fc6f6a8190b19862b5525a6L17-R17) [[2]](diffhunk://#diff-84d17454840ec0e2fd28881366dee0bc354fdb8664a00f454ea2f83b5cb84992L51-R51) [[3]](diffhunk://#diff-6a21b3619f644109b54ef985fbb3726aefb822dfbb4a96a7697678d44aad6e42L217-R218) [[4]](diffhunk://#diff-380f95b77653eaa1a38076e41ebf2fa9dabc4816b16acf452079a5a1e452d298L423-R423)

**Global style adjustments:**

* Updated the font sizes and line heights for display and title tokens in `globals.css` to be slightly smaller and more consistent, affecting `--text-display-xl`, `--text-display`, `--text-title-lg`, and `--text-title`.