### PR TITLE
refactor(typography): migrate create/update-post step headers to page…

### DIFF
--- a/src/components/molecules/createPostModules/headerModule.tsx
+++ b/src/components/molecules/createPostModules/headerModule.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
+import { Typography } from '@/components/atoms/typography'
 
 interface HeaderModuleProps {
   className?: string
@@ -22,9 +23,9 @@ const HeaderModule: React.FC<HeaderModuleProps> = ({ className }) => {
     <div className={`mb-6 sm:mb-8 ${className || ''}`}>
       <div className='flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 sm:gap-6'>
         <div className='flex-1'>
-          <h1 className='text-xl sm:text-2xl lg:text-3xl font-bold mb-2'>
+          <Typography variant='pageTitle' className='mb-2'>
             {title}
-          </h1>
+          </Typography>
           <p className='text-sm sm:text-base text-muted-foreground'>
             {description}
           </p>

--- a/src/components/templates/createPostTemplate/AIValuationStep.tsx
+++ b/src/components/templates/createPostTemplate/AIValuationStep.tsx
@@ -19,10 +19,7 @@ export const AIValuationStep: React.FC<AIValuationStepProps> = ({
     >
       <Card className='bg-card rounded-lg shadow-sm border p-6 sm:p-8'>
         <Card className='mb-6 sm:mb-8 border-0 shadow-none p-0'>
-          <Typography
-            variant='h2'
-            className='text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 sm:mb-3'
-          >
+          <Typography variant='pageTitle' className='mb-2 sm:mb-3'>
             {t('sections.aiValuation.title')}
           </Typography>
           <Typography variant='muted' className='text-sm sm:text-base'>

--- a/src/components/templates/createPostTemplate/DefaultStep.tsx
+++ b/src/components/templates/createPostTemplate/DefaultStep.tsx
@@ -18,7 +18,7 @@ export const DefaultStep: React.FC<DefaultStepProps> = ({
     >
       <Card className='bg-card rounded-lg shadow-sm border p-6 sm:p-8'>
         <Card className='text-center py-12 border-0 shadow-none p-0'>
-          <Typography variant='h2' className='text-2xl font-bold mb-4'>
+          <Typography variant='pageTitle' className='mb-4'>
             {step.title}
           </Typography>
           <Typography variant='muted'>{step.description}</Typography>

--- a/src/components/templates/createPostTemplate/MediaStep.tsx
+++ b/src/components/templates/createPostTemplate/MediaStep.tsx
@@ -90,10 +90,7 @@ export const MediaStep: React.FC<MediaStepProps> = ({
     >
       <Card className='bg-card rounded-lg shadow-sm border p-6 sm:p-8'>
         <Card className='mb-6 sm:mb-8 border-0 shadow-none p-0'>
-          <Typography
-            variant='h2'
-            className='text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 sm:mb-3'
-          >
+          <Typography variant='pageTitle' className='mb-2 sm:mb-3'>
             {t('sections.media.title')}
           </Typography>
           <Typography variant='muted' className='text-sm sm:text-base'>

--- a/src/components/templates/createPostTemplate/PropertyInfoStep.tsx
+++ b/src/components/templates/createPostTemplate/PropertyInfoStep.tsx
@@ -21,10 +21,7 @@ export const PropertyInfoStep: React.FC<PropertyInfoStepProps> = ({
     >
       <Card className='bg-card rounded-lg shadow-sm border p-6 sm:p-8'>
         <Card className='mb-6 sm:mb-8 border-0 shadow-none p-0'>
-          <Typography
-            variant='h2'
-            className='text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 sm:mb-3'
-          >
+          <Typography variant='pageTitle' className='mb-2 sm:mb-3'>
             {t('sections.propertyInfo.title')}
           </Typography>
           <Typography variant='muted' className='text-sm sm:text-base'>

--- a/src/components/templates/updatePostTemplate/MediaStep.tsx
+++ b/src/components/templates/updatePostTemplate/MediaStep.tsx
@@ -90,10 +90,7 @@ export const MediaStep: React.FC<MediaStepProps> = ({
     >
       <Card className='bg-card rounded-lg shadow-sm border p-6 sm:p-8'>
         <Card className='mb-6 sm:mb-8 border-0 shadow-none p-0'>
-          <Typography
-            variant='h2'
-            className='text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 sm:mb-3'
-          >
+          <Typography variant='pageTitle' className='mb-2 sm:mb-3'>
             {t('sections.media.title')}
           </Typography>
           <Typography variant='muted' className='text-sm sm:text-base'>


### PR DESCRIPTION
Step 4, Group B — create/update-post wizard step headers. Each step in the post-creation flow had its own header that overrode the variant to hit a custom 24/30/36px responsive ladder, bypassing the catalog. The page-level wrapper used a raw <h1>. All migrate to pageTitle, which renders 22/26px after the value swap.

Migrations:

  createPostModules/headerModule (raw <h1> → Typography pageTitle)
    'text-xl sm:text-2xl lg:text-3xl font-bold' → pageTitle defaults
    Was 20/24/30 → now 22/26 responsive

  createPostTemplate/AIValuationStep (h2 → pageTitle)
    'text-2xl sm:text-3xl lg:text-4xl font-bold' → pageTitle defaults
    Was 24/30/36 → now 22/26 responsive

  createPostTemplate/MediaStep (h2 → pageTitle)
    Same override as AIValuationStep

  createPostTemplate/PropertyInfoStep (h2 → pageTitle)
    Same override as AIValuationStep

  createPostTemplate/DefaultStep (h2 → pageTitle)
    'text-2xl font-bold' (flat 24px) → 22/26 responsive

  updatePostTemplate/MediaStep (h2 → pageTitle)
    Same as createPostTemplate/MediaStep — sibling implementation of
    the same step in the update flow.

Visual impact: every step header in the create/update post wizards now sizes uniformly via pageTitle. Largest before-vs-after delta is at lg+ (36px → 26px, ~10px shrink). DefaultStep gains responsive growth it didn't have before.

Out of scope (intentionally deferred):

  - Step description text below each header: variant='muted' overridden with 'text-sm sm:text-base'. Not lint-flagged (rule only catches text-2xl+) but a real bypass; folds into a later "muted-tier cleanup" pass.
  - Section sub-headers inside individual sections (orderSummarySection, packageConfigSection, mediaSection): different role, will go into Group C/D.

Verified: typecheck clean. Lint design-system warnings: 66 → 60 (exactly the 6 migrated callsites; no new errors).