### PR TITLE
refactor(typography): migrate page-title overrides to pageTitle (templates batch)

### DIFF
--- a/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
@@ -321,10 +321,7 @@ export const MembershipRegisterTemplate: React.FC = () => {
                       </div>
                       {currentMembership && (
                         <>
-                          <Typography
-                            variant='h2'
-                            className='text-2xl md:text-3xl font-bold tracking-tight'
-                          >
+                          <Typography variant='pageTitle'>
                             {currentMembership.packageName}
                           </Typography>
                           <div className='flex items-center gap-2 text-muted-foreground'>

--- a/src/components/templates/sellerPublicDetailTemplate/index.tsx
+++ b/src/components/templates/sellerPublicDetailTemplate/index.tsx
@@ -154,9 +154,7 @@ const SellerPublicDetailTemplate: React.FC<SellerPublicDetailTemplateProps> = ({
     <PageContainer width='content' className='py-6'>
       {/* Page heading */}
       <div className='mb-6'>
-        <Typography variant='h2' className='text-xl md:text-2xl'>
-          {t('title')}
-        </Typography>
+        <Typography variant='pageTitle'>{t('title')}</Typography>
         <Typography variant='p' className='text-muted-foreground mt-1'>
           {t('subtitle')}
         </Typography>

--- a/src/components/templates/usageGuideTemplate/index.tsx
+++ b/src/components/templates/usageGuideTemplate/index.tsx
@@ -77,8 +77,8 @@ const UsageGuideTemplate = () => {
               </Badge>
 
               <Typography
-                variant='h2'
-                className='max-w-3xl text-2xl leading-tight tracking-tight sm:text-3xl'
+                variant='pageTitle'
+                className='max-w-3xl leading-tight'
               >
                 {t('title')}
               </Typography>

--- a/src/pages/payment/result.tsx
+++ b/src/pages/payment/result.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/lib/utils'
+import { Typography } from '@/components/atoms/typography'
 
 type PaymentStatus = 'loading' | 'success' | 'failed' | 'cancelled'
 
@@ -509,9 +510,12 @@ const PaymentResultPage: NextPageWithLayout = () => {
                     className='w-16 h-16 border-4 border-primary border-t-transparent rounded-full'
                   />
                 </div>
-                <h2 className='text-2xl font-bold text-foreground mb-2'>
+                <Typography
+                  variant='pageTitle'
+                  className='text-foreground mb-2'
+                >
                   {t('processing.title')}
-                </h2>
+                </Typography>
                 <p className='text-muted-foreground'>{result.message}</p>
               </div>
             )}


### PR DESCRIPTION
Step 4, Group C — page-title-style overrides across template hero surfaces. All four were variant='h2' or raw <h2> overridden into a 24/30px ladder. Migrated to pageTitle (22/26px) so they share sizing with the rest of the application's page titles.

Migrations:

  templates/usageGuideTemplate (h2 → pageTitle)
    'max-w-3xl text-2xl leading-tight tracking-tight sm:text-3xl'
    Was 24/30 → now 22/26. max-w-3xl content cap preserved.

  templates/membershipRegisterTemplate (h2 → pageTitle)
    'text-2xl md:text-3xl font-bold tracking-tight'
    Was 24/30 → now 22/26. Renders the user's current package name in
    the membership panel.

  templates/sellerPublicDetailTemplate (h2 → pageTitle)
    'text-xl md:text-2xl' (no font weight set — was inheriting h2's
    semibold)
    Was 20/24 semibold → now 22/26 bold. Page heading on seller
    profile pages.

  pages/payment/result (raw <h2> → Typography pageTitle)
    'text-2xl font-bold text-foreground mb-2'
    Processing-state heading on the payment result page. Color and
    margin preserved.

Out of scope (intentionally deferred to Group E):

  - templates/usageGuideTemplate is small-PR-blocked but bundled here as the obvious "guide hero" sibling of the others.
  - paymentGuide / pricingGuide stat CardTitles (text-2xl/3xl on numeric values, not headings — Group E with eslint-disable).
  - customerManagementTemplate stat <p>'s (same pattern as guide stats — Group E).
  - payment/result motion.h1 (animated framer-motion success hero; Group E because the animation props make the Typography swap awkward).

Verified: typecheck clean. Lint design-system warnings: 66 → 62 (exactly the 4 migrated callsites; no new errors).