### PR TITLE
refactor(typography): migrate organism/section section-title overrides to variants

### DIFF
--- a/src/components/organisms/heroPromoCarousel/index.tsx
+++ b/src/components/organisms/heroPromoCarousel/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/atoms/button'
+import { Typography } from '@/components/atoms/typography'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import {
@@ -124,9 +125,9 @@ const HeroPromoCarousel = () => {
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-black/25 to-black/10' />
                   <div className='absolute bottom-10 left-6 sm:left-10 max-w-xl text-white'>
-                    <h2 className='text-2xl sm:text-4xl font-semibold tracking-tight mb-3'>
+                    <Typography variant='pageTitle' as='h2' className='mb-3'>
                       {s.heading}
-                    </h2>
+                    </Typography>
                     <p className='text-sm sm:text-base mb-5 leading-relaxed text-white/90'>
                       {s.sub}
                     </p>

--- a/src/components/organisms/locationBrowseSection/index.tsx
+++ b/src/components/organisms/locationBrowseSection/index.tsx
@@ -134,7 +134,7 @@ const LocationBrowseSection: React.FC<LocationBrowseSectionProps> = ({
                     <div className='absolute bottom-6 left-6 right-6 text-white'>
                       <Typography
                         variant='h3'
-                        className='text-2xl font-bold mb-2 text-white drop-shadow'
+                        className='mb-2 text-white drop-shadow'
                       >
                         {city.provinceName}
                       </Typography>

--- a/src/components/organisms/propertyList/index.tsx
+++ b/src/components/organisms/propertyList/index.tsx
@@ -82,10 +82,7 @@ const PropertyList: React.FC<PropertyListProps> = ({
 
   return (
     <div className='w-full'>
-      <Typography
-        variant='h2'
-        className='text-lg md:text-xl lg:text-2xl font-bold mb-6'
-      >
+      <Typography variant='sectionTitle' className='mb-6'>
         {t('homePage.property.listings')} (
         {isLoading ? '...' : displayedProperties.length})
       </Typography>

--- a/src/components/templates/newsListTemplate/index.tsx
+++ b/src/components/templates/newsListTemplate/index.tsx
@@ -189,8 +189,8 @@ const FeaturedArticle: React.FC<{ news: NewsItem }> = ({ news }) => {
         <div className='flex flex-col justify-between flex-1 sm:py-1'>
           <div>
             <Typography
-              variant='h2'
-              className='text-xl sm:text-2xl font-bold leading-tight line-clamp-3 group-hover:text-primary transition-colors mb-3'
+              variant='h3'
+              className='leading-tight line-clamp-3 group-hover:text-primary transition-colors mb-3'
             >
               {news.title}
             </Typography>


### PR DESCRIPTION
Step 4, Group D — section/card title overrides across organisms and the news list template. Each was overriding a heading-range size on a variant whose default already approximates the target size after the value swap; switching to the right variant deletes the override.

Migrations:

  organisms/locationBrowseSection — city carousel card title
    h3 + 'text-2xl font-bold' → h3 default (22px semibold)
    Was 24px bold, now 22px semibold. Color/drop-shadow preserved.

  organisms/heroPromoCarousel — hero carousel slide title
    Raw <h2> + 'text-2xl sm:text-4xl font-semibold tracking-tight'
    → Typography pageTitle (rendered as <h2> via the `as` prop —
    multiple slides per page; one h1 per page is preserved upstream).
    Was 24/36 → now 22/26 responsive.

  organisms/propertyList — list section header
    h2 + 'text-lg md:text-xl lg:text-2xl font-bold' → sectionTitle
    Was 18/20/24 → now 20/22 responsive (sectionTitle native ladder).

  templates/newsListTemplate — news article card title (line ~193)
    h2 + 'text-xl sm:text-2xl font-bold leading-tight ...' → h3
    Was 20/24 bold, now 22 semibold (h3 default). leading-tight,
    line-clamp-3, hover/transition styles preserved.

Out of scope:

  - listing-card price (text-xl sm:text-2xl on a <p>): stat-value pattern. Group E (eslint-disable + rationale).
  - latestNewsSection h2 overrides: dead code (no consumer in the codebase). Deletion belongs in a separate cleanup PR; leaving the warnings in place rather than expanding scope here.
  - apartmentDetail/PropertyHeader badge counts and listing-card badges: also stat-values, Group E.

Verified: typecheck clean. Lint design-system warnings: 66 → 62 (exactly the 4 migrated callsites; no new errors).