### PR TITLE
fix(chatbot): pin chat panel to bottom on initial mount after refresh

### DIFF
--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from 'react'
+import React, { FC, memo, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -403,4 +403,17 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
   )
 }
 
-export default AiChatBubble
+// Memoized so non-streaming bubbles don't re-render on every text delta of
+// the in-flight bot response. updateMessage in useChatSession returns a
+// fresh object only for the streaming message (the rest keep their identity
+// via Array.map), so referential equality on `message` is a sound bail-out.
+// Callbacks come from useCallback / useState setters in the parent and are
+// referentially stable across renders.
+export default memo(AiChatBubble, (prev, next) => {
+  return (
+    prev.message === next.message &&
+    prev.className === next.className &&
+    prev.onViewListingDetail === next.onViewListingDetail &&
+    prev.onOpenFullDetail === next.onOpenFullDetail
+  )
+})

--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject, useRef, useState } from 'react'
+import { FC, RefObject, useLayoutEffect, useRef, useState } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 
 import { cn } from '@/lib/utils'
@@ -61,6 +61,27 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
   const [fullDetailListingId, setFullDetailListingId] = useState<number | null>(
     null,
   )
+
+  // On panel mount (e.g. user reopens the chat after a page refresh and
+  // sessionStorage rehydrates prior messages), pin the scroll to the bottom
+  // so the most recent turn is visible. Without this, the container starts
+  // at scrollTop=0 and the user sees the oldest message instead.
+  // rAF-after-rAF: first frame writes scrollTop synchronously before paint;
+  // the second covers late layout (listing card images / async fonts) that
+  // would otherwise grow the content after our initial scroll-to-bottom.
+  useLayoutEffect(() => {
+    const container = scrollRef.current
+    if (!container) return
+    container.scrollTop = container.scrollHeight
+    const id1 = requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight
+      // Inner rAF intentional — runs after the next layout flush.
+      requestAnimationFrame(() => {
+        container.scrollTop = container.scrollHeight
+      })
+    })
+    return () => cancelAnimationFrame(id1)
+  }, [scrollRef])
 
   return (
     <div

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -208,9 +208,15 @@ export const useChatLogic = () => {
           scrollContainer?.removeEventListener('wheel', handleUserScroll)
           scrollContainer?.removeEventListener('touchmove', handleUserScroll)
         }
+        // Coalesce scroll-follow across bursty deltas: only one rAF in flight
+        // at a time, so 100 deltas in a single frame collapse to a single
+        // scrollTop write at next paint (instead of 100 queued writes).
+        let scrollRafPending = false
         const followScrollToBottom = () => {
-          if (!followBottom || !scrollContainer) return
+          if (!followBottom || !scrollContainer || scrollRafPending) return
+          scrollRafPending = true
           requestAnimationFrame(() => {
+            scrollRafPending = false
             scrollContainer.scrollTop = scrollContainer.scrollHeight
           })
         }

--- a/src/hooks/useChatAi/useChatSession.ts
+++ b/src/hooks/useChatAi/useChatSession.ts
@@ -1,8 +1,16 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 
 import type { TChatMessage } from './useChatLogic'
 
 const CHAT_SESSION_KEY = 'smart-rent-ai-chat-session'
+
+// Debounce window for sessionStorage writes. Streaming bot responses can fire
+// 50-200 state updates per turn (one per text delta from the SSE stream). A
+// synchronous JSON.stringify + sessionStorage.setItem on every delta blocks
+// the main thread and causes visible streaming jank. 400ms is short enough
+// that closing the tab still captures recent messages on the next pageshow,
+// long enough to coalesce a full streaming response into one write.
+const PERSIST_DEBOUNCE_MS = 400
 
 export const useChatSession = (initialMessage: TChatMessage) => {
   const [sessionMessages, setSessionMessages] = useState<TChatMessage[]>(() => {
@@ -25,18 +33,53 @@ export const useChatSession = (initialMessage: TChatMessage) => {
     return [initialMessage]
   })
 
+  // Hold the latest messages in a ref so the persist function can read them
+  // without being re-created (and re-scheduled) on every state change.
+  const messagesRef = useRef(sessionMessages)
+  messagesRef.current = sessionMessages
+
   useEffect(() => {
-    try {
-      if (sessionMessages.length > 0) {
+    if (sessionMessages.length === 0) return
+
+    const handle = window.setTimeout(() => {
+      try {
         sessionStorage.setItem(
           CHAT_SESSION_KEY,
-          JSON.stringify(sessionMessages),
+          JSON.stringify(messagesRef.current),
         )
+      } catch {
+        // Silent fail - session storage might be full or unavailable
       }
-    } catch {
-      // Silent fail - session storage might be full or unavailable
-    }
+    }, PERSIST_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(handle)
   }, [sessionMessages])
+
+  // Belt-and-braces: flush on tab hide / pagehide so a stream-in-progress
+  // doesn't lose its trailing 400ms when the user closes the tab.
+  useEffect(() => {
+    const flush = () => {
+      try {
+        if (messagesRef.current.length > 0) {
+          sessionStorage.setItem(
+            CHAT_SESSION_KEY,
+            JSON.stringify(messagesRef.current),
+          )
+        }
+      } catch {
+        // Silent fail
+      }
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') flush()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    window.addEventListener('pagehide', flush)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      window.removeEventListener('pagehide', flush)
+    }
+  }, [])
 
   const clearSession = useCallback(() => {
     try {


### PR DESCRIPTION
When the AI chat widget is reopened after a page refresh, useChatSession rehydrates messages from sessionStorage on first render. The scroll container started at scrollTop=0, leaving users staring at the OLDEST message instead of the most recent — they had to manually scroll down to see the conversation they were in.

Add a one-shot useLayoutEffect on AiChatInterface mount that sets scrollTop = scrollHeight synchronously before paint, then re-pins twice across rAFs to absorb late layout from listing-card images and async font swaps. The effect runs every panel mount, which is the desired behavior — closing and reopening the chat should also land at the bottom.

No behavior change for new messages or streaming follow: the existing followScrollToBottom and scrollToMessage paths in useChatLogic are untouched.