### PR TITLE
feat(chatbot): consume BE-generated tool_call summary for richer streaming UX

### DIFF
--- a/src/api/types/ai.type.ts
+++ b/src/api/types/ai.type.ts
@@ -211,6 +211,20 @@ export interface ChatStreamStatusPayload {
   round?: number
   tool?: string
   status?: 'success' | 'error'
+  /**
+   * Backend-generated, locale-aware one-line label of what the tool is
+   * about to do (`tool_call` phase only). Already in the user's language;
+   * the FE should display it verbatim and skip the static getToolLabel
+   * lookup when present.
+   * Example: "Đang tìm BĐS: quận 765 phòng/căn hộ giá 5-10tr..."
+   */
+  summary?: string
+  /**
+   * Sanitised arguments the agent passed to the tool — `auth_token` and
+   * other secrets are stripped backend-side. Useful for richer FE
+   * progress UI (skeleton card matching the search params, etc.).
+   */
+  args?: Record<string, unknown>
 }
 
 export interface ChatStreamTextPayload {

--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -48,10 +48,18 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
   const t = useTranslations('aiChat')
   const locale = useLocale() as 'vi' | 'en'
 
-  const statusLabel =
-    streamingStatus?.phase === 'tool_call' && streamingStatus.tool
-      ? getToolLabel(streamingStatus.tool, locale)
-      : undefined
+  // Prefer the BE-generated localised summary (carries arg context like
+  // "quận 765 phòng/căn hộ giá 5-10tr"); fall back to the static per-tool
+  // label when the backend didn't send one.
+  const statusLabel = (() => {
+    if (streamingStatus?.phase !== 'tool_call' || !streamingStatus.tool) {
+      return undefined
+    }
+    if (streamingStatus.summary) {
+      return streamingStatus.summary
+    }
+    return getToolLabel(streamingStatus.tool, locale)
+  })()
 
   // Track initial message count at mount to avoid animating restored messages
   const initialCountRef = useRef(messages.length)

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -38,6 +38,8 @@ export type TChatState = {
 export type TStreamingStatus = {
   phase: ChatStreamStatusPayload['phase']
   tool?: string
+  /** BE-generated localised label for the tool_call phase (preferred over getToolLabel). */
+  summary?: string
 } | null
 
 function buildLastListings(messages: TChatMessage[]): LastListingRef[] {
@@ -242,7 +244,11 @@ export const useChatLogic = () => {
             },
             {
               onStatus: (data) => {
-                setStreamingStatus({ phase: data.phase, tool: data.tool })
+                setStreamingStatus({
+                  phase: data.phase,
+                  tool: data.tool,
+                  summary: data.summary,
+                })
               },
               onTextDelta: (delta) => {
                 ensureBotMessage()


### PR DESCRIPTION
The AI service started emitting `summary` and `args` on the SSE `tool_call` status event (smartrent-ai feature/agent-tools-sprint-v2). The summary is a backend-generated, locale-aware one-liner like "Đang tìm BĐS: quận 765 phòng/căn hộ giá 5-10tr..." that carries the actual search parameters — much more useful than the previous static per-tool label ("Đang tìm bất động sản").

Wire it through:
- ChatStreamStatusPayload: added optional `summary` and `args` fields
- TStreamingStatus: forwards summary into hook state
- aiChatInterface: prefers `streamingStatus.summary` over the static getToolLabel fallback when present; falls back to the existing per-tool label dictionary otherwise

Verification (run after final edit):
- npm run typecheck   ✓ exit 0
- npm run lint -- --max-warnings=0 (touched files)   ✓ clean
- npm run i18n:check   ✓ 2849 keys in sync