### PR TITLE
fix: location-browse skeleton stuck on query error

### DIFF
--- a/src/components/templates/homepage/index.tsx
+++ b/src/components/templates/homepage/index.tsx
@@ -23,12 +23,14 @@ import PersonalizedPropertySection from '@/components/organisms/personalizedProp
 
 interface HomepageTemplateProps {
   cities?: ProvinceStatsItem[]
+  citiesLoading?: boolean
   categoryStats?: CategoryStatsItem[]
   latestNews?: NewsItem[]
 }
 
 const HomepageTemplate: React.FC<HomepageTemplateProps> = ({
   cities,
+  citiesLoading = false,
   categoryStats,
   latestNews = [],
 }) => {
@@ -109,7 +111,7 @@ const HomepageTemplate: React.FC<HomepageTemplateProps> = ({
           )}
         </div>
 
-        <LocationBrowseSection cities={cities} loading={cities === undefined} />
+        <LocationBrowseSection cities={cities} loading={citiesLoading} />
 
         {latestNews && latestNews.length > 0 && (
           <NewsGridSection news={latestNews} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,7 +50,9 @@ const HOMEPAGE_VI_KEYWORDS = [
 const Home: NextPageWithLayout = () => {
   const isClientSide = typeof window !== 'undefined'
 
-  const { data: provinceCities } = useQuery<ProvinceStatsItem[]>({
+  const { data: provinceCities, isPending: isProvinceCitiesPending } = useQuery<
+    ProvinceStatsItem[]
+  >({
     queryKey: ['homepage', 'province-stats'],
     queryFn: async () => {
       const response = await ListingService.getProvinceStats({
@@ -102,6 +104,7 @@ const Home: NextPageWithLayout = () => {
           <div className='container mx-auto space-y-6'>
             <HomepageTemplate
               cities={provinceCities}
+              citiesLoading={isProvinceCitiesPending}
               categoryStats={categoryStats}
               latestNews={latestNews}
             />


### PR DESCRIPTION
## Summary
- `LocationBrowseSection` (section "Bất động sản theo địa điểm" trên homepage) đang dùng `loading={cities === undefined}` ⇒ khi `getProvinceStats` fail (network/5xx) thì `data` của `useQuery` mãi mãi là `undefined` và skeleton treo vĩnh viễn, người dùng không bao giờ thoát ra được trạng thái loading.
- Đổi sang dùng `isPending` từ `useQuery` (TanStack v5): `isPending=true` chỉ khi thực sự đang chờ data, `false` ngay khi success hoặc error → skeleton sẽ thoát ra và rơi vào empty state "noData" có sẵn trong `LocationBrowseSection` khi gặp lỗi.
- Truyền state mới qua `HomepageTemplate` bằng prop `citiesLoading` (default `false`).

## Test plan
- [ ] Mở `/` ở dev, throttle network thành Offline trước khi load → confirm thấy empty state "noData" thay vì skeleton vĩnh viễn.
- [ ] Mở `/` với network OK → skeleton hiện rất nhanh rồi thay bằng cards 5 tỉnh (Hà Nội, HCM, Đà Nẵng, Bình Dương, Đồng Nai).
- [ ] Block request `getProvinceStats` ở DevTools → confirm skeleton biến mất, hiển thị empty state.
- [ ] `npm run lint`, `npm run typecheck`, `npm run i18n:check` đều pass (đã chạy pre-commit OK).
