### PR TITLE
feat(seller-dashboard): enhance dashboard UI

### DIFF
--- a/src/components/molecules/dashboardMembershipCard/index.tsx
+++ b/src/components/molecules/dashboardMembershipCard/index.tsx
@@ -194,23 +194,35 @@ const DashboardMembershipCard: React.FC = () => {
   }
 
   return (
-    <Card className='overflow-hidden'>
-      <CardHeader>
-        <div className='flex items-start justify-between'>
+    <Card className='relative overflow-hidden'>
+      {/* Subtle brand wash behind the header for a more premium feel */}
+      <div
+        aria-hidden='true'
+        className='pointer-events-none absolute inset-x-0 top-0 h-28 bg-gradient-to-b from-primary/5 to-transparent'
+      />
+      <CardHeader className='relative'>
+        <div className='flex items-start justify-between gap-4'>
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5 }}
+            className='flex items-start gap-3'
           >
-            <CardTitle className='flex items-center gap-2'>
-              <Crown className='h-6 w-6 text-blue-600' />
-              <span className='text-foreground'>{membership.packageName}</span>
-            </CardTitle>
-            <CardDescription className='mt-1 flex items-center gap-2'>
-              <Sparkles className='h-3 w-3 text-blue-600' />
-              {t('packageLevel')}:{' '}
-              <span className='font-semibold'>{membership.packageLevel}</span>
-            </CardDescription>
+            <span className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/15'>
+              <Crown className='h-6 w-6 text-primary' />
+            </span>
+            <div className='space-y-1'>
+              <CardTitle className='text-foreground'>
+                {membership.packageName}
+              </CardTitle>
+              <CardDescription className='flex items-center gap-1.5'>
+                <Sparkles className='h-3.5 w-3.5 text-primary' />
+                {t('packageLevel')}:{' '}
+                <span className='font-semibold text-foreground'>
+                  {membership.packageLevel}
+                </span>
+              </CardDescription>
+            </div>
           </motion.div>
           <motion.div
             initial={{ opacity: 0 }}
@@ -234,8 +246,8 @@ const DashboardMembershipCard: React.FC = () => {
           transition={{ delay: 0.2 }}
           className='flex items-center gap-3 p-3 rounded-lg bg-muted border border-border'
         >
-          <div className='flex items-center justify-center w-10 h-10 rounded-full bg-blue-100'>
-            <Calendar className='h-5 w-5 text-blue-600' />
+          <div className='flex items-center justify-center w-10 h-10 rounded-full bg-primary/10'>
+            <Calendar className='h-5 w-5 text-primary' />
           </div>
           <div className='flex-1'>
             <p className='text-xs text-muted-foreground'>{t('validUntil')}</p>
@@ -275,7 +287,7 @@ const DashboardMembershipCard: React.FC = () => {
           >
             <div className='flex items-center justify-between'>
               <div className='flex items-center gap-2 text-sm font-semibold'>
-                <Gift className='h-5 w-5 text-blue-600' />
+                <Gift className='h-5 w-5 text-primary' />
                 <span className='text-foreground'>{t('activeBenefits')}</span>
               </div>
               <Badge variant='secondary' className='font-semibold'>

--- a/src/components/molecules/dashboardPhoneClickChart/index.tsx
+++ b/src/components/molecules/dashboardPhoneClickChart/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import {
   ChartConfig,
@@ -26,6 +27,7 @@ import { Button } from '@/components/atoms/button'
 import {
   Bar,
   BarChart,
+  Brush,
   CartesianGrid,
   Line,
   LineChart,
@@ -34,7 +36,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { ListX, Loader2, Search } from 'lucide-react'
+import { ExternalLink, ListX, Loader2, Search } from 'lucide-react'
 import { format, parseISO, eachDayOfInterval, subDays } from 'date-fns'
 import { useIsMobile } from '@/hooks/useMediaQuery'
 import type {
@@ -44,6 +46,10 @@ import type {
 import { PhoneClickDetailService } from '@/api/services'
 import { Skeleton } from '@/components/atoms/skeleton'
 import DashboardNoDataState from '@/components/molecules/dashboardNoDataState'
+
+// Number of most-recent data points the zoom brush shows by default before the
+// user drags to widen/narrow the window.
+const DEFAULT_BRUSH_WINDOW = 45
 
 interface DashboardPhoneClickChartProps {
   listings: OwnerListingAnalyticsSummaryItem[]
@@ -219,6 +225,14 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
     })
   }, [analytics?.clicksOverTime, period])
 
+  // When the range is long (e.g. 365 days) the x-axis gets cramped. Default the
+  // zoom brush to the most recent window so the chart reads clearly, while still
+  // letting the user drag the handles to zoom in/out or pan across the range.
+  const clicksBrushStartIndex = useMemo(() => {
+    const len = clicksOverTimeData.length
+    return len > DEFAULT_BRUSH_WINDOW ? len - DEFAULT_BRUSH_WINDOW : 0
+  }, [clicksOverTimeData.length])
+
   const dayOrder = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
   const clicksByDayData = useMemo(() => {
     if (!analytics?.clicksByDayOfWeek) return []
@@ -344,7 +358,7 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                     <ChartContainer
                       config={chartConfig}
                       className={
-                        isMobile ? 'h-[220px] w-full' : 'h-[260px] w-full'
+                        isMobile ? 'h-[260px] w-full' : 'h-[300px] w-full'
                       }
                     >
                       <ResponsiveContainer width='100%' height='100%'>
@@ -407,6 +421,18 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                             }}
                             name={t('clicks')}
                           />
+                          {clicksOverTimeData.length > 1 && (
+                            <Brush
+                              dataKey='date'
+                              height={26}
+                              travellerWidth={10}
+                              gap={1}
+                              stroke='var(--color-count)'
+                              fill='hsl(var(--muted))'
+                              startIndex={clicksBrushStartIndex}
+                              className='text-xs'
+                            />
+                          )}
                         </LineChart>
                       </ResponsiveContainer>
                     </ChartContainer>
@@ -496,7 +522,7 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                         {t('rowsPerPage')}
                       </span>
                       <Select
-                        value={String(pageSize || 10)}
+                        value={String(pageSize || 5)}
                         onValueChange={(v) => onPageSizeChange?.(Number(v))}
                       >
                         <SelectTrigger className='w-[100px]'>
@@ -551,15 +577,33 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                                   {listing.totalClicks}
                                 </strong>
                               </p>
-                              <Button
-                                variant='outline'
-                                size='sm'
-                                onClick={() =>
-                                  handleSelectListing(listing.listingId)
-                                }
-                              >
-                                {t('viewDetails')}
-                              </Button>
+                              <div className='flex items-center gap-2'>
+                                <Button
+                                  variant='outline'
+                                  size='sm'
+                                  onClick={() =>
+                                    handleSelectListing(listing.listingId)
+                                  }
+                                >
+                                  {t('viewDetails')}
+                                </Button>
+                                <Button
+                                  asChild
+                                  variant='ghost'
+                                  size='icon'
+                                  className='size-8'
+                                >
+                                  <Link
+                                    href={`/listing-detail/${listing.listingId}`}
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    title={t('openListing')}
+                                    aria-label={t('openListing')}
+                                  >
+                                    <ExternalLink className='size-4' />
+                                  </Link>
+                                </Button>
+                              </div>
                             </div>
                           </div>
                         ))
@@ -624,15 +668,33 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                                 {listing.totalClicks}
                               </TableCell>
                               <TableCell className='text-right'>
-                                <Button
-                                  variant='outline'
-                                  size='sm'
-                                  onClick={() =>
-                                    handleSelectListing(listing.listingId)
-                                  }
-                                >
-                                  {t('viewDetails')}
-                                </Button>
+                                <div className='flex items-center justify-end gap-2'>
+                                  <Button
+                                    variant='outline'
+                                    size='sm'
+                                    onClick={() =>
+                                      handleSelectListing(listing.listingId)
+                                    }
+                                  >
+                                    {t('viewDetails')}
+                                  </Button>
+                                  <Button
+                                    asChild
+                                    variant='ghost'
+                                    size='icon'
+                                    className='size-8'
+                                  >
+                                    <Link
+                                      href={`/listing-detail/${listing.listingId}`}
+                                      target='_blank'
+                                      rel='noopener noreferrer'
+                                      title={t('openListing')}
+                                      aria-label={t('openListing')}
+                                    >
+                                      <ExternalLink className='size-4' />
+                                    </Link>
+                                  </Button>
+                                </div>
                               </TableCell>
                             </TableRow>
                           ))

--- a/src/components/molecules/dashboardSavedListingsChart/index.tsx
+++ b/src/components/molecules/dashboardSavedListingsChart/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import {
   ChartConfig,
@@ -30,6 +31,7 @@ import {
   AreaChart,
   Bar,
   BarChart,
+  Brush,
   CartesianGrid,
   Cell,
   ResponsiveContainer,
@@ -37,7 +39,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { Loader2, Heart, ListX, Search } from 'lucide-react'
+import { ExternalLink, Loader2, Heart, ListX, Search } from 'lucide-react'
 import { format, parseISO, eachDayOfInterval, subDays } from 'date-fns'
 import { useIsMobile } from '@/hooks/useMediaQuery'
 import type {
@@ -67,6 +69,10 @@ interface DashboardSavedListingsChartProps {
   period?: '7d' | '30d' | '90d' | '180d' | '365d' | 'all'
   onPeriodChange?: (p: '7d' | '30d' | '90d' | '180d' | '365d' | 'all') => void
 }
+
+// Number of most-recent data points the zoom brush shows by default before the
+// user drags to widen/narrow the window.
+const DEFAULT_BRUSH_WINDOW = 45
 
 const BAR_COLORS = [
   'var(--chart-1)',
@@ -241,6 +247,13 @@ const DashboardSavedListingsChart: React.FC<
     return filled
   }, [trend?.savesOverTime, period])
 
+  // Long ranges (e.g. 365 days) crowd the x-axis; default the zoom brush to the
+  // most recent window and let the user drag to zoom in/out or pan.
+  const savesBrushStartIndex = useMemo(() => {
+    const len = savesOverTimeData.length
+    return len > DEFAULT_BRUSH_WINDOW ? len - DEFAULT_BRUSH_WINDOW : 0
+  }, [savesOverTimeData.length])
+
   const barChartData = useMemo(() => {
     return listings.map((item) => ({
       name:
@@ -292,14 +305,18 @@ const DashboardSavedListingsChart: React.FC<
         />
       ) : (
         <>
-          <div className='rounded-xl border border-amber-200/70 bg-gradient-to-r from-amber-50/70 via-amber-50/30 to-background p-4 shadow-sm dark:border-amber-900/50 dark:from-amber-950/25 dark:via-amber-950/10 dark:to-background sm:p-5'>
-            <div className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300'>
+          <div className='inline-flex items-center gap-3 rounded-lg border border-amber-200/70 bg-amber-50/50 px-4 py-2.5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/15'>
+            <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40'>
               <Heart className='h-4 w-4 text-amber-500' />
-              {t('totalSavesAcrossAll')}
+            </span>
+            <div className='flex flex-col leading-tight'>
+              <span className='text-xs font-medium text-muted-foreground'>
+                {t('totalSavesAcrossAll')}
+              </span>
+              <span className='text-xl font-semibold tracking-tight text-foreground'>
+                {totalSavesAcrossAll}
+              </span>
             </div>
-            <p className='mt-2 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl'>
-              {totalSavesAcrossAll}
-            </p>
           </div>
 
           <div className='space-y-2.5'>
@@ -383,7 +400,7 @@ const DashboardSavedListingsChart: React.FC<
                     <ChartContainer
                       config={chartConfig}
                       className={
-                        isMobile ? 'h-[220px] w-full' : 'h-[260px] w-full'
+                        isMobile ? 'h-[260px] w-full' : 'h-[300px] w-full'
                       }
                     >
                       <ResponsiveContainer width='100%' height='100%'>
@@ -457,6 +474,18 @@ const DashboardSavedListingsChart: React.FC<
                             strokeWidth={2.5}
                             connectNulls
                           />
+                          {savesOverTimeData.length > 1 && (
+                            <Brush
+                              dataKey='date'
+                              height={26}
+                              travellerWidth={10}
+                              gap={1}
+                              stroke='var(--color-saves)'
+                              fill='hsl(var(--muted))'
+                              startIndex={savesBrushStartIndex}
+                              className='text-xs'
+                            />
+                          )}
                         </AreaChart>
                       </ResponsiveContainer>
                     </ChartContainer>
@@ -560,7 +589,7 @@ const DashboardSavedListingsChart: React.FC<
                     {t('rowsPerPage')}
                   </span>
                   <Select
-                    value={String(pageSize || 10)}
+                    value={String(pageSize || 5)}
                     onValueChange={(v) => onPageSizeChange?.(Number(v))}
                   >
                     <SelectTrigger className='w-[100px]'>
@@ -615,15 +644,33 @@ const DashboardSavedListingsChart: React.FC<
                               {listing.totalSaves}
                             </strong>
                           </p>
-                          <Button
-                            variant='outline'
-                            size='sm'
-                            onClick={() =>
-                              handleSelectListing(listing.listingId)
-                            }
-                          >
-                            {t('viewTrend')}
-                          </Button>
+                          <div className='flex items-center gap-2'>
+                            <Button
+                              variant='outline'
+                              size='sm'
+                              onClick={() =>
+                                handleSelectListing(listing.listingId)
+                              }
+                            >
+                              {t('viewTrend')}
+                            </Button>
+                            <Button
+                              asChild
+                              variant='ghost'
+                              size='icon'
+                              className='size-8'
+                            >
+                              <Link
+                                href={`/listing-detail/${listing.listingId}`}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                title={t('openListing')}
+                                aria-label={t('openListing')}
+                              >
+                                <ExternalLink className='size-4' />
+                              </Link>
+                            </Button>
+                          </div>
                         </div>
                       </div>
                     ))
@@ -688,15 +735,33 @@ const DashboardSavedListingsChart: React.FC<
                             {listing.totalSaves}
                           </TableCell>
                           <TableCell className='text-right'>
-                            <Button
-                              variant='outline'
-                              size='sm'
-                              onClick={() =>
-                                handleSelectListing(listing.listingId)
-                              }
-                            >
-                              {t('viewTrend')}
-                            </Button>
+                            <div className='flex items-center justify-end gap-2'>
+                              <Button
+                                variant='outline'
+                                size='sm'
+                                onClick={() =>
+                                  handleSelectListing(listing.listingId)
+                                }
+                              >
+                                {t('viewTrend')}
+                              </Button>
+                              <Button
+                                asChild
+                                variant='ghost'
+                                size='icon'
+                                className='size-8'
+                              >
+                                <Link
+                                  href={`/listing-detail/${listing.listingId}`}
+                                  target='_blank'
+                                  rel='noopener noreferrer'
+                                  title={t('openListing')}
+                                  aria-label={t('openListing')}
+                                >
+                                  <ExternalLink className='size-4' />
+                                </Link>
+                              </Button>
+                            </div>
                           </TableCell>
                         </TableRow>
                       ))

--- a/src/components/molecules/pricingPlanCard/index.tsx
+++ b/src/components/molecules/pricingPlanCard/index.tsx
@@ -26,13 +26,14 @@ import { getCardStyles, getButtonStyles } from './styles'
 import type { Membership } from '@/api/types/membership.type'
 import { MembershipPackageLevel } from '@/api/types/membership.type'
 
-// Each membership tier gets its own colour so the icon reads as a rank at a
-// glance: emerald (entry / growth) → sky (mid) → amber-gold (top tier). The
-// tile classes tint the icon's container to match instead of the flat primary.
+// Lower tiers get a subtle colour so the icon reads as a rank at a glance:
+// emerald (entry / growth) → sky (mid). The diamond (top) tier intentionally
+// drops the amber-gold tint and uses the neutral brand primary instead, so it
+// reads as premium without the loud gold colour mapping.
 const MEMBERSHIP_LEVEL_TILE_CLASSES: Record<MembershipPackageLevel, string> = {
   [MembershipPackageLevel.BASIC]: 'bg-emerald-500/10 border-emerald-500/20',
   [MembershipPackageLevel.STANDARD]: 'bg-sky-500/10 border-sky-500/20',
-  [MembershipPackageLevel.ADVANCED]: 'bg-amber-500/10 border-amber-500/20',
+  [MembershipPackageLevel.ADVANCED]: 'bg-primary/10 border-primary/15',
 }
 
 export const getMembershipLevelTileClasses = (
@@ -51,7 +52,7 @@ export const getMembershipLevelIcon = (
       <Sparkles className='size-7 text-sky-600 dark:text-sky-400' />
     ),
     [MembershipPackageLevel.ADVANCED]: (
-      <Crown className='size-7 text-amber-500 dark:text-amber-400' />
+      <Crown className='size-7 text-primary' />
     ),
   }
 

--- a/src/components/templates/dashboardTemplate/index.tsx
+++ b/src/components/templates/dashboardTemplate/index.tsx
@@ -75,7 +75,7 @@ const DashboardTemplate: React.FC = () => {
     '7d' | '30d' | '90d' | '180d' | '365d' | 'all'
   >('30d')
   const [clicksPage, setClicksPage] = React.useState(0)
-  const [clicksSize, setClicksSize] = React.useState(10)
+  const [clicksSize, setClicksSize] = React.useState(5)
   const [clicksKeyword, setClicksKeyword] = React.useState('')
   const debouncedClicksKeyword = useDebounce(clicksKeyword, 300)
   const { data: clicksListingsPage, isLoading: isClicksPageLoading } =
@@ -139,7 +139,7 @@ const DashboardTemplate: React.FC = () => {
     useOwnerSavedListingsAnalyticsSummary()
   // paging + search state for saved listings
   const [savesPage, setSavesPage] = React.useState(0)
-  const [savesSize, setSavesSize] = React.useState(10)
+  const [savesSize, setSavesSize] = React.useState(5)
   const [savesKeyword, setSavesKeyword] = React.useState('')
   const debouncedSavesKeyword = useDebounce(savesKeyword, 300)
   const { data: savedListingsPage, isLoading: isSavedPageLoading } =

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2442,6 +2442,7 @@
         "allListings": "All Listings Summary",
         "action": "Action",
         "viewDetails": "View Details",
+        "openListing": "Open listing in new tab",
         "days": {
           "MON": "Mon",
           "TUE": "Tue",
@@ -2476,6 +2477,7 @@
         "allListings": "All Listings Save Summary",
         "action": "Action",
         "viewTrend": "View Trend",
+        "openListing": "Open listing in new tab",
         "noData": "No data available",
         "emptyState": {
           "title": "No saved-listing analytics yet",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2443,6 +2443,7 @@
         "allListings": "Tổng quan tất cả tin đăng",
         "action": "Hành động",
         "viewDetails": "Xem chi tiết",
+        "openListing": "Mở tin đăng ở tab mới",
         "days": {
           "MON": "Th 2",
           "TUE": "Th 3",
@@ -2477,6 +2478,7 @@
         "allListings": "Tổng quan lượt lưu tất cả tin đăng",
         "action": "Hành động",
         "viewTrend": "Xem xu hướng",
+        "openListing": "Mở tin đăng ở tab mới",
         "noData": "Chưa có dữ liệu",
         "emptyState": {
           "title": "Chưa có dữ liệu phân tích lượt lưu",


### PR DESCRIPTION
- Refine membership card header with brand icon tile and primary tokens
- Drop amber-gold colour mapping on diamond (ADVANCED) pricing tier
- Default analytics tables to 5 rows instead of 10
- Shrink 'total saves across all listings' into a compact inline stat
- Add a zoom brush to clicks/saves trend charts so 365-day ranges are usable
- Add open-in-new-tab listing detail links in both analytics tables