### PR TITLE
fix(seller-dashboard): refine benefit tiles, zoom hint, skeletons

### DIFF
--- a/src/components/molecules/dashboardMembershipCard/index.tsx
+++ b/src/components/molecules/dashboardMembershipCard/index.tsx
@@ -22,7 +22,6 @@ import { useAuth } from '@/hooks/useAuth'
 import { MembershipStatus, BenefitStatus } from '@/api/types/membership.type'
 import { format } from 'date-fns'
 import { motion } from 'framer-motion'
-import { cn } from '@/lib/utils'
 
 const DashboardMembershipCard: React.FC = () => {
   const t = useTranslations('seller.dashboard.membership')
@@ -179,20 +178,6 @@ const DashboardMembershipCard: React.FC = () => {
     return (remaining / total) * 100
   }
 
-  const getBenefitColor = (remaining: number, total: number) => {
-    const percentage = (remaining / total) * 100
-    if (percentage > 50) return 'text-foreground bg-muted border-border'
-    if (percentage > 20) return 'text-foreground bg-amber-50 border-amber-200'
-    return 'text-foreground bg-red-50 border-red-200'
-  }
-
-  const getBenefitProgressColor = (remaining: number, total: number) => {
-    const percentage = (remaining / total) * 100
-    if (percentage > 50) return 'bg-primary'
-    if (percentage > 20) return 'bg-amber-500'
-    return 'bg-red-500'
-  }
-
   return (
     <Card className='relative overflow-hidden'>
       {/* Subtle brand wash behind the header for a more premium feel */}
@@ -301,23 +286,12 @@ const DashboardMembershipCard: React.FC = () => {
                   benefit.quantityRemaining,
                   benefit.totalQuantity,
                 )
-                const colorClass = getBenefitColor(
-                  benefit.quantityRemaining,
-                  benefit.totalQuantity,
-                )
-                const progressColor = getBenefitProgressColor(
-                  benefit.quantityRemaining,
-                  benefit.totalQuantity,
-                )
 
                 return (
                   <motion.div
                     key={benefit.userBenefitId}
                     variants={itemVariants}
-                    className={cn(
-                      'h-full p-3 rounded-lg border transition-all hover:shadow-md',
-                      colorClass,
-                    )}
+                    className='h-full p-3 rounded-lg border border-border bg-muted text-foreground transition-all hover:shadow-md'
                   >
                     <div className='flex items-start justify-between mb-2'>
                       <div className='flex items-start gap-2 flex-1'>
@@ -352,7 +326,7 @@ const DashboardMembershipCard: React.FC = () => {
                           delay: 0.5 + index * 0.1,
                           ease: 'easeOut',
                         }}
-                        className={cn('h-full', progressColor)}
+                        className='h-full bg-primary'
                       />
                     </div>
                   </motion.div>

--- a/src/components/molecules/dashboardPhoneClickChart/index.tsx
+++ b/src/components/molecules/dashboardPhoneClickChart/index.tsx
@@ -36,7 +36,13 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { ExternalLink, ListX, Loader2, Search } from 'lucide-react'
+import {
+  ExternalLink,
+  GripHorizontal,
+  ListX,
+  Loader2,
+  Search,
+} from 'lucide-react'
 import { format, parseISO, eachDayOfInterval, subDays } from 'date-fns'
 import { useIsMobile } from '@/hooks/useMediaQuery'
 import type {
@@ -436,6 +442,12 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                         </LineChart>
                       </ResponsiveContainer>
                     </ChartContainer>
+                    {clicksOverTimeData.length > 1 && (
+                      <p className='mt-2 flex items-center gap-1.5 text-xs text-muted-foreground'>
+                        <GripHorizontal className='size-3.5 shrink-0' />
+                        {t('zoomHint')}
+                      </p>
+                    )}
                   </div>
                 </section>
 
@@ -541,7 +553,7 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                     <div className='space-y-2.5'>
                       {isSummaryLoading ? (
                         Array.from({
-                          length: Math.max(3, Math.min(10, pageSize || 10)),
+                          length: Math.max(3, Math.min(10, pageSize || 5)),
                         }).map((_, idx) => (
                           <div
                             key={`m-sk-${idx}`}
@@ -628,7 +640,7 @@ const DashboardPhoneClickChart: React.FC<DashboardPhoneClickChartProps> = ({
                         {isSummaryLoading ? (
                           <>
                             {Array.from({
-                              length: Math.max(3, Math.min(10, pageSize || 10)),
+                              length: Math.max(3, Math.min(10, pageSize || 5)),
                             }).map((_, idx) => (
                               <TableRow key={`sk-${idx}`}>
                                 <TableCell>

--- a/src/components/molecules/dashboardSavedListingsChart/index.tsx
+++ b/src/components/molecules/dashboardSavedListingsChart/index.tsx
@@ -39,7 +39,14 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { ExternalLink, Loader2, Heart, ListX, Search } from 'lucide-react'
+import {
+  ExternalLink,
+  GripHorizontal,
+  Loader2,
+  Heart,
+  ListX,
+  Search,
+} from 'lucide-react'
 import { format, parseISO, eachDayOfInterval, subDays } from 'date-fns'
 import { useIsMobile } from '@/hooks/useMediaQuery'
 import type {
@@ -489,6 +496,12 @@ const DashboardSavedListingsChart: React.FC<
                         </AreaChart>
                       </ResponsiveContainer>
                     </ChartContainer>
+                    {savesOverTimeData.length > 1 && (
+                      <p className='mt-2 flex items-center gap-1.5 text-xs text-muted-foreground'>
+                        <GripHorizontal className='size-3.5 shrink-0' />
+                        {t('zoomHint')}
+                      </p>
+                    )}
                   </div>
                 </section>
 
@@ -608,7 +621,7 @@ const DashboardSavedListingsChart: React.FC<
                 <div className='space-y-2.5'>
                   {isSummaryLoading ? (
                     Array.from({
-                      length: Math.max(3, Math.min(10, pageSize || 10)),
+                      length: Math.max(3, Math.min(10, pageSize || 5)),
                     }).map((_, idx) => (
                       <div
                         key={`m-sk-${idx}`}
@@ -695,7 +708,7 @@ const DashboardSavedListingsChart: React.FC<
                     {isSummaryLoading ? (
                       <>
                         {Array.from({
-                          length: Math.max(3, Math.min(10, pageSize || 10)),
+                          length: Math.max(3, Math.min(10, pageSize || 5)),
                         }).map((_, idx) => (
                           <TableRow key={`sk-${idx}`}>
                             <TableCell>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2443,6 +2443,7 @@
         "action": "Action",
         "viewDetails": "View Details",
         "openListing": "Open listing in new tab",
+        "zoomHint": "Drag the slider handles to zoom in / out",
         "days": {
           "MON": "Mon",
           "TUE": "Tue",
@@ -2478,6 +2479,7 @@
         "action": "Action",
         "viewTrend": "View Trend",
         "openListing": "Open listing in new tab",
+        "zoomHint": "Drag the slider handles to zoom in / out",
         "noData": "No data available",
         "emptyState": {
           "title": "No saved-listing analytics yet",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2444,6 +2444,7 @@
         "action": "Hành động",
         "viewDetails": "Xem chi tiết",
         "openListing": "Mở tin đăng ở tab mới",
+        "zoomHint": "Kéo hai đầu thanh trượt để phóng to / thu nhỏ",
         "days": {
           "MON": "Th 2",
           "TUE": "Th 3",
@@ -2479,6 +2480,7 @@
         "action": "Hành động",
         "viewTrend": "Xem xu hướng",
         "openListing": "Mở tin đăng ở tab mới",
+        "zoomHint": "Kéo hai đầu thanh trượt để phóng to / thu nhỏ",
         "noData": "Chưa có dữ liệu",
         "emptyState": {
           "title": "Chưa có dữ liệu phân tích lượt lưu",


### PR DESCRIPTION
- Drop the amber/red background tint on active-benefit items so every tile matches (uniform neutral background, primary progress bar)
- Add a caption under the chart zoom bar so users know they can drag to zoom in/out (new zoomHint i18n key, en + vi)
- Align table loading skeleton row counts with the new 5-row default