### PR TITLE
feat(maps): cluster overlapping markers and color them by listing type

### DIFF
--- a/src/components/molecules/mapCluster/index.tsx
+++ b/src/components/molecules/mapCluster/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface MapClusterProps {
+  count: number
+  ariaLabel: string
+  onClick?: () => void
+}
+
+// Cluster bubble shown in place of several markers that sit close enough to
+// overlap. Clicking it zooms in so the underlying listings spread apart.
+const MapCluster: React.FC<MapClusterProps> = ({
+  count,
+  ariaLabel,
+  onClick,
+}) => {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className='flex items-center justify-center h-10 w-10 rounded-full border-2 border-white bg-primary text-primary-foreground text-sm font-semibold shadow-lg transition-transform duration-200 hover:scale-110 cursor-pointer'
+    >
+      {count}
+    </button>
+  )
+}
+
+export default MapCluster

--- a/src/components/molecules/mapMarker/index.tsx
+++ b/src/components/molecules/mapMarker/index.tsx
@@ -1,61 +1,74 @@
 import React from 'react'
 import { Badge } from '@/components/atoms/badge'
 import { formatByLocale } from '@/utils/currency/convert'
-import { VipType } from '@/api/types'
+import { VipType, LISTING_TYPE } from '@/api/types/property.type'
+import type { listingType as ListingPostType } from '@/api/types/property.type'
 import { Crown, Sparkles, Star } from 'lucide-react'
 
 interface MapMarkerProps {
   price: number
   vipType: VipType
+  listingType?: ListingPostType
   isSelected?: boolean
   onClick?: () => void
 }
 
-const getVipConfig = (vipType: VipType) => {
-  switch (vipType) {
-    case 'DIAMOND':
+interface ListingTypeStyle {
+  badge: string
+  text: string
+  arrow: string
+}
+
+// Color the marker by the listing type so rent vs share posts are
+// distinguishable at a glance. The VIP tier is shown via the leading icon.
+const getListingTypeStyle = (
+  listingType?: ListingPostType,
+): ListingTypeStyle => {
+  switch (listingType) {
+    case LISTING_TYPE.SHARE:
       return {
-        color: 'bg-blue-600 hover:bg-blue-700 border-blue-700',
-        icon: <Sparkles className='h-3 w-3' />,
-        textColor: 'text-white',
+        badge: 'bg-emerald-600 hover:bg-emerald-700 border-emerald-700',
+        text: 'text-white',
+        arrow: 'border-t-emerald-600',
       }
-    case 'GOLD':
+    case LISTING_TYPE.RENT:
       return {
-        color: 'bg-yellow-500 hover:bg-yellow-600 border-yellow-600',
-        icon: <Crown className='h-3 w-3' />,
-        textColor: 'text-white',
-      }
-    case 'SILVER':
-      return {
-        color: 'bg-gray-400 hover:bg-gray-500 border-gray-500',
-        icon: <Star className='h-3 w-3' />,
-        textColor: 'text-white',
+        badge: 'bg-blue-600 hover:bg-blue-700 border-blue-700',
+        text: 'text-white',
+        arrow: 'border-t-blue-600',
       }
     default:
       return {
-        color: 'bg-card hover:bg-muted border-border',
-        icon: null,
-        textColor: 'text-foreground',
+        badge: 'bg-card hover:bg-muted border-border',
+        text: 'text-foreground',
+        arrow: 'border-t-card',
       }
+  }
+}
+
+const getVipIcon = (vipType: VipType) => {
+  switch (vipType) {
+    case 'DIAMOND':
+      return <Sparkles className='h-3 w-3' />
+    case 'GOLD':
+      return <Crown className='h-3 w-3' />
+    case 'SILVER':
+      return <Star className='h-3 w-3' />
+    default:
+      return null
   }
 }
 
 const MapMarker: React.FC<MapMarkerProps> = ({
   price,
   vipType,
+  listingType,
   isSelected = false,
   onClick,
 }) => {
-  const config = getVipConfig(vipType)
+  const style = getListingTypeStyle(listingType)
+  const vipIcon = getVipIcon(vipType)
   const formattedPrice = formatByLocale(price, 'vi-VN')
-
-  // Determine arrow border color based on vipType
-  const getArrowBorderColor = () => {
-    if (vipType === 'DIAMOND') return 'border-t-blue-600'
-    if (vipType === 'GOLD') return 'border-t-yellow-500'
-    if (vipType === 'SILVER') return 'border-t-gray-400'
-    return 'border-t-card'
-  }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if ((event.key === 'Enter' || event.key === ' ') && onClick) {
@@ -70,19 +83,18 @@ const MapMarker: React.FC<MapMarkerProps> = ({
       tabIndex={0}
       onClick={onClick}
       onKeyDown={handleKeyDown}
-      className={`
-        relative cursor-pointer transition-all duration-200 transform
-        ${isSelected ? 'scale-110 z-50' : 'hover:scale-105 z-10'}
-      `}
+      className={`relative cursor-pointer transition-all duration-200 transform ${
+        isSelected ? 'scale-110' : 'hover:scale-105'
+      }`}
     >
       <Badge
         className={`
-          ${config.color} ${config.textColor}
+          ${style.badge} ${style.text}
           border-2 shadow-lg flex items-center gap-1 px-2 py-1
           ${isSelected ? 'ring-2 ring-offset-2 ring-blue-500' : ''}
         `}
       >
-        {config.icon}
+        {vipIcon}
         <span className='font-semibold text-xs whitespace-nowrap'>
           {formattedPrice}
         </span>
@@ -93,7 +105,7 @@ const MapMarker: React.FC<MapMarkerProps> = ({
           absolute left-1/2 -bottom-1 transform -translate-x-1/2
           w-0 h-0 border-l-4 border-r-4 border-t-4
           border-l-transparent border-r-transparent
-          ${getArrowBorderColor()}
+          ${style.arrow}
         `}
       />
     </div>

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -24,6 +24,7 @@ import { useLocationContext } from '@/contexts/location'
 import { buildApartmentDetailRoute } from '@/constants/route'
 import { ListingDetail, VipType } from '@/api/types/property.type'
 import MapMarker from '@/components/molecules/mapMarker'
+import MapCluster from '@/components/molecules/mapCluster'
 import PropertyCard from '@/components/molecules/propertyCard'
 import { ListingService } from '@/api/services/listing.service'
 import { Typography } from '@/components/atoms/typography'
@@ -40,6 +41,14 @@ const MAP_LISTINGS_LIMIT = 200
 const MIN_LISTING_FETCH_ZOOM = 11
 const MAP_BOUNDS_COORDINATE_PRECISION = 4
 const PROGRAMMATIC_PAN_SUPPRESS_MS = 600
+// Marker clustering: listings whose pins fall within this pixel radius of each
+// other are merged into one cluster bubble so adjacent posts never hide each
+// other. The grid size is derived from the Web Mercator tile size and zoom.
+const CLUSTER_PIXEL_RADIUS = 56
+const WORLD_TILE_SIZE = 256
+const CLUSTER_EXPAND_ZOOM_STEP = 2
+const MAX_CLUSTER_EXPAND_ZOOM = 18
+const SELECTED_MARKER_Z_INDEX = 9999
 
 interface MapViewport {
   neLat: number
@@ -65,6 +74,51 @@ const normalizeViewport = (viewport: MapViewport): MapViewport => ({
   swLng: roundCoordinate(viewport.swLng),
   zoom: Math.round(viewport.zoom),
 })
+
+interface MarkerCluster {
+  id: string
+  lat: number
+  lng: number
+  items: ListingDetail[]
+}
+
+// Group listings into a grid whose cell size matches CLUSTER_PIXEL_RADIUS at
+// the current zoom, so nearby pins collapse into a single cluster bubble.
+const clusterListings = (
+  listings: ListingDetail[],
+  zoom: number,
+): MarkerCluster[] => {
+  const degreesPerCell =
+    (CLUSTER_PIXEL_RADIUS * 360) / (WORLD_TILE_SIZE * 2 ** zoom)
+  // A plain record is used instead of `Map` because the `Map` identifier is
+  // the Google map component imported above.
+  const cells: Record<string, ListingDetail[]> = {}
+
+  listings.forEach((listing) => {
+    const { latitude, longitude } = listing.address
+    const cellKey = `${Math.floor(latitude / degreesPerCell)}:${Math.floor(
+      longitude / degreesPerCell,
+    )}`
+    const bucket = cells[cellKey]
+    if (bucket) {
+      bucket.push(listing)
+    } else {
+      cells[cellKey] = [listing]
+    }
+  })
+
+  return Object.entries(cells).map(([cellKey, items]) => {
+    const total = items.length
+    const sumLat = items.reduce((acc, item) => acc + item.address.latitude, 0)
+    const sumLng = items.reduce((acc, item) => acc + item.address.longitude, 0)
+    return {
+      id: cellKey,
+      lat: sumLat / total,
+      lng: sumLng / total,
+      items,
+    }
+  })
+}
 
 interface MapSidebarProps {
   isLoading: boolean
@@ -240,6 +294,7 @@ const MapContent: React.FC<MapContentProps> = ({
   const panSuppressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
+  const [zoomLevel, setZoomLevel] = useState(DEFAULT_ZOOM)
 
   const handleMapChange = useCallback(() => {
     if (!map) return
@@ -248,6 +303,9 @@ const MapContent: React.FC<MapContentProps> = ({
     const bounds = map.getBounds()
     const zoom = map.getZoom()
     if (!bounds || zoom === null || zoom === undefined) return
+
+    const roundedZoom = Math.round(zoom)
+    setZoomLevel((prev) => (prev === roundedZoom ? prev : roundedZoom))
 
     const ne = bounds.getNorthEast()
     const sw = bounds.getSouthWest()
@@ -294,6 +352,33 @@ const MapContent: React.FC<MapContentProps> = ({
     }
     requestLocation()
   }, [userCoordinates, centerOnUser, requestLocation])
+
+  // Keep the selected listing as its own marker so it is never hidden inside a
+  // cluster; cluster everything else by proximity at the current zoom.
+  const selectedListingId = selectedListing?.listingId
+  const clusters = useMemo(
+    () =>
+      clusterListings(
+        listings.filter((listing) => listing.listingId !== selectedListingId),
+        zoomLevel,
+      ),
+    [listings, selectedListingId, zoomLevel],
+  )
+
+  const handleClusterClick = useCallback(
+    (cluster: MarkerCluster) => {
+      if (!map) return
+      const currentMapZoom = map.getZoom() ?? zoomLevel
+      map.panTo({ lat: cluster.lat, lng: cluster.lng })
+      map.setZoom(
+        Math.min(
+          currentMapZoom + CLUSTER_EXPAND_ZOOM_STEP,
+          MAX_CLUSTER_EXPAND_ZOOM,
+        ),
+      )
+    },
+    [map, zoomLevel],
+  )
 
   // Initial fetch triggering
   useEffect(() => {
@@ -434,24 +519,66 @@ const MapContent: React.FC<MapContentProps> = ({
         </div>
       )}
 
-      {/* Markers */}
-      {listings.map((listing) => (
+      {/* Markers and clusters */}
+      {clusters.map((cluster) => {
+        if (cluster.items.length === 1) {
+          const listing = cluster.items[0]
+          return (
+            <AdvancedMarker
+              key={listing.listingId}
+              position={{
+                lat: listing.address.latitude,
+                lng: listing.address.longitude,
+              }}
+              onClick={() => onMarkerClick(listing)}
+            >
+              <MapMarker
+                price={listing.price}
+                vipType={listing.vipType}
+                listingType={listing.listingType}
+                onClick={() => onMarkerClick(listing)}
+              />
+            </AdvancedMarker>
+          )
+        }
+
+        return (
+          <AdvancedMarker
+            key={cluster.id}
+            position={{ lat: cluster.lat, lng: cluster.lng }}
+            onClick={() => handleClusterClick(cluster)}
+          >
+            <MapCluster
+              count={cluster.items.length}
+              ariaLabel={t('propertiesInCluster', {
+                count: cluster.items.length,
+              })}
+              onClick={() => handleClusterClick(cluster)}
+            />
+          </AdvancedMarker>
+        )
+      })}
+
+      {/* Selected listing always renders on top of clusters/markers */}
+      {selectedListing && (
         <AdvancedMarker
-          key={listing.listingId}
+          key={`selected-${selectedListing.listingId}`}
           position={{
-            lat: listing.address.latitude,
-            lng: listing.address.longitude,
+            lat: selectedListing.address.latitude,
+            lng: selectedListing.address.longitude,
           }}
-          onClick={() => onMarkerClick(listing)}
+          zIndex={SELECTED_MARKER_Z_INDEX}
+          onClick={() => onMarkerClick(selectedListing)}
         >
           <MapMarker
-            price={listing.price}
-            vipType={listing.vipType}
-            isSelected={selectedListing?.listingId === listing.listingId}
-            onClick={() => onMarkerClick(listing)}
+            price={selectedListing.price}
+            vipType={selectedListing.vipType}
+            listingType={selectedListing.listingType}
+            isSelected
+            onClick={() => onMarkerClick(selectedListing)}
           />
         </AdvancedMarker>
-      ))}
+      )}
     </>
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2044,6 +2044,7 @@
     "noListingsInArea": "No listings found in this area.",
     "listingsPanelAriaLabel": "Map listings panel",
     "myLocation": "My location",
+    "propertiesInCluster": "{count} properties in this area",
     "news": "News",
     "savedListings": "Saved Listings",
     "following": "Following",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1866,6 +1866,7 @@
     "noListingsInArea": "Không tìm thấy bất động sản trong khu vực này.",
     "listingsPanelAriaLabel": "Bảng danh sách bất động sản trên bản đồ",
     "myLocation": "Vị trí của tôi",
+    "propertiesInCluster": "{count} bất động sản trong khu vực này",
     "news": "Tin tức",
     "savedListings": "Tin đã lưu",
     "following": "Đang theo dõi",


### PR DESCRIPTION
Adjacent listings used to render their price pins on top of each other, so a post could be fully hidden behind its neighbour. Group nearby pins into a single cluster bubble (zoom-aware grid) that zooms in to expand on click, and keep the selected listing as its own top-most marker so it is never covered.

Also color each price marker by listing type (rent vs share) while keeping the VIP tier as a leading icon.