### PR TITLE
fix(maps): stop re-render storm on pan to remove lag

### DIFF
--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -385,10 +385,13 @@ const MapContent: React.FC<MapContentProps> = ({
     handleMapChange()
   }, [handleMapChange])
 
-  // Setup bounds listener
+  // Report the viewport on `idle` (fires once when the map stops moving)
+  // rather than on `bounds_changed` (fires on every frame while panning).
+  // This avoids re-rendering the whole map/sidebar on each drag frame, which
+  // is what made light panning feel laggy.
   useEffect(() => {
     if (!map) return
-    const listener = map.addListener('bounds_changed', handleMapChange)
+    const listener = map.addListener('idle', handleMapChange)
     return () => {
       if (listener?.remove) {
         listener.remove()


### PR DESCRIPTION
Report the map viewport on the 'idle' event instead of 'bounds_changed'. 'bounds_changed' fires on every frame while panning, and each one set React state that re-rendered the whole map and listings panel, making light panning feel laggy. 'idle' fires once when the map settles, so a drag now does no React work while the fetch and clustering still update when movement stops.