### PR TITLE
fix(maps): show card on marker click and give every marker a color

### DIFF
--- a/src/components/molecules/mapMarker/index.tsx
+++ b/src/components/molecules/mapMarker/index.tsx
@@ -44,10 +44,13 @@ const getVipStyle = (vipType: VipType): VipStyle => {
         icon: <Star className='h-3 w-3' />,
       }
     default:
+      // Normal (non-VIP) posts are the majority, so give them a solid, visible
+      // colour instead of the neutral card surface, otherwise the markers blend
+      // into the map and look colourless.
       return {
-        badge: 'bg-card hover:bg-muted border-border',
-        text: 'text-foreground',
-        arrow: 'border-t-card',
+        badge: 'bg-emerald-600 hover:bg-emerald-700 border-emerald-700',
+        text: 'text-white',
+        arrow: 'border-t-emerald-600',
         icon: null,
       }
   }

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -41,10 +41,12 @@ const MAP_LISTINGS_LIMIT = 200
 const MIN_LISTING_FETCH_ZOOM = 11
 const MAP_BOUNDS_COORDINATE_PRECISION = 4
 const PROGRAMMATIC_PAN_SUPPRESS_MS = 600
-// Marker clustering: listings whose pins fall within this pixel radius of each
-// other are merged into one cluster bubble so adjacent posts never hide each
-// other. The grid size is derived from the Web Mercator tile size and zoom.
-const CLUSTER_PIXEL_RADIUS = 56
+// Marker clustering: only pins that sit within this pixel radius of each other
+// (i.e. genuinely stacked) are merged into a cluster bubble. Kept small so that
+// in normal browsing the markers stay individual — clickable and color-coded —
+// and only fully-overlapping pins collapse. Grid size derives from the Web
+// Mercator tile size and zoom.
+const CLUSTER_PIXEL_RADIUS = 24
 const WORLD_TILE_SIZE = 256
 const CLUSTER_EXPAND_ZOOM_STEP = 2
 const MAX_CLUSTER_EXPAND_ZOOM = 18


### PR DESCRIPTION
Clustering was so aggressive that at normal zoom almost every pin became a count bubble, so clicking opened nothing (the bubble just zooms) and all markers looked the same. Shrink the cluster radius to 24px so only genuinely stacked pins merge; individual markers now dominate, are clickable (opening the right-side card) and keep their colour.

Also give normal (non-VIP) posts a solid emerald colour instead of the neutral card surface so markers no longer blend into the map and the VIP tiers (diamond/gold/silver) still stand out.