### PR TITLE
feat(maps): focus marker from list card with a pulse animation

### DIFF
--- a/src/components/molecules/mapMarker/index.tsx
+++ b/src/components/molecules/mapMarker/index.tsx
@@ -9,7 +9,8 @@ interface MapMarkerProps {
 }
 
 interface VipStyle {
-  dot: string
+  bg: string
+  hover: string
   arrow: string
   icon: React.ReactNode
 }
@@ -22,25 +23,29 @@ const getVipStyle = (vipType: VipType): VipStyle => {
   switch (vipType) {
     case 'DIAMOND':
       return {
-        dot: 'bg-blue-600 hover:bg-blue-700',
+        bg: 'bg-blue-600',
+        hover: 'hover:bg-blue-700',
         arrow: 'border-t-blue-600',
         icon: <Sparkles size={ICON_SIZE} />,
       }
     case 'GOLD':
       return {
-        dot: 'bg-yellow-500 hover:bg-yellow-600',
+        bg: 'bg-yellow-500',
+        hover: 'hover:bg-yellow-600',
         arrow: 'border-t-yellow-500',
         icon: <Crown size={ICON_SIZE} />,
       }
     case 'SILVER':
       return {
-        dot: 'bg-gray-400 hover:bg-gray-500',
+        bg: 'bg-gray-400',
+        hover: 'hover:bg-gray-500',
         arrow: 'border-t-gray-400',
         icon: <Star size={ICON_SIZE} />,
       }
     default:
       return {
-        dot: 'bg-emerald-600 hover:bg-emerald-700',
+        bg: 'bg-emerald-600',
+        hover: 'hover:bg-emerald-700',
         arrow: 'border-t-emerald-600',
         icon: <Home size={ICON_SIZE} />,
       }
@@ -68,12 +73,19 @@ const MapMarker: React.FC<MapMarkerProps> = ({
       onClick={onClick}
       onKeyDown={handleKeyDown}
       className={`relative cursor-pointer transition-all duration-200 transform ${
-        isSelected ? 'scale-125' : 'hover:scale-110'
+        isSelected ? 'scale-125 z-50' : 'hover:scale-110'
       }`}
     >
+      {/* Pulsing halo so a focused marker is easy to spot among the others */}
+      {isSelected && (
+        <span
+          aria-hidden
+          className={`absolute left-0 top-0 h-8 w-8 rounded-full opacity-60 animate-ping ${style.bg}`}
+        />
+      )}
       <div
         className={`
-          ${style.dot}
+          relative ${style.bg} ${style.hover}
           flex items-center justify-center h-8 w-8 rounded-full
           border-2 border-white text-white shadow-lg
           ${isSelected ? 'ring-2 ring-offset-2 ring-blue-500' : ''}

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -18,6 +18,7 @@ import {
   ChevronsRight,
   X,
   LocateFixed,
+  MapPin,
 } from 'lucide-react'
 import { ENV } from '@/constants/env'
 import { useLocationContext } from '@/contexts/location'
@@ -150,7 +151,7 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
                 key={listing.listingId}
                 role='button'
                 tabIndex={0}
-                className={`flex flex-col h-full cursor-pointer transition-all duration-200 rounded-xl border bg-card overflow-hidden ${
+                className={`relative flex flex-col h-full cursor-pointer transition-all duration-200 rounded-xl border bg-card overflow-hidden ${
                   isSelected
                     ? 'border-primary ring-2 ring-primary/20 shadow-md'
                     : 'border-border/50 hover:border-primary/50 hover:shadow-sm'
@@ -163,6 +164,21 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
                   }
                 }}
               >
+                {/* Focus this listing's marker on the map (pan + open card + animate) */}
+                <Button
+                  type='button'
+                  size='icon'
+                  variant='secondary'
+                  className='absolute top-2 right-2 z-10 h-8 w-8 rounded-full shadow-md pointer-events-auto'
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onSelectListing(listing)
+                  }}
+                  aria-label={t('showOnMap')}
+                >
+                  <MapPin className='h-4 w-4' />
+                </Button>
+
                 {/* Ensure standard click won't bubble up improperly from PropertyCard */}
                 <div className='pointer-events-none flex-1'>
                   <PropertyCard

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2044,6 +2044,7 @@
     "noListingsInArea": "No listings found in this area.",
     "listingsPanelAriaLabel": "Map listings panel",
     "myLocation": "My location",
+    "showOnMap": "Show on map",
     "news": "News",
     "savedListings": "Saved Listings",
     "following": "Following",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1866,6 +1866,7 @@
     "noListingsInArea": "Không tìm thấy bất động sản trong khu vực này.",
     "listingsPanelAriaLabel": "Bảng danh sách bất động sản trên bản đồ",
     "myLocation": "Vị trí của tôi",
+    "showOnMap": "Xem trên bản đồ",
     "news": "Tin tức",
     "savedListings": "Tin đã lưu",
     "following": "Đang theo dõi",


### PR DESCRIPTION
Add a 'show on map' button to each card in the listings panel. Clicking it selects the listing — panning the map to its marker and opening the right-side detail card — and the focused marker now pulses (animated halo) so it is easy to pick out among the others.