### PR TITLE
fix(maps): remove inner footer divider on drawer listing cards

### DIFF
--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -47,6 +47,9 @@ interface PropertyCardProps {
   className?: string
   bottomContent?: React.ReactNode
   imageLayout?: 'left' | 'top'
+  // Hide the divider line above the agent/footer section (used where the card
+  // sits inside another bordered container, e.g. the map listings drawer).
+  hideFooterDivider?: boolean
 }
 
 // Stats pill component for consistent styling
@@ -79,6 +82,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
     className,
     bottomContent,
     imageLayout = 'left',
+    hideFooterDivider = false,
   } = props
 
   const {
@@ -707,7 +711,12 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
 
           {/* User Info & Post Date Footer */}
           {user && (
-            <div className='flex items-center justify-between gap-2 mt-auto pt-2.5 border-t border-border/60'>
+            <div
+              className={classNames(
+                'flex items-center justify-between gap-2 mt-auto pt-2.5',
+                { 'border-t border-border/60': !hideFooterDivider },
+              )}
+            >
               <div className='flex items-center gap-2 flex-1 min-w-0'>
                 <BrokerAvatar
                   avatarUrl={user.avatarUrl}

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -170,6 +170,7 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
                     listing={listing}
                     className={`${isDesktopCard ? '' : 'compact '}border-0 shadow-none h-full`}
                     imageLayout='top'
+                    hideFooterDivider
                   />
                 </div>
 


### PR DESCRIPTION
The agent/footer section in PropertyCard draws a top divider line, which showed as a stray inner border on the map drawer cards (they already sit in a bordered container). Add a hideFooterDivider prop and enable it for the drawer listing cards.