### PR TITLE
fix(maps): flatten inner card corners on drawer listing cards

### DIFF
--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -168,7 +168,7 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
                 <div className='pointer-events-none flex-1'>
                   <PropertyCard
                     listing={listing}
-                    className={`${isDesktopCard ? '' : 'compact '}border-0 shadow-none h-full`}
+                    className={`${isDesktopCard ? '' : 'compact '}border-0 shadow-none rounded-none h-full`}
                     imageLayout='top'
                     hideFooterDivider
                   />


### PR DESCRIPTION
The reused PropertyCard keeps its own rounded-xl corners, which showed as a rounded edge just above the action buttons inside the drawer card. Add rounded-none so the inner card is flush; the outer container still provides the rounded shape via overflow-hidden.