### PR TITLE
feat(maps): dedicated MapPropertyCard for the map, stop reusing Prope…

### DIFF
--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import classNames from 'classnames'
+import { Badge } from '@/components/atoms/badge'
+import { Typography } from '@/components/atoms/typography'
+import ImageAtom from '@/components/atoms/imageAtom'
+import SaveListingButton from '@/components/molecules/saveListingButton'
+import CompareToggleBtn from '@/components/molecules/compareToggleBtn'
+import BrokerAvatar from '@/components/molecules/brokerAvatar'
+import { basePath, DEFAULT_IMAGE } from '@/constants'
+import { useTranslations } from 'next-intl'
+import {
+  Bed,
+  Bath,
+  Square,
+  Users,
+  Camera,
+  Check,
+  Sparkles,
+  MapPin,
+} from 'lucide-react'
+import { ListingDetail } from '@/api/types'
+import { formatByLocale } from '@/utils/currency/convert'
+
+interface MapPropertyCardProps {
+  listing: ListingDetail
+  onClick?: (listing: ListingDetail) => void
+  bottomContent?: React.ReactNode
+  className?: string
+}
+
+const StatPill: React.FC<{ icon: React.ReactNode; value: React.ReactNode }> = ({
+  icon,
+  value,
+}) => (
+  <div className='flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-muted/60'>
+    <span className='text-primary'>{icon}</span>
+    <Typography variant='small' className='font-semibold text-foreground'>
+      {value}
+    </Typography>
+  </div>
+)
+
+// Dedicated, flat listing card used only on the map (the left drawer list and
+// the selected-listing overlay). It is a copy of PropertyCard WITHOUT the Card
+// chrome (border / rounded corners / footer divider) so it sits flush inside
+// the map containers, which provide their own border and rounding. PropertyCard
+// is intentionally not reused here to avoid those nested-card artifacts.
+const MapPropertyCard: React.FC<MapPropertyCardProps> = ({
+  listing,
+  onClick,
+  bottomContent,
+  className,
+}) => {
+  const t = useTranslations()
+  const {
+    title,
+    price,
+    priceUnit,
+    area,
+    bedrooms,
+    bathrooms,
+    verified,
+    user,
+    address,
+    vipType,
+    roomCapacity,
+    media,
+  } = listing
+
+  const images = media?.filter((m) => m.mediaType === 'IMAGE') || []
+  const totalImages = images.length
+  const mainImage = images[0]?.url
+  const displayAddress = address?.fullNewAddress || address?.fullAddress
+  const { firstName, lastName } = user || {}
+  const userName = `${firstName || ''} ${lastName || ''}`.trim()
+  const isProfessionalBroker =
+    Boolean(user?.isBroker) || user?.brokerVerificationStatus === 'APPROVED'
+  const isPriority = vipType === 'GOLD' || vipType === 'DIAMOND'
+
+  return (
+    <div
+      className={classNames('flex flex-col h-full bg-card', className)}
+      onClick={onClick ? () => onClick(listing) : undefined}
+    >
+      {/* Image */}
+      <div className='p-2 pb-0'>
+        <div className='relative aspect-[4/3] overflow-hidden rounded-lg'>
+          <ImageAtom
+            src={mainImage || `${basePath}/images/default-image.jpg`}
+            defaultImage={DEFAULT_IMAGE}
+            alt={title}
+            className='w-full h-full object-cover object-center'
+          />
+          <div className='absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black/40 to-transparent pointer-events-none' />
+
+          {/* Save / compare actions */}
+          <div className='absolute top-2 right-2 flex gap-1.5 z-10'>
+            <CompareToggleBtn
+              listing={listing}
+              variant='ghost'
+              size='icon'
+              className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+            />
+            <SaveListingButton
+              listingId={listing.listingId}
+              variant='icon'
+              className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+            />
+          </div>
+
+          {/* Badges */}
+          <div className='absolute top-2 left-2 flex flex-col gap-1.5 z-10'>
+            {verified && (
+              <Badge className='bg-emerald-500/90 text-white text-2xs px-2.5 py-1 rounded-full shadow-md flex items-center gap-1 backdrop-blur-sm'>
+                <Check className='w-3 h-3' />
+                <span className='font-medium'>
+                  {t('homePage.property.verified')}
+                </span>
+              </Badge>
+            )}
+            {isPriority && (
+              <Badge className='bg-gradient-to-r from-primary to-primary/80 text-primary-foreground text-2xs px-2.5 py-1 rounded-full shadow-md flex items-center gap-1 backdrop-blur-sm'>
+                <Sparkles className='w-3 h-3' />
+                <span className='font-medium'>
+                  {t('homePage.priorityBadge')}
+                </span>
+              </Badge>
+            )}
+          </div>
+
+          {/* Image count */}
+          {totalImages > 0 && (
+            <div className='absolute bottom-2 left-2 flex items-center gap-1.5 bg-black/60 text-white text-xs px-2.5 py-1 rounded-full backdrop-blur-md'>
+              <Camera className='w-3.5 h-3.5' />
+              <span className='font-medium'>{totalImages}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className='flex flex-1 flex-col gap-2 p-3'>
+        <Typography
+          variant='h6'
+          className='text-foreground leading-tight font-semibold line-clamp-2'
+        >
+          {title}
+        </Typography>
+
+        {displayAddress && (
+          <div className='flex items-start gap-1.5 min-w-0'>
+            <MapPin className='w-3 h-3 flex-shrink-0 text-muted-foreground mt-0.5' />
+            <Typography
+              variant='small'
+              className='text-muted-foreground line-clamp-1 leading-snug'
+            >
+              {displayAddress}
+            </Typography>
+          </div>
+        )}
+
+        <Typography
+          variant='h5'
+          className='text-primary font-bold tracking-tight'
+        >
+          {formatByLocale(price, priceUnit)}
+        </Typography>
+
+        <div className='flex items-center flex-wrap gap-2'>
+          {bedrooms !== undefined && (
+            <StatPill icon={<Bed className='w-3 h-3' />} value={bedrooms} />
+          )}
+          {bathrooms !== undefined && (
+            <StatPill icon={<Bath className='w-3 h-3' />} value={bathrooms} />
+          )}
+          {area && (
+            <StatPill
+              icon={<Square className='w-3 h-3' />}
+              value={`${area} m²`}
+            />
+          )}
+          {roomCapacity && (
+            <StatPill
+              icon={<Users className='w-3 h-3' />}
+              value={roomCapacity}
+            />
+          )}
+        </div>
+
+        {/* Agent footer (no divider) */}
+        {user && (
+          <div className='flex items-center gap-2 mt-auto pt-1'>
+            <BrokerAvatar
+              avatarUrl={user.avatarUrl}
+              firstName={firstName}
+              lastName={lastName}
+              sizeClassName='size-9'
+              showBrokerBadge={isProfessionalBroker}
+              fallbackClassName='text-xs'
+            />
+            {userName && (
+              <Typography
+                variant='small'
+                className='font-medium truncate block leading-tight'
+              >
+                {userName}
+              </Typography>
+            )}
+          </div>
+        )}
+
+        {bottomContent}
+      </div>
+    </div>
+  )
+}
+
+export default MapPropertyCard

--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -47,9 +47,6 @@ interface PropertyCardProps {
   className?: string
   bottomContent?: React.ReactNode
   imageLayout?: 'left' | 'top'
-  // Hide the divider line above the agent/footer section (used where the card
-  // sits inside another bordered container, e.g. the map listings drawer).
-  hideFooterDivider?: boolean
 }
 
 // Stats pill component for consistent styling
@@ -82,7 +79,6 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
     className,
     bottomContent,
     imageLayout = 'left',
-    hideFooterDivider = false,
   } = props
 
   const {
@@ -711,12 +707,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
 
           {/* User Info & Post Date Footer */}
           {user && (
-            <div
-              className={classNames(
-                'flex items-center justify-between gap-2 mt-auto pt-2.5',
-                { 'border-t border-border/60': !hideFooterDivider },
-              )}
-            >
+            <div className='flex items-center justify-between gap-2 mt-auto pt-2.5 border-t border-border/60'>
               <div className='flex items-center gap-2 flex-1 min-w-0'>
                 <BrokerAvatar
                   avatarUrl={user.avatarUrl}

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -9,8 +9,6 @@ import {
 } from '@vis.gl/react-google-maps'
 import { Button } from '@/components/atoms/button'
 import { useDebounce } from '@/hooks/useDebounce'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { MEDIA_AT_LG } from '@/constants/breakpoints'
 import {
   Loader2,
   ExternalLink,
@@ -24,7 +22,7 @@ import { useLocationContext } from '@/contexts/location'
 import { buildApartmentDetailRoute } from '@/constants/route'
 import { ListingDetail, VipType } from '@/api/types/property.type'
 import MapMarker from '@/components/molecules/mapMarker'
-import PropertyCard from '@/components/molecules/propertyCard'
+import MapPropertyCard from '@/components/molecules/mapPropertyCard'
 import { ListingService } from '@/api/services/listing.service'
 import { Typography } from '@/components/atoms/typography'
 
@@ -98,7 +96,6 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
   t,
   tCommon,
 }) => {
-  const isDesktopCard = useMediaQuery(MEDIA_AT_LG) ?? false
   const router = useRouter()
 
   return (
@@ -164,14 +161,9 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
                   }
                 }}
               >
-                {/* Ensure standard click won't bubble up improperly from PropertyCard */}
+                {/* Ensure standard click won't bubble up improperly from the card */}
                 <div className='pointer-events-none flex-1'>
-                  <PropertyCard
-                    listing={listing}
-                    className={`${isDesktopCard ? '' : 'compact '}border-0 shadow-none rounded-none h-full`}
-                    imageLayout='top'
-                    hideFooterDivider
-                  />
+                  <MapPropertyCard listing={listing} />
                 </div>
 
                 <div className='px-4 pb-4 pt-0'>
@@ -249,7 +241,6 @@ const MapContent: React.FC<MapContentProps> = ({
 }) => {
   const map = useMap()
   const router = useRouter()
-  const isDesktopCard = useMediaQuery(MEDIA_AT_LG) ?? false
   const {
     coordinates: userCoordinates,
     isLoading: isLocating,
@@ -431,11 +422,9 @@ const MapContent: React.FC<MapContentProps> = ({
       {/* Selected property card: bottom sheet on mobile, right-side card on desktop */}
       {selectedListing && (
         <div className='absolute bottom-4 left-4 right-4 z-30 md:left-6 md:right-6 lg:top-20 lg:bottom-auto lg:left-auto lg:right-6 lg:w-[420px] xl:w-[460px]'>
-          <div className='relative bg-background rounded-xl shadow-2xl border border-border/50'>
-            <PropertyCard
+          <div className='relative overflow-hidden bg-background rounded-xl shadow-2xl border border-border/50'>
+            <MapPropertyCard
               listing={selectedListing}
-              className={`${isDesktopCard ? '' : 'compact '}border-0 shadow-none`}
-              imageLayout='top'
               bottomContent={
                 <Button
                   className='w-full shadow-sm'


### PR DESCRIPTION
…rtyCard

PropertyCard wraps everything in a Card (border, rounded corners, footer divider), which produced stray inner borders/corners when reused inside the map drawer and selected-listing overlay. Add a dedicated, flat MapPropertyCard (image, badges, title, address, price, stats, agent) used only on the map, and revert the hideFooterDivider workaround from PropertyCard so it is back to its original shared form.