### PR TITLE
feat(maps): cluster markers and render the full cached set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "smart-rent-fe",
       "version": "0.1.0",
       "dependencies": {
+        "@googlemaps/markerclusterer": "^2.6.2",
         "@hookform/resolvers": "^5.2.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -1338,6 +1339,17 @@
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz",
       "integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.6.2",
+      "resolved": "https://npm.vexere.net/@googlemaps/markerclusterer/-/markerclusterer-2.6.2.tgz",
+      "integrity": "sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/supercluster": "^7.1.3",
+        "fast-equals": "^5.2.2",
+        "supercluster": "^8.0.1"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.1",
@@ -4678,6 +4690,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://npm.vexere.net/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/google.maps": {
       "version": "3.58.1",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
@@ -4827,6 +4845,15 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://npm.vexere.net/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -9183,6 +9210,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://npm.vexere.net/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -12965,6 +12998,15 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://npm.vexere.net/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@googlemaps/markerclusterer": "^2.6.2",
     "@hookform/resolvers": "^5.2.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -7,6 +7,7 @@ import {
   AdvancedMarker,
   useMap,
 } from '@vis.gl/react-google-maps'
+import { MarkerClusterer, type Marker } from '@googlemaps/markerclusterer'
 import { Button } from '@/components/atoms/button'
 import { useDebounce } from '@/hooks/useDebounce'
 import {
@@ -35,14 +36,11 @@ const USER_LOCATION_ZOOM = 14
 const MAP_HEIGHT = 'h-[calc(100vh-80px)]'
 const MAP_INTERACTION_DEBOUNCE_MS = 1000
 const MAP_LISTINGS_LIMIT = 200
-// Hard cap on markers handed to Google Maps at once. The accumulating cache can
-// hold far more points than any single viewport ever showed before; rendering
-// thousands of AdvancedMarkers makes Google's marker code recurse and throw
-// "Maximum call stack size exceeded". Capping at the per-fetch limit keeps the
-// rendered count within the range the map already handled.
-const MAX_RENDERED_MARKERS = MAP_LISTINGS_LIMIT
-// Render priority when the in-view set exceeds the cap: VIP tiers win so the
-// most important pins are never the ones dropped.
+// Max cards shown in the side panel at once (the map itself shows every cached
+// pin via clustering; the list stays bounded for scroll performance).
+const SIDEBAR_LISTINGS_LIMIT = 200
+// Ordering for the in-view set: VIP tiers first so the panel surfaces the most
+// important listings, then stable by id.
 const VIP_RENDER_PRIORITY: Record<VipType, number> = {
   DIAMOND: 0,
   GOLD: 1,
@@ -258,6 +256,49 @@ const MapListingsPanelContent: React.FC<MapSidebarProps> = ({
   )
 }
 
+interface ClusteredMarkerProps {
+  listing: ListingDetail
+  isSelected: boolean
+  onMarkerClick: (listing: ListingDetail) => void
+  setMarkerRef: (marker: Marker | null, listingId: number) => void
+}
+
+// A single map pin. Extracted (and memoized) so its `ref` callback identity is
+// stable across parent re-renders — an inline ref would make React detach and
+// reattach every marker on each render, thrashing the clusterer.
+const ClusteredMarker: React.FC<ClusteredMarkerProps> = React.memo(
+  ({ listing, isSelected, onMarkerClick, setMarkerRef }) => {
+    const handleRef = useCallback(
+      (marker: Marker | null) => setMarkerRef(marker, listing.listingId),
+      [setMarkerRef, listing.listingId],
+    )
+
+    return (
+      <AdvancedMarker
+        ref={handleRef}
+        position={{
+          lat: listing.address.latitude,
+          lng: listing.address.longitude,
+        }}
+        zIndex={isSelected ? SELECTED_MARKER_Z_INDEX : undefined}
+        onClick={(event) => {
+          // Stop the event so the map's own onClick (which closes the card)
+          // does not also fire and immediately clear the selection.
+          event.stop()
+          onMarkerClick(listing)
+        }}
+      >
+        <MapMarker
+          vipType={listing.vipType}
+          isSelected={isSelected}
+          onClick={() => onMarkerClick(listing)}
+        />
+      </AdvancedMarker>
+    )
+  },
+)
+ClusteredMarker.displayName = 'ClusteredMarker'
+
 interface MapContentProps {
   listings: ListingDetail[]
   selectedListing: ListingDetail | null
@@ -294,6 +335,54 @@ const MapContent: React.FC<MapContentProps> = ({
   const panSuppressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
+
+  // Marker clustering: collect the rendered AdvancedMarker elements by
+  // listingId and feed them to a MarkerClusterer. Dense areas group into
+  // clusters instead of rendering every pin, so the full cached set can be
+  // shown at any zoom without overflowing Google's marker.js — and the pins no
+  // longer change as you zoom the same spot.
+  const clustererRef = useRef<MarkerClusterer | null>(null)
+  const [markerElements, setMarkerElements] = useState<Record<string, Marker>>(
+    {},
+  )
+
+  const setMarkerRef = useCallback(
+    (marker: Marker | null, listingId: number) => {
+      const key = String(listingId)
+      setMarkerElements((prev) => {
+        if (marker && prev[key]) return prev
+        if (!marker && !prev[key]) return prev
+        if (marker) {
+          return { ...prev, [key]: marker }
+        }
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    },
+    [],
+  )
+
+  // Lazily create the clusterer once the map is ready, then keep its marker set
+  // in sync with what is rendered. Keyed on both `map` and `markerElements` so
+  // markers collected before the map loads are still added once it appears.
+  useEffect(() => {
+    if (!map) return
+    if (!clustererRef.current) {
+      clustererRef.current = new MarkerClusterer({ map })
+    }
+    const clusterer = clustererRef.current
+    clusterer.clearMarkers()
+    clusterer.addMarkers(Object.values(markerElements))
+  }, [map, markerElements])
+
+  // Detach the clusterer when the map view unmounts.
+  useEffect(() => {
+    return () => {
+      clustererRef.current?.clearMarkers()
+      clustererRef.current = null
+    }
+  }, [])
 
   const handleMapChange = useCallback(() => {
     if (!map) return
@@ -489,32 +578,16 @@ const MapContent: React.FC<MapContentProps> = ({
         </div>
       )}
 
-      {/* Markers */}
-      {listings.map((listing) => {
-        const isSelected = selectedListing?.listingId === listing.listingId
-        return (
-          <AdvancedMarker
-            key={listing.listingId}
-            position={{
-              lat: listing.address.latitude,
-              lng: listing.address.longitude,
-            }}
-            zIndex={isSelected ? SELECTED_MARKER_Z_INDEX : undefined}
-            onClick={(event) => {
-              // Stop the event so the map's own onClick (which closes the card)
-              // does not also fire and immediately clear the selection.
-              event.stop()
-              onMarkerClick(listing)
-            }}
-          >
-            <MapMarker
-              vipType={listing.vipType}
-              isSelected={isSelected}
-              onClick={() => onMarkerClick(listing)}
-            />
-          </AdvancedMarker>
-        )
-      })}
+      {/* Markers (grouped by the clusterer above) */}
+      {listings.map((listing) => (
+        <ClusteredMarker
+          key={listing.listingId}
+          listing={listing}
+          isSelected={selectedListing?.listingId === listing.listingId}
+          onMarkerClick={onMarkerClick}
+          setMarkerRef={setMarkerRef}
+        />
+      ))}
     </>
   )
 }
@@ -601,19 +674,23 @@ const MapViewTemplate: React.FC = () => {
         inView.push(listing)
       }
     })
-    if (inView.length <= MAX_RENDERED_MARKERS) {
-      return inView
-    }
-    // Too many pins for one render — keep the highest-priority ones (VIP tier,
-    // then stable by id) and cap, so Google's marker code never overflows.
+    // Return every cached pin in view (clustering renders them all without
+    // overflow), ordered VIP-first then stable by id so the set never reshuffles
+    // or swaps marker types as the same area is zoomed in and out.
     inView.sort((a, b) => {
       const priorityDelta =
         VIP_RENDER_PRIORITY[a.vipType] - VIP_RENDER_PRIORITY[b.vipType]
       return priorityDelta !== 0 ? priorityDelta : a.listingId - b.listingId
     })
-    return inView.slice(0, MAX_RENDERED_MARKERS)
+    return inView
     // cacheVersion bumps whenever the (ref-held) cache mutates, forcing recompute.
   }, [cacheVersion, currentViewport, isBelowMinZoom])
+
+  // The side panel stays bounded for scroll performance; the map shows all pins.
+  const sidebarListings = useMemo(
+    () => visibleListings.slice(0, SIDEBAR_LISTINGS_LIMIT),
+    [visibleListings],
+  )
 
   useEffect(() => {
     if (!debouncedViewport) {
@@ -747,7 +824,7 @@ const MapViewTemplate: React.FC = () => {
           >
             <MapListingsPanelContent
               isLoading={isLoading}
-              listings={visibleListings}
+              listings={sidebarListings}
               selectedListing={selectedListing}
               totalCount={totalCount}
               hasMore={hasMore}


### PR DESCRIPTION
Replaces the lossy 200-marker cap (which made pins swap in/out — even to a different VIP type — when zooming the same spot, because a different subset crossed the cap at each zoom).

- Add @googlemaps/markerclusterer and feed every cached in-view pin to a MarkerClusterer, so dense areas group into clusters instead of rendering thousands of AdvancedMarkers (which overflowed Google's marker.js).
- Render all cached points in view, ordered VIP-first then stable by id, so the marker set never reshuffles or changes type as the same area is zoomed in and out — it only grows as the FE cache fills.
- Extract a memoized ClusteredMarker with a stable ref callback so React doesn't detach/reattach every marker (and thrash the clusterer) on each re-render.
- Keep the side panel bounded to 200 cards for scroll performance; the map shows everything via clusters.