### PR TITLE
fix(payment): stop classifying SePay returns as ZaloPay callbacks

### DIFF
--- a/src/pages/payment/result.tsx
+++ b/src/pages/payment/result.tsx
@@ -182,13 +182,16 @@ const PaymentResultPage: NextPageWithLayout = () => {
       return t('success.messageDefault')
     }
 
+    // Only match parameters that are unique to ZaloPay's redirect. SePay
+    // returns with a bare `?status=success|error|cancel` (and may carry a
+    // generic `bankcode`), so neither `status` nor `bankcode` can be used to
+    // discriminate — including them here misclassifies every SePay return as a
+    // ZaloPay callback and fires a bogus ZALOPAY callback request.
     const isZaloPayCallback = (params: URLSearchParams) =>
       [
-        'status',
         'apptransid',
         'checksum',
         'appid',
-        'bankcode',
         // Backward compatibility with older ZaloPay redirect schemas
         'resultCode',
         'orderId',


### PR DESCRIPTION
SePay redirects back to /payment/result with a bare ?status=success|error| cancel. isZaloPayCallback included 'status' (and 'bankcode'), so every SePay return matched and the page fired a bogus ZALOPAY callback request, which the backend rejected. Restrict detection to ZaloPay-specific params (apptransid, checksum, appid, plus legacy resultCode/orderId) so SePay returns fall through to the polling-based confirmation path.