### PR TITLE
fix(seller/transactions): map legacy VNPay gateway and trim table col…

### DIFF
--- a/src/components/molecules/transactionHistory/TransactionDetailDialog.tsx
+++ b/src/components/molecules/transactionHistory/TransactionDetailDialog.tsx
@@ -13,7 +13,7 @@ import { Typography } from '@/components/atoms/typography'
 import PaymentStatusBadge from '@/components/atoms/paymentStatusBadge'
 import { useCustomerTransactionDetail } from '@/hooks/useCustomerTransactions'
 import type { CustomerTransactionDetail } from '@/api/types/customer-transaction.type'
-import { useTransactionFormatters } from './helpers'
+import { getGatewayLabel, useTransactionFormatters } from './helpers'
 
 export interface TransactionDetailDialogProps {
   transactionId: string | null
@@ -50,7 +50,10 @@ const DetailBody: React.FC<{ detail: CustomerTransactionDetail }> = ({
       />
       <Row label={t('amount')} value={formatAmount(detail.amount)} />
       <Row label={t('paymentType')} value={typeLabel(detail.paymentType)} />
-      <Row label={t('gateway')} value={detail.paymentGateway} />
+      <Row
+        label={t('gateway')}
+        value={getGatewayLabel(detail.paymentGateway)}
+      />
       <Row label={t('gatewayCode')} value={detail.gatewayTransactionCode} />
       <Row label={t('paymentMethod')} value={detail.paymentMethod} />
       <Row label={t('created')} value={formatDateTime(detail.createdAt)} />

--- a/src/components/molecules/transactionHistory/TransactionListItem.tsx
+++ b/src/components/molecules/transactionHistory/TransactionListItem.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/atoms/card'
 import { Typography } from '@/components/atoms/typography'
 import PaymentStatusBadge from '@/components/atoms/paymentStatusBadge'
 import type { CustomerTransactionItem } from '@/api/types/customer-transaction.type'
-import { useTransactionFormatters } from './helpers'
+import { formatPaymentMethod, useTransactionFormatters } from './helpers'
 
 export interface TransactionListItemProps {
   item: CustomerTransactionItem
@@ -19,9 +19,7 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = ({
   const t = useTranslations('seller.transactions.columns')
   const { formatAmount, formatDateTime, typeLabel } = useTransactionFormatters()
 
-  const method =
-    [item.paymentGateway, item.paymentMethod].filter(Boolean).join(' · ') ||
-    null
+  const method = formatPaymentMethod(item.paymentGateway, item.paymentMethod)
   const roomLabel = item.room?.roomName || item.room?.roomCode
 
   return (

--- a/src/components/molecules/transactionHistory/TransactionTable.tsx
+++ b/src/components/molecules/transactionHistory/TransactionTable.tsx
@@ -11,7 +11,7 @@ import {
 import { Typography } from '@/components/atoms/typography'
 import PaymentStatusBadge from '@/components/atoms/paymentStatusBadge'
 import type { CustomerTransactionItem } from '@/api/types/customer-transaction.type'
-import { useTransactionFormatters } from './helpers'
+import { formatPaymentMethod, useTransactionFormatters } from './helpers'
 
 const EMPTY = '—'
 const HEAD_CLASS =
@@ -27,8 +27,6 @@ const TransactionRow: React.FC<{
   onSelect: (id: string) => void
 }> = ({ item, onSelect }) => {
   const { formatAmount, formatDateTime, typeLabel } = useTransactionFormatters()
-  const room = item.room
-  const landlord = item.landlord
 
   return (
     <TableRow
@@ -49,36 +47,13 @@ const TransactionRow: React.FC<{
         {formatAmount(item.amount)}
       </TableCell>
       <TableCell className='min-w-[160px] text-sm text-muted-foreground whitespace-nowrap'>
-        {[item.paymentGateway, item.paymentMethod]
-          .filter(Boolean)
-          .join(' · ') || EMPTY}
+        {formatPaymentMethod(item.paymentGateway, item.paymentMethod) || EMPTY}
       </TableCell>
       <TableCell className='min-w-[130px]'>
         <PaymentStatusBadge status={item.status} />
       </TableCell>
-      <TableCell className='min-w-[220px] max-w-[280px]'>
-        <Typography variant='small' className='block truncate'>
-          {room?.roomName || room?.roomCode || EMPTY}
-        </Typography>
-        {room?.address && (
-          <Typography variant='caption' as='span' className='block truncate'>
-            {room.address}
-          </Typography>
-        )}
-      </TableCell>
-      <TableCell className='min-w-[180px] max-w-[220px] text-sm'>
-        <span className='block truncate'>{landlord?.name || EMPTY}</span>
-        {landlord?.phone && (
-          <span className='block truncate text-muted-foreground'>
-            {landlord.phone}
-          </span>
-        )}
-      </TableCell>
       <TableCell className='min-w-[160px] text-sm text-muted-foreground whitespace-nowrap'>
         {formatDateTime(item.createdAt)}
-      </TableCell>
-      <TableCell className='min-w-[160px] text-sm text-muted-foreground whitespace-nowrap'>
-        {item.completedAt ? formatDateTime(item.completedAt) : EMPTY}
       </TableCell>
     </TableRow>
   )
@@ -107,17 +82,8 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({
             <TableHead className={`${HEAD_CLASS} min-w-[130px]`}>
               {t('status')}
             </TableHead>
-            <TableHead className={`${HEAD_CLASS} min-w-[220px]`}>
-              {t('room')}
-            </TableHead>
-            <TableHead className={`${HEAD_CLASS} min-w-[180px]`}>
-              {t('landlord')}
-            </TableHead>
             <TableHead className={`${HEAD_CLASS} min-w-[160px]`}>
               {t('created')}
-            </TableHead>
-            <TableHead className={`${HEAD_CLASS} min-w-[160px]`}>
-              {t('completed')}
             </TableHead>
           </TableRow>
         </TableHeader>

--- a/src/components/molecules/transactionHistory/helpers.ts
+++ b/src/components/molecules/transactionHistory/helpers.ts
@@ -8,6 +8,36 @@ import { formatDateTimeWithLocale } from '@/utils/date/formatters'
 const KNOWN_TYPES = new Set<string>(CUSTOMER_TRANSACTION_TYPES)
 
 /**
+ * Display names for payment gateways. These are brand names, so they are not
+ * translated. VNPAY is mapped temporarily: it is no longer an active gateway,
+ * but legacy transactions made before the SePay migration still reference it.
+ */
+const GATEWAY_LABELS: Record<string, string> = {
+  SEPAY: 'SePay',
+  VNPAY: 'VNPay',
+  PAYPAL: 'PayPal',
+  MOMO: 'MoMo',
+  ZALOPAY: 'ZaloPay',
+}
+
+/** Map a raw gateway code to its display name, falling back to the raw value. */
+export function getGatewayLabel(gateway?: string | null): string | null {
+  if (!gateway) return null
+  return GATEWAY_LABELS[gateway.toUpperCase()] ?? gateway
+}
+
+/**
+ * Format the "method" cell shared by the list, table and detail views:
+ * the mapped gateway label joined with the raw payment method (e.g. "VNPay").
+ */
+export function formatPaymentMethod(
+  gateway?: string | null,
+  method?: string | null,
+): string | null {
+  return [getGatewayLabel(gateway), method].filter(Boolean).join(' · ') || null
+}
+
+/**
  * Title-case an unknown enum-ish value (e.g. `NEW_FEE_TYPE` -> `New Fee Type`)
  * so the UI never crashes or shows a raw SCREAMING_CASE token.
  */


### PR DESCRIPTION
…umns

- Add gateway label map (incl. temporary VNPay mapping for legacy pre-SePay transactions) used by the table, mobile list and detail dialog
- Drop the frequently-empty Room/Landlord and redundant Completed columns from the desktop table to remove horizontal scrolling; full details remain available in the transaction detail dialog