### PR TITLE
fix: reject whitespace-only input for name fields

### DIFF
--- a/src/components/molecules/personalInfoForm/index.tsx
+++ b/src/components/molecules/personalInfoForm/index.tsx
@@ -47,10 +47,12 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
   const validationSchema = yup.object().shape({
     firstName: yup
       .string()
+      .trim()
       .required(t('homePage.auth.validation.firstNameRequired'))
       .min(2, t('homePage.auth.validation.firstNameMinLength')),
     lastName: yup
       .string()
+      .trim()
       .required(t('homePage.auth.validation.lastNameRequired'))
       .min(2, t('homePage.auth.validation.lastNameMinLength')),
     email: yup

--- a/src/components/molecules/registerForm/index.tsx
+++ b/src/components/molecules/registerForm/index.tsx
@@ -44,10 +44,12 @@ const RegisterForm: NextPage<RegisterFormProps> = (props) => {
   const registerSchema = yup.object({
     firstName: yup
       .string()
+      .trim()
       .required(t('homePage.auth.validation.firstNameRequired'))
       .min(2, t('homePage.auth.validation.firstNameMinLength')),
     lastName: yup
       .string()
+      .trim()
       .required(t('homePage.auth.validation.lastNameRequired'))
       .min(2, t('homePage.auth.validation.lastNameMinLength')),
     email: yup


### PR DESCRIPTION
Add .trim() to firstName/lastName in registerForm and personalInfoForm so that whitespace-only values like "  " no longer pass .required()/.min(2) validation.