### PR TITLE
Thanh tiến trình lượt đẩy kéo dài hết block trên desktop

### DIFF
--- a/src/components/molecules/listings/MembershipPushDisplay.tsx
+++ b/src/components/molecules/listings/MembershipPushDisplay.tsx
@@ -131,7 +131,7 @@ export const MembershipPushDisplay: React.FC<MembershipPushDisplayProps> = ({
                     {benefit.quantityRemaining}/{benefit.totalQuantity}
                   </span>
                 </div>
-                <div className='mt-1 h-1 w-full overflow-hidden rounded-full bg-muted sm:w-14'>
+                <div className='mt-1 h-1 w-full overflow-hidden rounded-full bg-muted'>
                   <div
                     className={cn(
                       'h-full rounded-full',


### PR DESCRIPTION
- Bỏ giới hạn sm:w-14 khiến thanh bị cụt; để w-full để thanh trải hết chiều ngang của block (bằng với hàng tên + số lượng) trên cả mobile lẫn desktop