### PR TITLE
fix(detail): show 3 recently viewed cards in carousel instead of 4

### DIFF
--- a/src/components/organisms/apartmentDetail/RecentlyViewedSection.tsx
+++ b/src/components/organisms/apartmentDetail/RecentlyViewedSection.tsx
@@ -110,7 +110,7 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
             {Array.from({ length: 3 }).map((_, index) => (
               <CarouselItem
                 key={index}
-                className='basis-full sm:basis-1/2 lg:basis-1/4 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+                className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
               >
                 <div className='space-y-2'>
                   <Skeleton className='aspect-[4/3] rounded-lg w-full' />
@@ -157,7 +157,7 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
           {listingsData.map((listing) => (
             <CarouselItem
               key={listing.listingId}
-              className='basis-full sm:basis-1/2 lg:basis-1/4 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+              className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
             >
               <Link
                 href={`/listing-detail/${listing.listingId}`}

--- a/src/components/organisms/apartmentDetail/SimilarPropertiesSection.tsx
+++ b/src/components/organisms/apartmentDetail/SimilarPropertiesSection.tsx
@@ -85,7 +85,7 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
             {skeletonItems.map((_, index) => (
               <CarouselItem
                 key={index}
-                className='basis-full sm:basis-1/2 lg:basis-1/4 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+                className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
               >
                 <div className='w-full space-y-2 md:space-y-3'>
                   <Skeleton className='aspect-[4/3] rounded-lg w-full' />
@@ -153,7 +153,7 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
           {validListings.map((listing) => (
             <CarouselItem
               key={listing.listingId}
-              className='basis-full sm:basis-1/2 lg:basis-1/4 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+              className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
             >
               <Link
                 href={`/listing-detail/${listing.listingId}`}


### PR DESCRIPTION
Change CarouselItem basis from lg:basis-1/4 to lg:basis-1/3 on the recently viewed carousel (skeleton + content).