### PR TITLE
feat(maps): make clusters recognisable by colour + icon, not just a n…

### DIFF
--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -115,32 +115,105 @@ const listingInViewport = (
   )
 }
 
-// Bubble shown for a cluster. The number is the count of listings grouped at
-// that spot — click it (or zoom in) to break the cluster apart into individual
-// pins. Sized up a little for bigger groups so dense areas stand out.
-const buildClusterContent = (count: number): HTMLElement => {
-  const size = count >= 100 ? 52 : count >= 10 ? 44 : 36
-  const el = document.createElement('div')
-  el.className =
-    'flex items-center justify-center rounded-full bg-primary text-white font-semibold border-2 border-white shadow-lg'
-  el.style.width = `${size}px`
-  el.style.height = `${size}px`
-  el.style.fontSize = size >= 44 ? '14px' : '12px'
-  el.textContent = String(count)
-  return el
+// Density tiers for clusters. Colour (not just the count) tells the user how
+// busy a spot is at a glance — calm green for a few, amber for a crowd, rose for
+// a hotspot — so dense areas are obvious before the eye even reads a number.
+interface ClusterTier {
+  // px diameter of the core bubble
+  size: number
+  // solid core colour
+  core: string
+  // translucent halo colour (the "stacked pins" ring behind the core)
+  halo: string
+  // icon stroke colour shown in the white corner badge
+  iconColor: string
 }
 
-// Custom cluster renderer so the count reads clearly and matches the brand
-// colour instead of the library's default blue blobs.
-const clusterRenderer: Renderer = {
+const getClusterTier = (count: number): ClusterTier => {
+  if (count >= 50) {
+    return {
+      size: 52,
+      core: 'bg-rose-600',
+      halo: 'bg-rose-400',
+      iconColor: 'text-rose-600',
+    }
+  }
+  if (count >= 10) {
+    return {
+      size: 44,
+      core: 'bg-amber-500',
+      halo: 'bg-amber-400',
+      iconColor: 'text-amber-500',
+    }
+  }
+  return {
+    size: 36,
+    core: 'bg-emerald-600',
+    halo: 'bg-emerald-400',
+    iconColor: 'text-emerald-600',
+  }
+}
+
+// Lucide "layers" glyph as inline SVG. Used as a corner badge so a cluster is
+// unmistakably a *group* of pins, not a single one — recognisable even for the
+// colour-blind, who can't rely on the tier colour alone.
+const LAYERS_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="M22 17.65 12.83 21.8a2 2 0 0 1-1.66 0L2 17.65"/><path d="M22 12.65 12.83 16.8a2 2 0 0 1-1.66 0L2 12.65"/></svg>'
+
+// Bubble shown for a cluster. It is built to read as a *cluster* on sight:
+//  • a coloured core whose hue + size encode the density tier,
+//  • a soft halo behind it that looks like overlapping pins (a "stack"),
+//  • a white corner badge with a layers icon — a colour-independent signal that
+//    this is a group, not one listing.
+// The count is kept (people genuinely want to know "how many"), but it's no
+// longer the *only* thing telling you it's a cluster.
+const buildClusterContent = (count: number, label: string): HTMLElement => {
+  const tier = getClusterTier(count)
+
+  const wrapper = document.createElement('div')
+  wrapper.className = 'relative flex items-center justify-center'
+  wrapper.style.width = `${tier.size}px`
+  wrapper.style.height = `${tier.size}px`
+  wrapper.setAttribute('role', 'button')
+  wrapper.setAttribute('aria-label', label)
+
+  // Halo: a larger translucent disc behind the core that gives the "stacked
+  // pins" look so the bubble reads as a group, not a single marker.
+  const halo = document.createElement('span')
+  halo.setAttribute('aria-hidden', 'true')
+  halo.className = `absolute -inset-1.5 rounded-full ${tier.halo} opacity-30`
+
+  // Core: the solid, tier-coloured bubble holding the count.
+  const core = document.createElement('div')
+  core.className = `relative flex h-full w-full items-center justify-center rounded-full ${tier.core} font-semibold text-white border-2 border-white shadow-lg`
+  core.style.fontSize = tier.size >= 44 ? '14px' : '12px'
+  core.textContent = String(count)
+
+  // Corner badge: white circle with the layers icon, the colour-independent
+  // "this is a group" cue.
+  const badge = document.createElement('span')
+  badge.setAttribute('aria-hidden', 'true')
+  badge.className = `absolute -right-1 -top-1 flex h-[18px] w-[18px] items-center justify-center rounded-full bg-white shadow ${tier.iconColor}`
+  badge.innerHTML = LAYERS_ICON_SVG
+
+  wrapper.append(halo, core, badge)
+  return wrapper
+}
+
+// Custom cluster renderer: the count reads clearly, the density tier colour and
+// the layers badge make it obvious it's a cluster, and an aria-label exposes the
+// same to screen readers. Built as a factory so it can pull a localised label.
+const createClusterRenderer = (
+  getClusterLabel: (count: number) => string,
+): Renderer => ({
   render: ({ count, position }) =>
     new google.maps.marker.AdvancedMarkerElement({
       position,
-      content: buildClusterContent(count),
+      content: buildClusterContent(count, getClusterLabel(count)),
       // Sit above ordinary pins but below the selected one.
       zIndex: 1000 + count,
     }),
-}
+})
 
 interface SidebarListingCardProps {
   listing: ListingDetail
@@ -465,7 +538,9 @@ const MapContent: React.FC<MapContentProps> = ({
     if (!clustererRef.current) {
       clustererRef.current = new MarkerClusterer({
         map,
-        renderer: clusterRenderer,
+        renderer: createClusterRenderer((count) =>
+          t('clusterAriaLabel', { count }),
+        ),
       })
     }
     const clusterer = clustererRef.current
@@ -489,7 +564,7 @@ const MapContent: React.FC<MapContentProps> = ({
     if (toAdd.length > 0) clusterer.addMarkers(toAdd, true)
     clusterer.render()
     syncedMarkersRef.current = current
-  }, [map, markerElements])
+  }, [map, markerElements, t])
 
   // Detach the clusterer when the map view unmounts.
   useEffect(() => {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2052,6 +2052,7 @@
     "listingsPanelAriaLabel": "Map listings panel",
     "myLocation": "My location",
     "showOnMap": "Show on map",
+    "clusterAriaLabel": "{count, plural, one {# listing grouped here} other {# listings grouped here}} — click to zoom in",
     "news": "News",
     "savedListings": "Saved Listings",
     "following": "Following",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1873,6 +1873,7 @@
     "listingsPanelAriaLabel": "Bảng danh sách bất động sản trên bản đồ",
     "myLocation": "Vị trí của tôi",
     "showOnMap": "Xem trên bản đồ",
+    "clusterAriaLabel": "{count, plural, other {# tin đăng được gộp tại đây}} — nhấn để phóng to",
     "news": "Tin tức",
     "savedListings": "Tin đã lưu",
     "following": "Đang theo dõi",


### PR DESCRIPTION
…umber

Cluster bubbles now encode density with a colour tier (emerald → amber → rose), carry a soft "stacked pins" halo, and show a white layers-icon badge so they read as a *group* on sight — even for colour-blind users — instead of relying on the bare count. The count is kept (people want "how many"), and a localised aria-label exposes the same to screen readers.