### PR TITLE
feat(fe): tappable follow-up suggestion chips in chatbot

### DIFF
--- a/src/api/services/chatbot.service.ts
+++ b/src/api/services/chatbot.service.ts
@@ -8,6 +8,7 @@ import type {
   ChatStreamStatusPayload,
   ChatStreamTextPayload,
   ChatStreamListingsPayload,
+  ChatStreamSuggestionsPayload,
   ChatStreamDonePayload,
   ChatStreamErrorPayload,
 } from '@/api/types/ai.type'
@@ -77,6 +78,9 @@ export async function streamChat(
           return
         case 'listings':
           handlers.onListings?.(data as ChatStreamListingsPayload)
+          return
+        case 'suggestions':
+          handlers.onSuggestions?.(data as ChatStreamSuggestionsPayload)
           return
         case 'done':
           handlers.onDone?.(data as ChatStreamDonePayload)

--- a/src/api/types/ai.type.ts
+++ b/src/api/types/ai.type.ts
@@ -254,10 +254,22 @@ export interface ChatStreamErrorPayload {
   message: string
 }
 
+export interface ChatSuggestion {
+  /** Text shown on the chip. */
+  label: string
+  /** Message sent when the chip is tapped (often equals label). */
+  query: string
+}
+
+export interface ChatStreamSuggestionsPayload {
+  items: ChatSuggestion[]
+}
+
 export interface ChatStreamHandlers {
   onStatus?: (data: ChatStreamStatusPayload) => void
   onTextDelta?: (delta: string) => void
   onListings?: (payload: ChatStreamListingsPayload) => void
+  onSuggestions?: (payload: ChatStreamSuggestionsPayload) => void
   onDone?: (data: ChatStreamDonePayload) => void
   onError?: (message: string) => void
 }

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -25,8 +25,10 @@ import AiChatContactCard from '@/components/molecules/aiChatContactCard'
 type TAiChatBubbleProps = {
   message: TChatMessage
   className?: string
+  isLast?: boolean
   onViewListingDetail?: (listingId: number) => void
   onOpenFullDetail?: (listingId: number) => void
+  onSuggestionClick?: (query: string) => void
 }
 
 // Convert [Mã tin: xxx] to clickable links
@@ -189,8 +191,10 @@ const INITIAL_SEARCH_RESULTS = 3
 const AiChatBubble: FC<TAiChatBubbleProps> = ({
   message,
   className,
+  isLast,
   onViewListingDetail,
   onOpenFullDetail,
+  onSuggestionClick,
 }) => {
   const isBot = message.sender === 'bot'
   const hasListings = isBot && message.listings && message.listings.length > 0
@@ -373,6 +377,29 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
             <AiChatCompare listings={message.listings!} />
           </div>
         )}
+
+        {isBot &&
+          isLast &&
+          message.suggestions &&
+          message.suggestions.length > 0 && (
+            <div
+              className='mt-2 flex flex-wrap gap-2'
+              aria-label={tAi('suggestionsLabel')}
+            >
+              {message.suggestions.map((suggestion) => (
+                <Button
+                  key={suggestion.query}
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  className='h-auto rounded-full px-3 py-1 text-sm font-normal'
+                  onClick={() => onSuggestionClick?.(suggestion.query)}
+                >
+                  {suggestion.label}
+                </Button>
+              ))}
+            </div>
+          )}
       </div>
 
       {!isBot && <AiChatAvatar type='user' className='mt-0.5' />}
@@ -413,7 +440,9 @@ export default memo(AiChatBubble, (prev, next) => {
   return (
     prev.message === next.message &&
     prev.className === next.className &&
+    prev.isLast === next.isLast &&
     prev.onViewListingDetail === next.onViewListingDetail &&
-    prev.onOpenFullDetail === next.onOpenFullDetail
+    prev.onOpenFullDetail === next.onOpenFullDetail &&
+    prev.onSuggestionClick === next.onSuggestionClick
   )
 })

--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -144,8 +144,10 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
                   >
                     <AiChatBubble
                       message={message}
+                      isLast={index === messages.length - 1}
                       onViewListingDetail={onViewListingDetail}
                       onOpenFullDetail={setFullDetailListingId}
+                      onSuggestionClick={onSendMessage}
                     />
                   </div>
                 )

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -6,6 +6,7 @@ import { streamChat } from '@/api/services/chatbot.service'
 import type {
   ChatMessage,
   ChatListing,
+  ChatSuggestion,
   LastListingRef,
   ChatStreamStatusPayload,
 } from '@/api/types/ai.type'
@@ -27,6 +28,7 @@ export type TChatMessage = {
     reason: string
   }>
   toolsUsed?: string[]
+  suggestions?: ChatSuggestion[]
 }
 
 export type TChatState = {
@@ -265,6 +267,14 @@ export const useChatLogic = () => {
                   listings: payload.listings,
                   totalCount: payload.totalCount ?? payload.listings.length,
                   aiRankings: payload.aiRankings ?? [],
+                }))
+                followScrollToBottom()
+              },
+              onSuggestions: (payload) => {
+                ensureBotMessage()
+                updateMessage(botMessageId, (m) => ({
+                  ...m,
+                  suggestions: payload.items,
                 }))
                 followScrollToBottom()
               },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -55,7 +55,8 @@
     "loginRequired": "Please log in to use the AI assistant. Logging in helps us provide a better experience and save your conversation history.",
     "scrollToBottom": "Scroll to bottom",
     "expandTable": "View full",
-    "expandTableTitle": "Comparison Details"
+    "expandTableTitle": "Comparison Details",
+    "suggestionsLabel": "Suggested follow-ups"
   },
   "chat": {
     "title": "AI Property Assistant",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -55,7 +55,8 @@
     "loginRequired": "Vui lòng đăng nhập để sử dụng trợ lý AI. Đăng nhập giúp chúng tôi cung cấp trải nghiệm tốt hơn và lưu lịch sử trò chuyện của bạn.",
     "scrollToBottom": "Cuộn xuống cuối",
     "expandTable": "Xem đầy đủ",
-    "expandTableTitle": "Chi tiết so sánh"
+    "expandTableTitle": "Chi tiết so sánh",
+    "suggestionsLabel": "Gợi ý tiếp theo"
   },
   "chat": {
     "title": "Trợ Lý Tìm Nhà AI",


### PR DESCRIPTION
Render the server-sent follow-up suggestions as chips under the latest bot message; tapping a chip sends its query immediately.

- ai.type.ts: ChatSuggestion + ChatStreamSuggestionsPayload + onSuggestions handler.
- chatbot.service.ts: handle the "suggestions" SSE event.
- useChatLogic: store suggestions on the streaming bot message (TChatMessage.suggestions).
- aiChatBubble: render chips (isLast-gated) via the Button atom; onSuggestionClick reuses sendMessage. aiChatInterface threads isLast + onSuggestionClick.
- i18n: aiChat.suggestionsLabel (en + vi) for the chip group aria-label.

Verified: typecheck, eslint (touched files), i18n:check, vitest all clean.