### PR TITLE
perf(homepage): fetch tier carousels from GET /homepage-tier (no count)

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -63,6 +63,7 @@ export const PATHS = {
   LISTING: {
     LIST: '/v1/listings',
     SEARCH: '/v1/listings/search',
+    HOMEPAGE_TIER: '/v1/listings/homepage-tier',
     SELLER_DIAMOND: '/v1/listings/sellers/:userId/diamond',
     SELLER_GOLD: '/v1/listings/sellers/:userId/gold',
     SELLER_SILVER: '/v1/listings/sellers/:userId/silver',

--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -292,6 +292,27 @@ export class ListingService {
   }
 
   /**
+   * Homepage carousel data source: top `limit` listings of one VIP tier.
+   * GET /v1/listings/homepage-tier — no paging / no total count (fast even for
+   * the large NORMAL tier). Returns the card list directly (no pagination wrapper).
+   */
+  static async getHomepageTier(
+    vipType: VipType,
+    limit = 10,
+    instance?: AxiosInstance,
+  ): Promise<ApiResponse<ListingDetail[]>> {
+    return apiRequest<ListingDetail[]>(
+      {
+        method: 'GET',
+        url: PATHS.LISTING.HOMEPAGE_TIER,
+        params: { vipType, limit },
+        skipAuth: true, // Public API - không cần authentication
+      },
+      instance,
+    )
+  }
+
+  /**
    * Get seller listings by a specific VIP tier (public)
    * GET /v1/listings/sellers/:userId/{diamond|gold|silver|normal}
    */

--- a/src/hooks/useListings/useRecommendedListingsByVip.ts
+++ b/src/hooks/useListings/useRecommendedListingsByVip.ts
@@ -21,12 +21,13 @@ interface UseRecommendedListingsByVipReturn {
 /**
  * Hook to fetch listings for a single VIP tier (one homepage carousel).
  *
- * Each carousel calls POST /v1/listings/search with only the params that vary —
- * vipType is pinned, everything else is fixed (verified=true, page=1, a small
- * size, optional NEWEST sort). No user coordinates are sent: the tier carousels
- * aren't ranked by distance, and omitting them keeps the request identical
- * across all users so the backend's listing-search cache is actually shared
- * (a per-user coordinate would mint a fresh cache key for the same result).
+ * Calls the dedicated GET /v1/listings/homepage-tier endpoint, which returns the
+ * top N of one tier with NO paging and NO total count — much faster than the
+ * paginated POST /search (whose COUNT(*) over the huge NORMAL tier was the cause
+ * of the slow "Tin mới" section). vipType is pinned; no coordinates are sent
+ * (tiers aren't ranked by distance), so the backend response caches across all
+ * users. Ordering (newest-first within tier) preserves push: a pushed listing
+ * bumps updatedAt and rises to the top, same as the old search path.
  */
 export const useRecommendedListingsByVip = (
   options: UseRecommendedListingsByVipOptions,
@@ -36,17 +37,8 @@ export const useRecommendedListingsByVip = (
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['recommended-listings-by-vip', vipType, sortBy, page, size],
     queryFn: async () => {
-      const response = await ListingService.search({
-        vipType,
-        verified: true,
-        page,
-        size,
-        ...(sortBy ? { sortBy: sortBy as any } : {}),
-      })
-
-      const listings = response.data?.listings || []
-
-      return listings
+      const response = await ListingService.getHomepageTier(vipType, size)
+      return response.data || []
     },
     enabled: enabled,
     // Even the NEWEST (sorted) carousel gets a non-zero staleTime so re-mounting


### PR DESCRIPTION
Point useRecommendedListingsByVip at the new GET /v1/listings/homepage-tier endpoint instead of POST /search. It returns the top N of one tier with no paging and no total count, so the heavy COUNT(*) over the large NORMAL tier (the slow 'Tin mới' section) is gone. No coordinates sent; newest-first ordering preserves push.