### PR TITLE
fix(update-post): wrap tier limits in <p> to fix grid layout fragment…

### DIFF
--- a/src/components/templates/updatePostTemplate/MediaStep.tsx
+++ b/src/components/templates/updatePostTemplate/MediaStep.tsx
@@ -113,14 +113,18 @@ export const MediaStep: React.FC<MediaStepProps> = ({
         {tier && (
           <Alert className='mb-6 border-primary/50 bg-primary/10 text-foreground'>
             <Info className='h-5 w-5 text-primary' />
-            <AlertDescription className='text-base font-semibold text-foreground'>
-              {t.rich('sections.media.tierLimits', {
-                tierName: tier.tierName,
-                min: minImages,
-                max: maxImages,
-                videos: maxVideos,
-                b: (chunks) => <span className='font-semibold'>{chunks}</span>,
-              })}
+            <AlertDescription className='text-base text-foreground'>
+              <p>
+                {t.rich('sections.media.tierLimits', {
+                  tierName: tier.tierName,
+                  min: minImages,
+                  max: maxImages,
+                  videos: maxVideos,
+                  b: (chunks) => (
+                    <span className='font-semibold'>{chunks}</span>
+                  ),
+                })}
+              </p>
             </AlertDescription>
           </Alert>
         )}


### PR DESCRIPTION
…ation

AlertDescription uses CSS grid which made each t.rich() chunk render on its own line. Wrapping in <p> collapses all chunks into a single grid item so they flow inline correctly.