### PR TITLE
fix(listing-detail): hide non-approved/expired listings from public d…

### DIFF
--- a/src/pages/listing-detail/[...slug].tsx
+++ b/src/pages/listing-detail/[...slug].tsx
@@ -6,8 +6,15 @@ import DetailPostTemplate from '@/components/templates/detailPostTemplate'
 import SeoHead from '@/components/atoms/seo/SeoHead'
 import { ListingNotFound } from '@/components/molecules/listingNotFound'
 import type { ListingDetail } from '@/api/types'
+import { POST_STATUS } from '@/api/types'
 import { ListingService } from '@/api/services'
 import { PUBLIC_ROUTES } from '@/constants'
+
+const PUBLICLY_VISIBLE_STATUSES = new Set([
+  POST_STATUS.DISPLAYING,
+  POST_STATUS.EXPIRING_SOON,
+  POST_STATUS.VERIFIED,
+])
 
 interface ListingDetailProps {
   listing?: ListingDetail
@@ -112,6 +119,15 @@ export async function getServerSideProps(context: {
   const listing = res?.data || null
 
   if (!listing) {
+    return { props: { listingNotFound: true } }
+  }
+
+  const isVisible =
+    !listing.expired &&
+    (!listing.listingStatus ||
+      PUBLICLY_VISIBLE_STATUSES.has(listing.listingStatus))
+
+  if (!isVisible) {
     return { props: { listingNotFound: true } }
   }
 


### PR DESCRIPTION
…etail page

Listings with status outside DISPLAYING, EXPIRING_SOON, VERIFIED — or with expired=true — now return the not-found state instead of rendering the full detail page. Handled in getServerSideProps so no listing data leaks to the client.