### PR TITLE
feat(payment-status-badge): remove icons, add per-state color backgro…

### DIFF
--- a/src/components/atoms/paymentStatusBadge/index.constants.ts
+++ b/src/components/atoms/paymentStatusBadge/index.constants.ts
@@ -8,8 +8,7 @@ export type PaymentStatusType =
 
 export interface PaymentStatusConfig {
   labelKey: string
-  variant: 'default' | 'secondary' | 'destructive' | 'outline'
-  icon: string
+  className: string
 }
 
 export const PAYMENT_STATUS_CONFIG: Record<
@@ -18,37 +17,36 @@ export const PAYMENT_STATUS_CONFIG: Record<
 > = {
   COMPLETED: {
     labelKey: 'components.paymentStatusBadge.completed',
-    variant: 'default',
-    icon: '✓',
+    className:
+      'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800',
   },
   PENDING: {
     labelKey: 'components.paymentStatusBadge.pending',
-    variant: 'secondary',
-    icon: '⏳',
+    className:
+      'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-800',
   },
   FAILED: {
     labelKey: 'components.paymentStatusBadge.failed',
-    variant: 'destructive',
-    icon: '✕',
+    className:
+      'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
   },
   CANCELLED: {
     labelKey: 'components.paymentStatusBadge.cancelled',
-    variant: 'outline',
-    icon: '⊘',
+    className:
+      'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700',
   },
   REFUNDED: {
     labelKey: 'components.paymentStatusBadge.refunded',
-    variant: 'secondary',
-    icon: '↩',
+    className:
+      'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800',
   },
   UNKNOWN: {
     labelKey: 'components.paymentStatusBadge.unknown',
-    variant: 'outline',
-    icon: '?',
+    className:
+      'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700',
   },
 }
 
 export const PAYMENT_STATUS_STYLES = {
   badge: 'px-2.5 py-1.5 text-xs font-medium',
-  icon: 'mr-1',
 } as const

--- a/src/components/atoms/paymentStatusBadge/index.tsx
+++ b/src/components/atoms/paymentStatusBadge/index.tsx
@@ -11,17 +11,14 @@ import {
 export interface PaymentStatusBadgeProps {
   status: PaymentStatusType | string
   className?: string
-  showIcon?: boolean
 }
 
 export const PaymentStatusBadge: React.FC<PaymentStatusBadgeProps> = ({
   status,
   className,
-  showIcon = true,
 }) => {
   const t = useTranslations()
 
-  // Normalize status to PaymentStatusType
   const normalizedStatus = (status?.toUpperCase() ||
     'UNKNOWN') as PaymentStatusType
   const config =
@@ -29,16 +26,11 @@ export const PaymentStatusBadge: React.FC<PaymentStatusBadgeProps> = ({
 
   return (
     <Badge
-      variant={config.variant}
-      className={cn(PAYMENT_STATUS_STYLES.badge, className)}
+      variant='outline'
+      className={cn(PAYMENT_STATUS_STYLES.badge, config.className, className)}
       role='status'
       aria-label={t(config.labelKey)}
     >
-      {showIcon && (
-        <span className={PAYMENT_STATUS_STYLES.icon} aria-hidden='true'>
-          {config.icon}
-        </span>
-      )}
       {t(config.labelKey)}
     </Badge>
   )

--- a/src/components/molecules/personalInfoForm/index.tsx
+++ b/src/components/molecules/personalInfoForm/index.tsx
@@ -49,12 +49,20 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
       .string()
       .trim()
       .required(t('homePage.auth.validation.firstNameRequired'))
-      .min(2, t('homePage.auth.validation.firstNameMinLength')),
+      .test(
+        'notDefault',
+        t('homePage.auth.validation.firstNameInvalid'),
+        (value) => value !== '#32',
+      ),
     lastName: yup
       .string()
       .trim()
       .required(t('homePage.auth.validation.lastNameRequired'))
-      .min(2, t('homePage.auth.validation.lastNameMinLength')),
+      .test(
+        'notDefault',
+        t('homePage.auth.validation.lastNameInvalid'),
+        (value) => value !== '#32',
+      ),
     email: yup
       .string()
       .required(t('homePage.auth.validation.emailRequired'))

--- a/src/components/molecules/transactionHistory/TransactionDetailDialog.tsx
+++ b/src/components/molecules/transactionHistory/TransactionDetailDialog.tsx
@@ -123,7 +123,7 @@ const DetailBody: React.FC<{ detail: CustomerTransactionDetail }> = ({
               >
                 <span className='absolute -left-[1.30rem] top-1 size-2 rounded-full bg-primary' />
                 <div className='flex flex-wrap items-center gap-2'>
-                  <PaymentStatusBadge status={event.status} showIcon={false} />
+                  <PaymentStatusBadge status={event.status} />
                   <span className='text-xs text-muted-foreground'>
                     {formatDateTime(event.at)}
                   </span>

--- a/src/components/organisms/accountManagement/index.tsx
+++ b/src/components/organisms/accountManagement/index.tsx
@@ -20,7 +20,6 @@ import {
   Search,
   Gift,
   BadgeCheck,
-  Sparkles,
 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
@@ -289,34 +288,23 @@ const AccountManagement: NextPage<AccountManagementProps> = ({
           className='space-y-5 md:space-y-6'
         >
           <div className='space-y-4'>
-            <div className='flex items-start gap-3 sm:gap-4'>
-              <div className='mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full border border-primary/30'>
-                <Sparkles className='size-4.5 text-primary' />
-              </div>
-              <div className='space-y-2'>
-                <span className='inline-flex items-center rounded-full border px-2.5 py-0.5 text-2xs font-semibold uppercase tracking-[0.06em] text-muted-foreground'>
-                  {safeT(
-                    'homePage.auth.accountManagement.brokerHookBanner.badge',
-                    'SellerNet Pro',
-                  )}
-                </span>
-                <h3 className='text-base font-semibold leading-snug text-foreground md:text-lg'>
-                  {safeT(
-                    'homePage.auth.accountManagement.brokerHookBanner.title',
-                    'Bật hồ sơ môi giới để tăng độ tin cậy và tiếp cận khách hàng nhanh hơn.',
-                  )}
-                </h3>
-
-                {isProfessionalBroker && (
-                  <p className='inline-flex items-center gap-1.5 rounded-full border border-emerald-300/70 bg-emerald-50/60 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-950/20 dark:text-emerald-300'>
-                    <CheckCircle2 className='h-3.5 w-3.5' />
-                    {safeT(
-                      'homePage.auth.accountManagement.brokerProfessional.description',
-                      'Tài khoản của bạn đã được xác minh là môi giới chuyên nghiệp.',
-                    )}
-                  </p>
+            <div className='space-y-2'>
+              <h3 className='text-base font-semibold leading-snug text-foreground md:text-lg'>
+                {safeT(
+                  'homePage.auth.accountManagement.brokerHookBanner.title',
+                  'Bật hồ sơ môi giới để tăng độ tin cậy và tiếp cận khách hàng nhanh hơn.',
                 )}
-              </div>
+              </h3>
+
+              {isProfessionalBroker && (
+                <p className='inline-flex items-center gap-1.5 rounded-full border border-emerald-300/70 bg-emerald-50/60 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-950/20 dark:text-emerald-300'>
+                  <CheckCircle2 className='h-3.5 w-3.5' />
+                  {safeT(
+                    'homePage.auth.accountManagement.brokerProfessional.description',
+                    'Tài khoản của bạn đã được xác minh là môi giới chuyên nghiệp.',
+                  )}
+                </p>
+              )}
             </div>
 
             <div className='mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3'>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -582,7 +582,9 @@
         "newPasswordLowercase": "Password must have at least 1 lowercase letter",
         "newPasswordNumber": "Password must have at least 1 number",
         "avatarSizeExceeded": "Avatar file size must not exceed {maxSize}MB",
-        "avatarFormatInvalid": "Avatar must be jpeg, png, or webp format"
+        "avatarFormatInvalid": "Avatar must be jpeg, png, or webp format",
+        "firstNameInvalid": "Please enter a valid first name",
+        "lastNameInvalid": "Please enter a valid last name"
       },
       "oauth": {
         "processing_login": "Processing login...",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -582,7 +582,9 @@
         "newPasswordLowercase": "Mật khẩu cần có ít nhất 1 ký tự viết thường",
         "newPasswordNumber": "Mật khẩu cần có ít nhất 1 ký tự số",
         "avatarSizeExceeded": "Kích thước ảnh đại diện không được vượt quá {maxSize}MB",
-        "avatarFormatInvalid": "Ảnh đại diện phải có định dạng jpeg, png, hoặc webp"
+        "avatarFormatInvalid": "Ảnh đại diện phải có định dạng jpeg, png, hoặc webp",
+        "firstNameInvalid": "Vui lòng nhập tên hợp lệ",
+        "lastNameInvalid": "Vui lòng nhập họ hợp lệ"
       },
       "oauth": {
         "processing_login": "Đang xử lý đăng nhập...",
@@ -682,8 +684,8 @@
           "title": "Thông tin cá nhân",
           "contactInfo": "Thông tin liên hệ",
           "businessInfo": "Thông tin xuất hóa đơn",
-          "firstName": "Họ",
-          "lastName": "Tên",
+          "firstName": "Tên",
+          "lastName": "Họ",
           "phoneNumber": "Số điện thoại chính",
           "email": "Email",
           "idDocument": "Mã số thuế",


### PR DESCRIPTION
…unds

Replace generic shadcn variant colors with distinct background/text/border colors per payment state (green=completed, yellow=pending, red=failed, gray=cancelled, blue=refunded) with dark mode support.