### PR TITLE
fix(dashboard): use packageSalePrice for renewal price display

### DIFF
--- a/src/api/types/membership.type.ts
+++ b/src/api/types/membership.type.ts
@@ -107,6 +107,7 @@ export interface UserMembership {
   readonly daysRemaining: number
   readonly status: MembershipStatus
   readonly totalPaid: number
+  readonly packageSalePrice: number
   readonly benefits: UserBenefit[]
   readonly createdAt: string
   readonly updatedAt: string

--- a/src/components/molecules/renewMembershipDialog/index.tsx
+++ b/src/components/molecules/renewMembershipDialog/index.tsx
@@ -126,7 +126,7 @@ export const RenewMembershipDialog: React.FC<RenewMembershipDialogProps> = ({
                 variant='small'
                 className='font-bold text-sm text-foreground mt-0.5 block'
               >
-                {formatCurrency(membership.totalPaid)}
+                {formatCurrency(membership.packageSalePrice)}
               </Typography>
             </div>
           </div>

--- a/src/hooks/usePhoneClickDetails/useOwnerListingAnalytics.ts
+++ b/src/hooks/usePhoneClickDetails/useOwnerListingAnalytics.ts
@@ -41,6 +41,7 @@ export const useOwnerListingsAnalyticsSummary = () => {
     retry: false,
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }
 
@@ -72,6 +73,7 @@ export const useOwnerListingAnalytics = (
     retry: false,
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }
 
@@ -114,5 +116,6 @@ export const useOwnerListingsAnalyticsPage = (params: {
     retry: false,
     staleTime: 10 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }

--- a/src/hooks/useSavedListings/useOwnerSavedListingsAnalytics.ts
+++ b/src/hooks/useSavedListings/useOwnerSavedListingsAnalytics.ts
@@ -37,6 +37,7 @@ export const useOwnerSavedListingsAnalyticsSummary = () => {
     retry: false,
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }
 
@@ -62,6 +63,7 @@ export const useOwnerListingSavesTrend = (
     retry: false,
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }
 
@@ -98,5 +100,6 @@ export const useOwnerSavedListingsAnalyticsPage = (params: {
     retry: false,
     staleTime: 10 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
   })
 }


### PR DESCRIPTION
totalPaid reflects the historical price paid, not the current package price. Add packageSalePrice field (from backend) and use it in the renewal dialog so the displayed price matches what will be charged.