### PR TITLE
fix(post): sync update-post step 5 UI with create-post and allow bene…

### DIFF
--- a/src/components/molecules/createPostSections/SelectPromotionDialog.tsx
+++ b/src/components/molecules/createPostSections/SelectPromotionDialog.tsx
@@ -221,8 +221,8 @@ export const SelectBenefitDialog: React.FC<SelectBenefitDialogProps> = ({
           <DialogClose asChild>
             <Button variant='outline'>{t('cancel')}</Button>
           </DialogClose>
-          <Button onClick={handleApply} disabled={selected === null}>
-            {t('apply', { count: selected === null ? 0 : 1 })}
+          <Button onClick={handleApply}>
+            {selected === null ? t('clearBenefit') : t('apply', { count: 1 })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -25,6 +25,7 @@ import {
   Check,
   Loader2,
   AlertCircle,
+  X,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SelectBenefitDialog } from '@/components/molecules/createPostSections/SelectPromotionDialog'
@@ -507,12 +508,24 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
               <ChevronRight className='w-4 h-4' />
             </div>
             {propertyInfo.benefitIds && propertyInfo.benefitIds.length > 0 && (
-              <Typography
-                variant='muted'
-                className='text-xs text-primary bg-primary/10 px-2 py-1 rounded-md'
-              >
-                {t('promotionApplied')}: 1 benefit
-              </Typography>
+              <div className='flex items-center gap-1'>
+                <Typography
+                  variant='muted'
+                  className='text-xs text-primary bg-primary/10 px-2 py-1 rounded-md'
+                >
+                  {t('promotionApplied')}: 1 benefit
+                </Typography>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon'
+                  className='h-6 w-6 text-muted-foreground hover:text-destructive'
+                  onClick={() => handleApplyBenefits([])}
+                  aria-label={t('removePromotion')}
+                >
+                  <X className='w-3 h-3' />
+                </Button>
+              </div>
             )}
             {!membership && !isMembershipLoading && (
               <Typography
@@ -529,6 +542,7 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
           open={benefitDialogOpen}
           onOpenChange={setBenefitDialogOpen}
           onApply={handleApplyBenefits}
+          selectedBenefitIds={propertyInfo.benefitIds ?? []}
           membershipData={membership}
         />
 

--- a/src/components/organisms/updatePostSections/orderSummarySection.tsx
+++ b/src/components/organisms/updatePostSections/orderSummarySection.tsx
@@ -4,13 +4,9 @@ import { useCreatePost } from '@/contexts/createPost'
 import { useVipTiers } from '@/hooks/useVipTiers'
 import { useAuthContext } from '@/contexts/auth'
 import { useMyMembership } from '@/hooks/useMembership'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from '@/components/atoms/card'
+import { useQuery } from '@tanstack/react-query'
+import { UserService } from '@/api/services/user.service'
+import { Card, CardContent, CardHeader } from '@/components/atoms/card'
 import { Separator } from '@/components/atoms/separator'
 import { Badge } from '@/components/atoms/badge'
 import { Typography } from '@/components/atoms/typography'
@@ -26,6 +22,9 @@ import {
   MapPin,
   Sparkles,
   Award,
+  User as UserIcon,
+  Mail,
+  Phone,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import Image from 'next/image'
@@ -55,6 +54,17 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
   const { data: vipTiers = [] } = useVipTiers()
   const { user } = useAuthContext()
   const { data: myMembership } = useMyMembership(user?.userId)
+
+  const { data: profileResponse, isLoading: isCheckingProfile } = useQuery({
+    queryKey: ['update-post-order-summary-profile', user?.userId],
+    queryFn: () => UserService.getProfile(),
+    enabled: !!user?.userId,
+    retry: false,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+  })
+
+  const profile = profileResponse?.data
 
   const mediaArray = Array.isArray(media) ? media : []
 
@@ -89,6 +99,22 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
       ? selectedBenefit?.benefitNameDisplay || t('freePosting')
       : selectedTier?.tierName || t('notSelected')
 
+  const totalPrice = (() => {
+    const duration = propertyInfo.durationDays
+    if (usingMembershipQuota || usingPromotion) return 0
+    if (!selectedTier || !duration) return 0
+    switch (duration) {
+      case 10:
+        return selectedTier.price10Days
+      case 15:
+        return selectedTier.price15Days
+      case 30:
+        return selectedTier.price30Days
+      default:
+        return (selectedTier.pricePerDay || 0) * duration
+    }
+  })()
+
   const formatDate = (date?: string | Date) => {
     if (!date) return t('notSelected')
     const d = typeof date === 'string' ? new Date(date) : date
@@ -106,30 +132,208 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
     return endDate.toLocaleDateString('vi-VN')
   }
 
+  const contactFullName =
+    [profile?.firstName, profile?.lastName].filter(Boolean).join(' ').trim() ||
+    [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim()
+
+  const contactEmail =
+    profile?.email?.trim() || user?.email?.trim() || tCommon('notAvailable')
+
+  const contactPhone =
+    profile?.contactPhoneNumber?.trim() ||
+    profile?.phoneNumber?.trim() ||
+    user?.contactPhoneNumber?.trim() ||
+    user?.phoneNumber?.trim() ||
+    tCommon('notAvailable')
+
+  const latitude = propertyInfo?.address?.latitude
+  const longitude = propertyInfo?.address?.longitude
+  const hasValidCoordinates =
+    typeof latitude === 'number' &&
+    typeof longitude === 'number' &&
+    latitude !== 0 &&
+    longitude !== 0
+  const embeddedMapUrl = hasValidCoordinates
+    ? `https://www.google.com/maps?q=${latitude},${longitude}&z=15&output=embed`
+    : ''
+
   return (
     <Card className={cn('border-0 shadow-none', className)}>
       <CardHeader className='px-0'>
-        <CardTitle className='text-2xl sm:text-3xl md:text-4xl'>
-          {t('title')}
-        </CardTitle>
-        <CardDescription className='text-sm sm:text-base'>
-          {t('description')}
-        </CardDescription>
+        <Typography variant='pageTitle'>{t('title')}</Typography>
       </CardHeader>
 
       <CardContent className='px-0'>
-        {/* Flex Layout: Left Content + Right Payment Summary */}
-        <div className='flex flex-col md:flex-row gap-6'>
-          {/* Left Side - Main Content */}
-          <div className='flex-1 space-y-6  md:w-[calc(100%-444px)]'>
+        {/* Stacked Layout: Main Content on top, Payment Summary below */}
+        <div className='flex flex-col gap-6'>
+          {/* Top - Main Content */}
+          <div className='space-y-8 sm:space-y-10'>
+            {/* Contact Information */}
+            <section className='space-y-3'>
+              <Typography variant='h4' className='font-semibold'>
+                {tCommon('contactInformation')}
+              </Typography>
+              <div>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
+                  <div className='h-full min-h-[92px] rounded-lg border bg-muted/30 p-3'>
+                    <div className='flex flex-col items-center justify-center gap-2 h-full text-center'>
+                      <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 flex-shrink-0'>
+                        <UserIcon className='w-4 h-4 text-primary' />
+                      </div>
+                      <div className='min-w-0'>
+                        <Typography variant='muted' className='text-xs'>
+                          {tCommon('fullName')}
+                        </Typography>
+                        <Typography className='mt-1 text-sm font-semibold leading-5 break-words'>
+                          {contactFullName || tCommon('notAvailable')}
+                        </Typography>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className='h-full min-h-[92px] rounded-lg border bg-muted/30 p-3'>
+                    <div className='flex flex-col items-center justify-center gap-2 h-full text-center'>
+                      <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 flex-shrink-0'>
+                        <Mail className='w-4 h-4 text-primary' />
+                      </div>
+                      <div className='min-w-0'>
+                        <Typography variant='muted' className='text-xs'>
+                          {tCommon('email')}
+                        </Typography>
+                        <Typography className='mt-1 text-sm font-semibold leading-5 break-all'>
+                          {contactEmail}
+                        </Typography>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className='h-full min-h-[92px] rounded-lg border bg-muted/30 p-3'>
+                    <div className='flex flex-col items-center justify-center gap-2 h-full text-center'>
+                      <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 flex-shrink-0'>
+                        <Phone className='w-4 h-4 text-primary' />
+                      </div>
+                      <div className='min-w-0'>
+                        <Typography variant='muted' className='text-xs'>
+                          {tCommon('phoneNumber')}
+                        </Typography>
+                        <Typography className='mt-1 text-sm font-semibold leading-5 break-words'>
+                          {isCheckingProfile &&
+                          contactPhone === tCommon('notAvailable')
+                            ? tCommon('checking')
+                            : contactPhone}
+                        </Typography>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* Combined Package & Payment Summary */}
+            <section className='space-y-3'>
+              <div className='flex items-center gap-2'>
+                <Package className='w-5 h-5 text-primary' />
+                <Typography variant='h4' className='font-semibold'>
+                  {tCreatePost('sections.orderSummary.packageDetails')}
+                </Typography>
+              </div>
+
+              <div className='grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4'>
+                {/* Left: Package info */}
+                <div className='space-y-3'>
+                  <OrderSummaryRow
+                    label={tCreatePost(
+                      'sections.packageConfig.selectedPackage',
+                    )}
+                    value={
+                      <Badge variant='default' className='font-medium'>
+                        {packageName}
+                      </Badge>
+                    }
+                    variant='highlight'
+                  />
+
+                  {(usingMembershipQuota || usingPromotion) && (
+                    <div className='flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2'>
+                      <Award className='w-4 h-4 text-primary flex-shrink-0' />
+                      <Typography className='text-sm text-primary font-medium'>
+                        {tCreatePost('sections.packageConfig.freePosting')}
+                      </Typography>
+                    </div>
+                  )}
+
+                  {/* Compact chip grid: duration + start + end dates */}
+                  <div className='grid grid-cols-3 gap-2'>
+                    <div className='rounded-lg border bg-muted/30 p-2.5 min-w-0'>
+                      <Typography variant='muted' className='text-xs truncate'>
+                        {tCreatePost('sections.packageConfig.duration')}
+                      </Typography>
+                      <Typography className='mt-1 text-sm font-semibold leading-5 break-words'>
+                        {`${propertyInfo.durationDays || 0} ${tCreatePost('sections.packageConfig.days')}`}
+                      </Typography>
+                    </div>
+                    <div className='rounded-lg border bg-muted/30 p-2.5 min-w-0'>
+                      <Typography
+                        variant='muted'
+                        className='text-xs flex items-center gap-1 truncate'
+                      >
+                        <Calendar className='w-3 h-3 flex-shrink-0' />
+                        {tCreatePost('sections.packageConfig.startDate')}
+                      </Typography>
+                      <Typography className='mt-1 text-sm font-semibold leading-5 break-words'>
+                        {formatDate(propertyInfo.postDate)}
+                      </Typography>
+                    </div>
+                    <div className='rounded-lg border bg-muted/30 p-2.5 min-w-0'>
+                      <Typography
+                        variant='muted'
+                        className='text-xs flex items-center gap-1 truncate'
+                      >
+                        <Calendar className='w-3 h-3 flex-shrink-0' />
+                        {tCreatePost('sections.packageConfig.endDate')}
+                      </Typography>
+                      <Typography className='mt-1 text-sm font-semibold leading-5 break-words'>
+                        {getEndDate()}
+                      </Typography>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Right: Payment breakdown */}
+                <div className='rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3 md:self-start'>
+                  <div className='flex items-center gap-2'>
+                    <CreditCard className='w-4 h-4 text-primary' />
+                    <Typography className='text-sm font-semibold'>
+                      {tCreatePost('sections.packageConfig.priceBreakdown')}
+                    </Typography>
+                  </div>
+                  <div className='flex items-baseline justify-between gap-3'>
+                    <Typography variant='muted' className='text-xs sm:text-sm'>
+                      {tCreatePost('sections.packageConfig.packagePrice')}
+                    </Typography>
+                    <Typography className='text-sm font-medium'>
+                      {`${totalPrice.toLocaleString('vi-VN')} đ`}
+                    </Typography>
+                  </div>
+                  <Separator />
+                  <div className='flex items-baseline justify-between gap-3'>
+                    <Typography className='text-sm font-semibold'>
+                      {tCreatePost('sections.packageConfig.totalAmount')}
+                    </Typography>
+                    <Typography className='text-title font-bold text-primary leading-none'>
+                      {`${totalPrice.toLocaleString('vi-VN')} đ`}
+                    </Typography>
+                  </div>
+                </div>
+              </div>
+            </section>
+
             {/* Property Preview with Media */}
-            <Card>
-              <CardHeader>
-                <CardTitle className='text-lg'>
-                  {tCreatePost('sections.propertyInfo.title')}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='space-y-4'>
+            <section className='space-y-3'>
+              <Typography variant='h4' className='font-semibold'>
+                {tCreatePost('sections.propertyInfo.title')}
+              </Typography>
+              <div className='space-y-4'>
                 {/* Media Section - Video Priority or Cover Image - Responsive */}
                 {(videoUrl || coverImage) && (
                   <div className='relative w-full rounded-lg overflow-hidden bg-muted'>
@@ -174,22 +378,28 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                 )}
 
                 {/* Property Details */}
-                <div className='space-y-3'>
+                <div className='space-y-4'>
                   <Typography
-                    variant='h3'
-                    className='font-bold text-xl break-words'
+                    variant='h4'
+                    title={
+                      propertyInfo.title ||
+                      tCreatePost('sections.propertyInfo.noTitle')
+                    }
+                    className='font-semibold break-words leading-snug line-clamp-2 hover:line-clamp-none'
                   >
                     {propertyInfo.title ||
                       tCreatePost('sections.propertyInfo.noTitle')}
                   </Typography>
 
                   {propertyInfo.description && (
-                    <Typography
-                      variant='muted'
-                      className='text-sm line-clamp-3 break-words'
-                    >
-                      {propertyInfo.description}
-                    </Typography>
+                    <div className='rounded-lg border bg-muted/20 p-3'>
+                      <Typography
+                        variant='muted'
+                        className='text-sm leading-6 line-clamp-4 break-words'
+                      >
+                        {propertyInfo.description}
+                      </Typography>
+                    </div>
                   )}
 
                   <Separator />
@@ -197,29 +407,37 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                   {/* Key Information Grid */}
                   <div className='grid grid-cols-2 gap-3'>
                     {propertyInfo.price && (
-                      <div className='flex items-center gap-2'>
-                        <CreditCard className='w-4 h-4 text-muted-foreground flex-shrink-0' />
-                        <div className='min-w-0'>
+                      <div className='rounded-lg border bg-background/70 p-3'>
+                        <div className='flex items-center gap-2'>
+                          <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10'>
+                            <CreditCard className='w-4 h-4 text-primary flex-shrink-0' />
+                          </div>
                           <Typography variant='muted' className='text-xs'>
                             {tCreatePost('sections.propertyInfo.price')}
                           </Typography>
-                          <Typography className='font-semibold text-sm truncate'>
+                        </div>
+                        <div className='min-w-0'>
+                          <Typography className='mt-2 font-semibold text-sm break-words'>
                             {propertyInfo.price.toLocaleString('vi-VN')} đ
                             {propertyInfo.priceUnit &&
-                              `/${propertyInfo.priceUnit}`}
+                              `/${tCommon(`priceUnits.${propertyInfo.priceUnit}`)}`}
                           </Typography>
                         </div>
                       </div>
                     )}
 
                     {propertyInfo.area && (
-                      <div className='flex items-center gap-2'>
-                        <Ruler className='w-4 h-4 text-muted-foreground flex-shrink-0' />
-                        <div className='min-w-0'>
+                      <div className='rounded-lg border bg-background/70 p-3'>
+                        <div className='flex items-center gap-2'>
+                          <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10'>
+                            <Ruler className='w-4 h-4 text-primary flex-shrink-0' />
+                          </div>
                           <Typography variant='muted' className='text-xs'>
                             {tCreatePost('sections.propertyInfo.area')}
                           </Typography>
-                          <Typography className='font-semibold text-sm'>
+                        </div>
+                        <div className='min-w-0'>
+                          <Typography className='mt-2 font-semibold text-sm'>
                             {propertyInfo.area} m²
                           </Typography>
                         </div>
@@ -227,13 +445,17 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                     )}
 
                     {propertyInfo.bedrooms && (
-                      <div className='flex items-center gap-2'>
-                        <Bed className='w-4 h-4 text-muted-foreground flex-shrink-0' />
-                        <div className='min-w-0'>
+                      <div className='rounded-lg border bg-background/70 p-3'>
+                        <div className='flex items-center gap-2'>
+                          <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10'>
+                            <Bed className='w-4 h-4 text-primary flex-shrink-0' />
+                          </div>
                           <Typography variant='muted' className='text-xs'>
                             {tCreatePost('sections.propertyInfo.bedrooms')}
                           </Typography>
-                          <Typography className='font-semibold text-sm'>
+                        </div>
+                        <div className='min-w-0'>
+                          <Typography className='mt-2 font-semibold text-sm'>
                             {propertyInfo.bedrooms}
                           </Typography>
                         </div>
@@ -241,13 +463,17 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                     )}
 
                     {propertyInfo.bathrooms && (
-                      <div className='flex items-center gap-2'>
-                        <Bath className='w-4 h-4 text-muted-foreground flex-shrink-0' />
-                        <div className='min-w-0'>
+                      <div className='rounded-lg border bg-background/70 p-3'>
+                        <div className='flex items-center gap-2'>
+                          <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10'>
+                            <Bath className='w-4 h-4 text-primary flex-shrink-0' />
+                          </div>
                           <Typography variant='muted' className='text-xs'>
                             {tCreatePost('sections.propertyInfo.bathrooms')}
                           </Typography>
-                          <Typography className='font-semibold text-sm'>
+                        </div>
+                        <div className='min-w-0'>
+                          <Typography className='mt-2 font-semibold text-sm'>
                             {propertyInfo.bathrooms}
                           </Typography>
                         </div>
@@ -259,30 +485,81 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                   {(composedNewAddress || composedLegacyAddress) && (
                     <>
                       <Separator />
-                      <div className='flex items-start gap-2'>
-                        <MapPin className='w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0' />
-                        <div className='min-w-0 flex-1 space-y-1'>
-                          {composedNewAddress && (
-                            <Typography className='text-sm break-words'>
-                              <span className='font-medium'>
+                      <div className='rounded-lg border bg-muted/20 p-3 space-y-3'>
+                        <div className='flex items-start gap-2'>
+                          <div className='flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 mt-0.5 flex-shrink-0'>
+                            <MapPin className='w-4 h-4 text-primary' />
+                          </div>
+                          <div className='min-w-0 flex-1 space-y-1'>
+                            {composedNewAddress && (
+                              <Typography className='text-sm break-words mt-1'>
+                                <span className='font-medium'>
+                                  {tCreatePost(
+                                    'sections.propertyInfo.address.structureType.newShort',
+                                  )}
+                                  :
+                                </span>{' '}
+                                {composedNewAddress}
+                              </Typography>
+                            )}
+                            {composedLegacyAddress && (
+                              <Typography className='text-xs text-muted-foreground break-words'>
+                                <span className='font-medium'>
+                                  {tCreatePost(
+                                    'sections.propertyInfo.address.structureType.legacyShort',
+                                  )}
+                                  :
+                                </span>{' '}
+                                {composedLegacyAddress}
+                              </Typography>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className='space-y-2'>
+                          <Typography
+                            variant='muted'
+                            className='text-xs flex items-center gap-1'
+                          >
+                            <MapPin className='w-3 h-3' />
+                            {tCreatePost('sections.propertyInfo.mapPreview')}
+                          </Typography>
+
+                          {hasValidCoordinates ? (
+                            <>
+                              <div className='overflow-hidden rounded-lg border bg-background'>
+                                <iframe
+                                  src={embeddedMapUrl}
+                                  title={tCreatePost(
+                                    'sections.propertyInfo.mapPreview',
+                                  )}
+                                  className='w-full h-52'
+                                  loading='lazy'
+                                  referrerPolicy='no-referrer-when-downgrade'
+                                />
+                              </div>
+                              <Typography
+                                variant='muted'
+                                className='text-xs break-words'
+                              >
                                 {tCreatePost(
-                                  'sections.propertyInfo.address.structureType.newShort',
+                                  'sections.propertyInfo.coordinates',
                                 )}
-                                :
-                              </span>{' '}
-                              {composedNewAddress}
-                            </Typography>
-                          )}
-                          {composedLegacyAddress && (
-                            <Typography className='text-xs text-muted-foreground break-words'>
-                              <span className='font-medium'>
+                                :&nbsp;
+                                {latitude?.toFixed(6)}, {longitude?.toFixed(6)}
+                              </Typography>
+                            </>
+                          ) : (
+                            <div className='rounded-lg border border-dashed bg-background p-3'>
+                              <Typography
+                                variant='muted'
+                                className='text-xs text-center'
+                              >
                                 {tCreatePost(
-                                  'sections.propertyInfo.address.structureType.legacyShort',
+                                  'sections.propertyInfo.mapNotSelected',
                                 )}
-                                :
-                              </span>{' '}
-                              {composedLegacyAddress}
-                            </Typography>
+                              </Typography>
+                            </div>
                           )}
                         </div>
                       </div>
@@ -293,7 +570,7 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                   <Separator />
                   <div className='flex flex-wrap gap-2'>
                     {propertyInfo.productType && (
-                      <Badge variant='secondary' className='gap-1'>
+                      <Badge variant='secondary' className='gap-1 px-2.5 py-1'>
                         <Home className='w-3 h-3' />
                         {tNormal(
                           getProductTypeTranslationKey(
@@ -303,14 +580,14 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                       </Badge>
                     )}
                     {propertyInfo.direction && (
-                      <Badge variant='outline'>
+                      <Badge variant='outline' className='px-2.5 py-1'>
                         {tNormal(
                           getDirectionTranslationKey(propertyInfo.direction),
                         )}
                       </Badge>
                     )}
                     {propertyInfo.furnishing && (
-                      <Badge variant='outline'>
+                      <Badge variant='outline' className='px-2.5 py-1'>
                         {tNormal(
                           getFurnishingTranslationKey(propertyInfo.furnishing),
                         )}
@@ -346,7 +623,7 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                                   <Badge
                                     key={id}
                                     variant='secondary'
-                                    className='text-xs flex items-center gap-1'
+                                    className='text-xs flex items-center gap-1 px-2 py-1'
                                   >
                                     {IconComponent && (
                                       <IconComponent className='w-3 h-3' />
@@ -360,7 +637,10 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                                 )
                               })}
                             {propertyInfo.amenityIds.length > 6 && (
-                              <Badge variant='secondary' className='text-xs'>
+                              <Badge
+                                variant='secondary'
+                                className='text-xs px-2 py-1'
+                              >
                                 +{propertyInfo.amenityIds.length - 6}
                               </Badge>
                             )}
@@ -369,108 +649,9 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
                       </>
                     )}
                 </div>
-              </CardContent>
-            </Card>
-
-            {/* Contact Information */}
-            <Card>
-              <CardHeader>
-                <CardTitle className='text-lg'>
-                  {tCommon('contactInformation')}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='space-y-3'>
-                <OrderSummaryRow
-                  label={tCommon('fullName')}
-                  value={
-                    user?.firstName && user?.lastName
-                      ? `${user.firstName} ${user.lastName}`
-                      : tCommon('notAvailable')
-                  }
-                />
-                <Separator />
-                <OrderSummaryRow
-                  label={tCommon('email')}
-                  value={user?.email || tCommon('notAvailable')}
-                />
-                <Separator />
-                <OrderSummaryRow
-                  label={tCommon('phoneNumber')}
-                  value={user?.phoneNumber || tCommon('notAvailable')}
-                />
-              </CardContent>
-            </Card>
+              </div>
+            </section>
           </div>
-
-          {/* Right Side - Package & Payment Summary (Sticky) */}
-          <Card className='md:w-[380px] xl:w-[420px] h-fit md:sticky md:top-[100px] space-y-0'>
-            {/* Package Details */}
-            <CardHeader className='pb-4'>
-              <Card className='flex items-center gap-2 border-0 shadow-none p-0'>
-                <Package className='w-5 h-5 text-primary' />
-                <CardTitle className='text-lg'>
-                  {tCreatePost('sections.orderSummary.packageDetails')}
-                </CardTitle>
-              </Card>
-            </CardHeader>
-
-            <CardContent className='space-y-3 pb-6'>
-              <OrderSummaryRow
-                label={tCreatePost('sections.packageConfig.selectedPackage')}
-                value={
-                  <Badge variant='default' className='font-medium'>
-                    {packageName}
-                  </Badge>
-                }
-                variant='highlight'
-              />
-              {(usingMembershipQuota || usingPromotion) && (
-                <>
-                  <Separator />
-                  <OrderSummaryRow
-                    label={tCreatePost(
-                      'sections.packageConfig.usingMembershipQuota',
-                    )}
-                    value={
-                      <Card className='flex items-center gap-2 border-0 shadow-none p-0'>
-                        <Award className='w-4 h-4 text-primary' />
-                        <Typography className='text-sm text-primary font-medium'>
-                          {tCreatePost('sections.packageConfig.freePosting')}
-                        </Typography>
-                      </Card>
-                    }
-                  />
-                </>
-              )}
-              <Separator />
-              <OrderSummaryRow
-                label={tCreatePost('sections.packageConfig.duration')}
-                value={`${propertyInfo.durationDays || 0} ${tCreatePost('sections.packageConfig.days')}`}
-              />
-              <Separator />
-              <OrderSummaryRow
-                label={tCreatePost('sections.packageConfig.startDate')}
-                value={
-                  <Card className='flex items-center gap-2 border-0 shadow-none p-0'>
-                    <Calendar className='w-4 h-4 text-muted-foreground' />
-                    <Typography className='text-sm'>
-                      {formatDate(propertyInfo.postDate)}
-                    </Typography>
-                  </Card>
-                }
-              />
-              <Separator />
-              <OrderSummaryRow
-                label={tCreatePost('sections.packageConfig.endDate')}
-                value={
-                  <Card className='flex items-center gap-2 border-0 shadow-none p-0'>
-                    <Calendar className='w-4 h-4 text-muted-foreground' />
-                    <Typography className='text-sm'>{getEndDate()}</Typography>
-                  </Card>
-                }
-              />
-            </CardContent>
-          </Card>
         </div>
       </CardContent>
     </Card>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1168,14 +1168,16 @@
           "daysRemaining": "{count} days left",
           "noMembership": "You don't have any membership package",
           "cancel": "Cancel",
-          "apply": "Apply ({count})"
+          "apply": "Apply ({count})",
+          "clearBenefit": "Clear benefit"
         },
         "updatePost": {
           "description": "Current package information (post date can be adjusted)",
           "endDateAutoCalculated": "End date (Auto-calculated)",
           "endDateNote": "End date is automatically calculated based on start date + duration",
           "updateNote": "Note: Package type and duration cannot be changed during update"
-        }
+        },
+        "removePromotion": "Remove benefit"
       },
       "orderSummary": {
         "title": "Order Summary",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1168,14 +1168,16 @@
           "daysRemaining": "còn {count} ngày",
           "noMembership": "Bạn chưa có gói hội viên nào",
           "cancel": "Hủy",
-          "apply": "Áp dụng ({count})"
+          "apply": "Áp dụng ({count})",
+          "clearBenefit": "Huỷ áp dụng"
         },
         "updatePost": {
           "description": "Thông tin gói đăng tin hiện tại (có thể điều chỉnh ngày đăng)",
           "endDateAutoCalculated": "Ngày kết thúc (Tự động tính)",
           "endDateNote": "Ngày kết thúc được tự động tính dựa trên ngày bắt đầu + thời hạn",
           "updateNote": "Lưu ý: Loại gói và thời hạn không thể thay đổi khi cập nhật"
-        }
+        },
+        "removePromotion": "Xoá quyền lợi"
       },
       "orderSummary": {
         "title": "Tóm tắt Đơn hàng",


### PR DESCRIPTION
…fit cancellation

- Replace updatePost orderSummarySection with the richer create-post version: stacked layout, profile API for contact info, map preview, payment breakdown, Typography design tokens
- Add X button next to applied-benefit chip so users can unapply without reopening the dialog; also pass selectedBenefitIds to the dialog so it pre-selects the active benefit on open
- Enable the dialog Apply button when no benefit is selected (changed text to "Huỷ áp dụng") so deselecting inside the dialog also works
- Add removePromotion and benefit.clearBenefit i18n keys (vi + en)