### PR TITLE
feat(membership): sync FE with BE renewal/upgrade queued-slot redesign

### DIFF
--- a/src/api/types/membership.type.ts
+++ b/src/api/types/membership.type.ts
@@ -117,7 +117,16 @@ export type GetPackagesResponse = Membership[]
 
 export interface GetPackageByIdResponse extends Membership {}
 
-export interface GetMyMembershipResponse extends UserMembership {}
+// A user can hold at most two ACTIVE membership records at once:
+//   - current: startDate <= NOW() < endDate  (in use right now, benefits granted)
+//   - queued:  startDate > NOW()             (waiting to start when current expires, no benefits yet)
+// Both may be null. Renewal creates a queued slot instead of replacing current.
+export interface MyMembershipResponse {
+  readonly current: UserMembership | null
+  readonly queued: UserMembership | null
+}
+
+export interface GetMyMembershipResponse extends MyMembershipResponse {}
 
 export type GetMembershipHistoryResponse = UserMembership[]
 
@@ -168,11 +177,15 @@ export interface NewBenefit {
   readonly createdAt?: string
 }
 
+// "CURRENT" = upgrading the active slot immediately (no queued slot exists)
+// "QUEUED"  = upgrading the queued slot, active slot stays untouched
+export type UpgradeContext = 'CURRENT' | 'QUEUED'
+
 export interface UpgradePreview {
   readonly currentMembershipId?: number
   readonly currentPackageName?: string
   readonly currentPackageLevel?: string
-  readonly daysRemaining?: number
+  readonly daysRemaining?: number | null
   readonly targetMembershipId?: number
   readonly targetPackageName?: string
   readonly targetPackageLevel?: string
@@ -183,6 +196,7 @@ export interface UpgradePreview {
   readonly discountPercentage?: number
   readonly forfeitedBenefits?: ForfeitedBenefit[]
   readonly newBenefits?: NewBenefit[]
+  readonly upgradeContext?: UpgradeContext
   readonly eligible: boolean
   readonly ineligibilityReason: string | null
 }
@@ -193,6 +207,9 @@ export interface UpgradeRequest {
 }
 
 export interface UpgradeResponse {
+  readonly upgradeContext?: UpgradeContext
+  // When the upgraded tier will activate — non-null only when upgradeContext is "QUEUED"
+  readonly activationDate?: string | null
   readonly transactionRef: string
   readonly paymentUrl: string | null
   readonly paymentProvider: string
@@ -221,6 +238,19 @@ export interface RenewalRequest {
 // PaymentResponse is reused for renewal (same shape as purchase/upgrade payment)
 export type InitiateRenewalResponse = PurchaseMembershipResponse
 
+// BE DomainCode QUEUED_MEMBERSHIP_EXISTS ("14009") — thrown by initiate-renewal
+// when the user already has a queued slot waiting to activate.
+export const QUEUED_MEMBERSHIP_EXISTS_CODE = '14009'
+
+export class QueuedMembershipExistsError extends Error {
+  readonly code = QUEUED_MEMBERSHIP_EXISTS_CODE
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'QueuedMembershipExistsError'
+  }
+}
+
 export type ExpiryUrgency = 'none' | 'warning' | 'danger' | 'critical'
 
 export function getExpiryUrgency(
@@ -236,7 +266,9 @@ export function getExpiryUrgency(
 
 export function canRenewMembership(
   membership: UserMembership | null | undefined,
+  queued?: UserMembership | null,
 ): boolean {
+  if (queued) return false // queued slot already taken — only one allowed
   if (!membership) return false
   if (
     membership.status === MembershipStatus.ACTIVE &&

--- a/src/components/molecules/dashboardMembershipCard/index.tsx
+++ b/src/components/molecules/dashboardMembershipCard/index.tsx
@@ -25,6 +25,7 @@ import {
   MembershipStatus,
   BenefitStatus,
   PaymentProvider,
+  QueuedMembershipExistsError,
 } from '@/api/types/membership.type'
 import { format } from 'date-fns'
 import { motion } from 'framer-motion'
@@ -34,7 +35,9 @@ import RenewMembershipDialog from '@/components/molecules/renewMembershipDialog'
 const DashboardMembershipCard: React.FC = () => {
   const t = useTranslations('seller.dashboard.membership')
   const { user } = useAuth()
-  const { data: membership, isLoading } = useMyMembership(user?.userId)
+  const { data, isLoading } = useMyMembership(user?.userId)
+  const membership = data?.current ?? null
+  const queued = data?.queued ?? null
   const renewalMutation = useInitiateRenewal()
   const [renewDialogOpen, setRenewDialogOpen] = React.useState(false)
 
@@ -48,7 +51,11 @@ const DashboardMembershipCard: React.FC = () => {
       {
         onError: (err) => {
           toast.error(
-            err instanceof Error ? err.message : t('renewDialog.errorMessage'),
+            err instanceof QueuedMembershipExistsError
+              ? t('alreadyQueued')
+              : err instanceof Error
+                ? err.message
+                : t('renewDialog.errorMessage'),
           )
         },
       },
@@ -67,6 +74,34 @@ const DashboardMembershipCard: React.FC = () => {
         <CardContent>
           <div className='flex items-center justify-center py-8'>
             <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!membership && queued) {
+    return (
+      <Card className='relative overflow-hidden'>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2'>
+            <Crown className='h-5 w-5 text-primary' />
+            {t('title')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className='flex items-center gap-3 p-3 rounded-lg bg-muted border border-border'>
+            <Badge variant='secondary'>{t('queuedBadge')}</Badge>
+            <div className='flex-1 min-w-0'>
+              <p className='text-sm font-semibold text-foreground'>
+                {queued.packageName}
+              </p>
+              <p className='text-xs text-muted-foreground'>
+                {t('queuedActivatesOn', {
+                  date: format(new Date(queued.startDate), 'dd/MM/yyyy'),
+                })}
+              </p>
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -267,7 +302,7 @@ const DashboardMembershipCard: React.FC = () => {
               {format(new Date(membership.endDate), 'dd/MM/yyyy')}
             </p>
           </div>
-          {isActive && (
+          {isActive && !queued && (
             <Button
               size='sm'
               variant='outline'
@@ -279,6 +314,30 @@ const DashboardMembershipCard: React.FC = () => {
             </Button>
           )}
         </motion.div>
+
+        {/* Queued membership (renewal already purchased, waiting to activate) */}
+        {queued && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.25 }}
+            className='flex items-center gap-3 p-3 rounded-lg bg-muted/60 border border-dashed border-border'
+          >
+            <Badge variant='secondary' className='shrink-0'>
+              {t('queuedBadge')}
+            </Badge>
+            <div className='flex-1 min-w-0'>
+              <p className='text-sm font-semibold text-foreground truncate'>
+                {queued.packageName}
+              </p>
+              <p className='text-xs text-muted-foreground'>
+                {t('queuedActivatesOn', {
+                  date: format(new Date(queued.startDate), 'dd/MM/yyyy'),
+                })}
+              </p>
+            </div>
+          </motion.div>
+        )}
 
         {/* Days Remaining */}
         {isActive && membership.daysRemaining > 0 && (

--- a/src/components/molecules/dashboardMembershipNavCard/index.tsx
+++ b/src/components/molecules/dashboardMembershipNavCard/index.tsx
@@ -18,7 +18,8 @@ import { Typography } from '@/components/atoms/typography'
 const DashboardMembershipNavCard: React.FC = () => {
   const t = useTranslations('seller.dashboard.membership')
   const { user } = useAuth()
-  const { data: membership } = useMyMembership(user?.userId)
+  const { data: myMembership } = useMyMembership(user?.userId)
+  const membership = myMembership?.current ?? null
 
   const features = [
     {

--- a/src/components/molecules/listings/MembershipPushDisplay.tsx
+++ b/src/components/molecules/listings/MembershipPushDisplay.tsx
@@ -1,18 +1,14 @@
 import React from 'react'
 import { Skeleton } from '@/components/atoms/skeleton'
 import { cn } from '@/lib/utils'
-import {
-  BenefitType,
-  BenefitStatus,
-  GetMyMembershipResponse,
-} from '@/api/types'
+import { BenefitType, BenefitStatus, UserMembership } from '@/api/types'
 import { format } from 'date-fns'
 import { motion } from 'framer-motion'
 import { Zap, Calendar, Crown } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 interface MembershipPushDisplayProps {
-  membershipData: GetMyMembershipResponse | null | undefined
+  membershipData: UserMembership | null | undefined
   isLoading: boolean
   className?: string
 }

--- a/src/components/molecules/renewListingDialog/index.tsx
+++ b/src/components/molecules/renewListingDialog/index.tsx
@@ -81,7 +81,8 @@ export const RenewListingDialog: React.FC<RenewListingDialogProps> = ({
 }) => {
   const t = useTranslations('seller.listingManagement.card.renewDialog')
   const { user } = useAuthContext()
-  const { data: membership } = useMyMembership(user?.userId)
+  const { data: myMembership } = useMyMembership(user?.userId)
+  const membership = myMembership?.current ?? null
 
   const listingVipType = (listing?.vipType ?? 'NORMAL') as VipType
   const tier = isRenewableTier(listingVipType) ? listingVipType : null

--- a/src/components/molecules/repostListingDialog/index.tsx
+++ b/src/components/molecules/repostListingDialog/index.tsx
@@ -128,7 +128,8 @@ export const RepostListingDialog: React.FC<RepostListingDialogProps> = ({
 }) => {
   const t = useTranslations('seller.listingManagement.card.repostDialog')
   const { user } = useAuthContext()
-  const { data: membership } = useMyMembership(user?.userId)
+  const { data: myMembership } = useMyMembership(user?.userId)
+  const membership = myMembership?.current ?? null
   const { language } = useLanguage()
 
   const initialDuration: DurationDays = React.useMemo(() => {

--- a/src/components/molecules/upgradeCard/index.tsx
+++ b/src/components/molecules/upgradeCard/index.tsx
@@ -61,6 +61,7 @@ const UpgradeCard: React.FC<UpgradeCardProps> = ({
   const targetLevel = upgrade.targetPackageLevel as MembershipPackageLevel
   const targetIcon = getMembershipLevelIcon(targetLevel)
   const targetIconTile = getMembershipLevelTileClasses(targetLevel)
+  const isQueuedContext = upgrade.upgradeContext === 'QUEUED'
 
   const cardVariants = {
     hidden: { opacity: 0, y: 8 },
@@ -121,10 +122,14 @@ const UpgradeCard: React.FC<UpgradeCardProps> = ({
                       variant='small'
                       className='text-muted-foreground'
                     >
-                      {t('discountExplanation.description', {
-                        days: upgrade.daysRemaining || 0,
-                        percent: upgrade.discountPercentage.toFixed(1),
-                      })}
+                      {isQueuedContext
+                        ? t('discountExplanation.descriptionQueued', {
+                            percent: upgrade.discountPercentage.toFixed(1),
+                          })
+                        : t('discountExplanation.description', {
+                            days: upgrade.daysRemaining || 0,
+                            percent: upgrade.discountPercentage.toFixed(1),
+                          })}
                     </Typography>
                     <div className='flex items-start gap-2 pt-2 border-t border-border'>
                       <Zap className='size-3.5 text-primary flex-shrink-0 mt-0.5' />
@@ -156,21 +161,29 @@ const UpgradeCard: React.FC<UpgradeCardProps> = ({
               <Typography variant='h3' className='font-semibold'>
                 {upgrade.targetPackageName}
               </Typography>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className='flex items-center gap-1.5 text-muted-foreground cursor-help mx-auto w-fit'>
-                    <Typography variant='small' className='text-sm'>
-                      {t('daysRemaining', { days: upgrade.daysRemaining || 0 })}
+              {isQueuedContext ? (
+                <Badge variant='outline' className='text-xs font-medium'>
+                  {t('queuedBadge')}
+                </Badge>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className='flex items-center gap-1.5 text-muted-foreground cursor-help mx-auto w-fit'>
+                      <Typography variant='small' className='text-sm'>
+                        {t('daysRemaining', {
+                          days: upgrade.daysRemaining || 0,
+                        })}
+                      </Typography>
+                      <Info className='size-3' />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side='bottom' className='max-w-xs'>
+                    <Typography variant='small'>
+                      {t('remainingTimeExplanation')}
                     </Typography>
-                    <Info className='size-3' />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side='bottom' className='max-w-xs'>
-                  <Typography variant='small'>
-                    {t('remainingTimeExplanation')}
-                  </Typography>
-                </TooltipContent>
-              </Tooltip>
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
 
             <div className='flex items-center gap-2 text-muted-foreground bg-muted/50 border border-border px-2.5 py-1 rounded-md'>

--- a/src/components/molecules/upgradePreviewModal/index.tsx
+++ b/src/components/molecules/upgradePreviewModal/index.tsx
@@ -81,6 +81,7 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
   const formattedFinalPrice = formatByLocale(preview.finalPrice || 0, 'vi')
 
   const isFreeUpgrade = (preview.finalPrice || 0) === 0
+  const isQueuedContext = preview.upgradeContext === 'QUEUED'
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
@@ -125,7 +126,11 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
                     {preview.currentPackageName}
                   </Typography>
                   <Typography variant='small' className='text-muted-foreground'>
-                    {t('daysRemaining', { days: preview.daysRemaining || 0 })}
+                    {isQueuedContext
+                      ? t('queuedBadge')
+                      : t('daysRemaining', {
+                          days: preview.daysRemaining || 0,
+                        })}
                   </Typography>
                 </div>
                 <ArrowRight className='size-5 text-primary flex-shrink-0' />

--- a/src/components/organisms/createPostSections/orderSummarySection.tsx
+++ b/src/components/organisms/createPostSections/orderSummarySection.tsx
@@ -53,7 +53,8 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
 
   const { data: vipTiers = [] } = useVipTiers()
   const { user } = useAuthContext()
-  const { data: myMembership } = useMyMembership(user?.userId)
+  const { data: myMembershipData } = useMyMembership(user?.userId)
+  const myMembership = myMembershipData?.current ?? null
 
   const { data: profileResponse, isLoading: isCheckingProfile } = useQuery({
     queryKey: ['create-post-order-summary-profile', user?.userId],

--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -66,8 +66,9 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
   const { data: vipTiers = [], isLoading, isError, error } = useVipTiers()
 
   const userId = useMemo(() => user?.userId, [user?.userId])
-  const { data: membership, isLoading: isMembershipLoading } =
+  const { data: myMembership, isLoading: isMembershipLoading } =
     useMyMembership(userId)
+  const membership = myMembership?.current ?? null
 
   const [benefitDialogOpen, setBenefitDialogOpen] = useState(false)
 

--- a/src/components/organisms/updatePostSections/orderSummarySection.tsx
+++ b/src/components/organisms/updatePostSections/orderSummarySection.tsx
@@ -53,7 +53,8 @@ const OrderSummarySection: React.FC<OrderSummarySectionProps> = ({
 
   const { data: vipTiers = [] } = useVipTiers()
   const { user } = useAuthContext()
-  const { data: myMembership } = useMyMembership(user?.userId)
+  const { data: myMembershipData } = useMyMembership(user?.userId)
+  const myMembership = myMembershipData?.current ?? null
 
   const { data: profileResponse, isLoading: isCheckingProfile } = useQuery({
     queryKey: ['update-post-order-summary-profile', user?.userId],

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -60,8 +60,9 @@ const ListingsWithPagination = () => {
     refetch,
   } = useListContext<ListingOwnerDetail>()
   const { user } = useAuthContext()
-  const { data: membershipData, isLoading: isMembershipLoading } =
+  const { data: myMembership, isLoading: isMembershipLoading } =
     useMyMembership(user?.userId)
+  const membershipData = myMembership?.current ?? null
   const { data: quotaData, refetch: refetchQuota } = usePushQuota()
   const pushMutation = usePushListing()
   const isMobile = useIsMobile()

--- a/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
@@ -17,6 +17,7 @@ import {
   canRenewMembership,
   getExpiryUrgency,
   MembershipStatus,
+  QueuedMembershipExistsError,
 } from '@/api/types/membership.type'
 import { useDialog } from '@/hooks/useDialog'
 import PaymentMethodDialog from '@/components/molecules/paymentMethodDialog'
@@ -92,12 +93,14 @@ const URGENCY_BADGE_CLASSES = {
 
 interface RenewalTabContentProps {
   membership: UserMembership
+  queued: UserMembership | null
   onRenewClick: () => void
   isRenewing: boolean
 }
 
 const RenewalTabContent: React.FC<RenewalTabContentProps> = ({
   membership,
+  queued,
   onRenewClick,
   isRenewing,
 }) => {
@@ -237,26 +240,47 @@ const RenewalTabContent: React.FC<RenewalTabContentProps> = ({
             </div>
           </div>
 
-          {/* Renewal note */}
-          <div className='flex items-start gap-2.5 p-3.5 rounded-lg bg-primary/5 border border-primary/15'>
-            <CheckCircle2 className='size-4 text-primary mt-0.5 flex-shrink-0' />
-            <Typography variant='small' className='text-muted-foreground'>
-              {tPage('renewal.renewalNote')}
-            </Typography>
-          </div>
+          {queued ? (
+            /* Already has a queued slot — renewal is not allowed until it activates */
+            <div className='flex items-start gap-2.5 p-3.5 rounded-lg bg-muted/40 border border-border'>
+              <RefreshCw className='size-4 text-muted-foreground mt-0.5 flex-shrink-0' />
+              <div className='space-y-0.5'>
+                <Typography variant='small' className='font-semibold'>
+                  {queued.packageName}
+                </Typography>
+                <Typography variant='small' className='text-muted-foreground'>
+                  {tPage('renewal.alreadyQueuedNote', {
+                    date: format(new Date(queued.startDate), 'dd/MM/yyyy'),
+                  })}
+                </Typography>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Renewal note */}
+              <div className='flex items-start gap-2.5 p-3.5 rounded-lg bg-primary/5 border border-primary/15'>
+                <CheckCircle2 className='size-4 text-primary mt-0.5 flex-shrink-0' />
+                <Typography variant='small' className='text-muted-foreground'>
+                  {tPage('renewal.renewalNote')}
+                </Typography>
+              </div>
 
-          {/* CTA */}
-          <Button
-            onClick={onRenewClick}
-            disabled={isRenewing}
-            size='lg'
-            className='w-full gap-2'
-          >
-            <RefreshCw className={cn('size-4', isRenewing && 'animate-spin')} />
-            {isRenewing
-              ? tPage('renewal.renewButtonLoading')
-              : tPage('renewal.renewButton')}
-          </Button>
+              {/* CTA */}
+              <Button
+                onClick={onRenewClick}
+                disabled={isRenewing}
+                size='lg'
+                className='w-full gap-2'
+              >
+                <RefreshCw
+                  className={cn('size-4', isRenewing && 'animate-spin')}
+                />
+                {isRenewing
+                  ? tPage('renewal.renewButtonLoading')
+                  : tPage('renewal.renewButton')}
+              </Button>
+            </>
+          )}
         </CardContent>
       </Card>
     </motion.div>
@@ -299,8 +323,11 @@ export const MembershipRegisterTemplate: React.FC = () => {
     error: membershipError,
   } = useMembershipPackages()
 
-  const { data: currentMembership, isLoading: checkingMembership } =
-    useMyMembership(user?.userId)
+  const { data: myMembership, isLoading: checkingMembership } = useMyMembership(
+    user?.userId,
+  )
+  const currentMembership = myMembership?.current ?? null
+  const queuedMembership = myMembership?.queued ?? null
 
   const {
     data: upgrades = [],
@@ -314,9 +341,10 @@ export const MembershipRegisterTemplate: React.FC = () => {
 
   // Derive display mode
   const hasMembership = !!currentMembership
-  const canRenew = canRenewMembership(
-    currentMembership as UserMembership | null,
-  )
+  const canRenew = canRenewMembership(currentMembership, queuedMembership)
+  // All upgrade options share the same context: "QUEUED" when the user has a
+  // queued slot (upgrade targets it, current stays untouched), "CURRENT" otherwise.
+  const upgradeContext = upgrades[0]?.upgradeContext ?? 'CURRENT'
   const isLoading = checkingMembership || membershipLoading || upgradesLoading
   const hasError = membershipError || upgradesError
 
@@ -481,9 +509,11 @@ export const MembershipRegisterTemplate: React.FC = () => {
         handleClosePayment()
       } catch (error) {
         toast.error(
-          error instanceof Error
-            ? error.message
-            : tPage('errors.renewalFailed'),
+          error instanceof QueuedMembershipExistsError
+            ? tPage('errors.queuedExists')
+            : error instanceof Error
+              ? error.message
+              : tPage('errors.renewalFailed'),
         )
       }
     },
@@ -808,6 +838,22 @@ export const MembershipRegisterTemplate: React.FC = () => {
             </motion.div>
           </AnimatePresence>
 
+          {queuedMembership && (
+            <Alert>
+              <Clock className='size-4' />
+              <AlertTitle>{tPage('queued.title')}</AlertTitle>
+              <AlertDescription>
+                {tPage('queued.activatesOn', {
+                  date: format(
+                    new Date(queuedMembership.startDate),
+                    'dd/MM/yyyy',
+                  ),
+                })}{' '}
+                — {queuedMembership.packageName}
+              </AlertDescription>
+            </Alert>
+          )}
+
           <motion.div
             key='purchase-content'
             initial={{ opacity: 0, y: 12 }}
@@ -832,14 +878,37 @@ export const MembershipRegisterTemplate: React.FC = () => {
   }
 
   // ── Membership exists: show tabs ──
-  // Tabs to show: always show upgrade tab; show renewal tab if eligible
-  const showRenewalTab = canRenew
+  // Tabs to show: always show upgrade tab; show renewal tab if eligible for
+  // renewal, or if there's already a queued slot to display info about.
+  const showRenewalTab = canRenew || !!queuedMembership
 
   const handlePaymentMethod = (provider: PaymentProvider) => {
     if (activeTab === 'renewal') return handleRenewalSelectMethod(provider)
     if (activeTab === 'upgrade') return handleUpgradeSelectMethod(provider)
     return handlePurchaseSelectMethod(provider)
   }
+
+  // Tells the user upfront whether the upgrade they're about to pick targets
+  // the queued slot (current untouched) or replaces the current slot immediately.
+  const upgradeContextBanner = upgrades.length > 0 && (
+    <Alert className='max-w-3xl mx-auto' variant='default'>
+      <ArrowRight className='size-4' />
+      <AlertTitle>
+        {upgradeContext === 'QUEUED'
+          ? tUpgrade('context.queuedBanner.title')
+          : tUpgrade('context.currentBanner.title')}
+      </AlertTitle>
+      <AlertDescription>
+        {upgradeContext === 'QUEUED'
+          ? tUpgrade('context.queuedBanner.description', {
+              date: queuedMembership
+                ? format(new Date(queuedMembership.startDate), 'dd/MM/yyyy')
+                : '',
+            })
+          : tUpgrade('context.currentBanner.description')}
+      </AlertDescription>
+    </Alert>
+  )
 
   return (
     <>
@@ -898,7 +967,8 @@ export const MembershipRegisterTemplate: React.FC = () => {
                 >
                   {currentMembership ? (
                     <RenewalTabContent
-                      membership={currentMembership as UserMembership}
+                      membership={currentMembership}
+                      queued={queuedMembership}
                       onRenewClick={handleOpenPayment}
                       isRenewing={renewalMutation.isPending}
                     />
@@ -907,7 +977,7 @@ export const MembershipRegisterTemplate: React.FC = () => {
               </AnimatePresence>
             </TabsContent>
 
-            <TabsContent value='upgrade' className='mt-6'>
+            <TabsContent value='upgrade' className='mt-6 flex flex-col gap-6'>
               <AnimatePresence mode='wait'>
                 <motion.div
                   key='upgrade-content'
@@ -915,7 +985,9 @@ export const MembershipRegisterTemplate: React.FC = () => {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -12 }}
                   transition={{ duration: 0.3, ease: 'easeOut' }}
+                  className='flex flex-col gap-6'
                 >
+                  {upgradeContextBanner}
                   {renderUpgradeGrid()}
                 </motion.div>
               </AnimatePresence>
@@ -929,7 +1001,9 @@ export const MembershipRegisterTemplate: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -12 }}
               transition={{ duration: 0.35, ease: 'easeOut' }}
+              className='flex flex-col gap-6'
             >
+              {upgradeContextBanner}
               {renderUpgradeGrid()}
             </motion.div>
           </AnimatePresence>

--- a/src/hooks/useMembership/index.ts
+++ b/src/hooks/useMembership/index.ts
@@ -4,6 +4,10 @@ import type {
   PurchaseMembershipRequest,
   RenewalRequest,
 } from '@/api/types/membership.type'
+import {
+  QUEUED_MEMBERSHIP_EXISTS_CODE,
+  QueuedMembershipExistsError,
+} from '@/api/types/membership.type'
 import { startGatewayCheckout } from '@/utils/payment'
 
 // Export upgrade hooks
@@ -134,6 +138,9 @@ export const useInitiateRenewal = () => {
     }) => {
       const response = await MembershipService.initiateRenewal(request, userId)
       if (!response.success || !response.data) {
+        if (response.code === QUEUED_MEMBERSHIP_EXISTS_CODE) {
+          throw new QueuedMembershipExistsError(response.message || '')
+        }
         throw new Error(response.message || 'Failed to initiate renewal')
       }
       return response.data

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1885,7 +1885,8 @@
       "purchaseFailed": "An error occurred while registering the package",
       "alreadyHasMembership": "You already have an active membership. Please use the upgrade feature instead.",
       "renewalFailed": "Unable to renew. Please try again.",
-      "renewalNotEligible": "Your plan is not currently eligible for renewal."
+      "renewalNotEligible": "Your plan is not currently eligible for renewal.",
+      "queuedExists": "You already have a queued package. Please wait for it to activate before renewing again."
     },
     "success": {
       "purchaseSuccess": "Package registered successfully!"
@@ -1902,6 +1903,10 @@
     "purchaseButton": "Purchase Membership",
     "noMembership": "You don't have an active membership yet.",
     "alreadyHasMembership": "You already have an active membership. Redirecting to upgrade page...",
+    "queued": {
+      "title": "Queued Package",
+      "activatesOn": "Activates on {date}"
+    },
     "renewal": {
       "title": "Renew Your Membership",
       "subtitle": "Renew your {packageName} plan for another month at the current price.",
@@ -1919,14 +1924,26 @@
         "danger": "Your plan has very little time left — renew now!",
         "critical": "Your plan just expired — renew now to restore your benefits."
       },
-      "renewalNote": "Your new plan will start immediately after your current plan ends. No days lost."
+      "renewalNote": "Your new plan will start immediately after your current plan ends. No days lost.",
+      "alreadyQueuedNote": "You already have a queued package activating on {date}. You cannot renew again until it starts."
     }
   },
   "membershipUpgrade": {
     "title": "Upgrade Your Membership",
     "subtitle": "Choose a higher-tier membership and get a discount based on your remaining membership time.",
+    "context": {
+      "queuedBanner": {
+        "title": "Upgrading Your Queued Package",
+        "description": "Your current plan is not affected. The new plan will activate on {date}."
+      },
+      "currentBanner": {
+        "title": "Upgrade Applies Immediately",
+        "description": "Your current plan will be replaced right away. You get a discount based on your remaining time."
+      }
+    },
     "savePercent": "Save {percent}%",
     "daysRemaining": "{days} days remaining in your current plan",
+    "queuedBadge": "Queued",
     "upgradingFrom": "Upgrade from {currentPlan}",
     "originalPrice": "Original Price",
     "discount": "Your Discount",
@@ -1943,6 +1960,7 @@
     "discountExplanation": {
       "title": "Smart Discount Applied",
       "description": "You have {days} days remaining in your current plan. We're giving you a {percent}% discount so you don't lose that value when upgrading!",
+      "descriptionQueued": "This is a queued package that hasn't activated yet. The {percent}% discount is exactly what you already paid for this queued package.",
       "howItWorks": "Your discount is calculated based on the unused time in your current membership. The more time remaining, the bigger your discount.",
       "savings": "Total savings: {amount}"
     },
@@ -2446,6 +2464,9 @@
           }
         },
         "renewButton": "Renew Package",
+        "queuedBadge": "Queued",
+        "queuedActivatesOn": "Activates on {date}",
+        "alreadyQueued": "You already have a queued package. Please wait for it to activate before renewing again.",
         "renewDialog": {
           "title": "Renew Membership",
           "description": "Renew your current package for another month. You will be redirected to the payment gateway.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2180,7 +2180,8 @@
       "purchaseFailed": "Đã có lỗi xảy ra khi đăng ký gói",
       "alreadyHasMembership": "Bạn đã có gói hội viên đang hoạt động. Vui lòng sử dụng tính năng nâng cấp.",
       "renewalFailed": "Không thể gia hạn. Vui lòng thử lại.",
-      "renewalNotEligible": "Gói của bạn không đủ điều kiện gia hạn lúc này."
+      "renewalNotEligible": "Gói của bạn không đủ điều kiện gia hạn lúc này.",
+      "queuedExists": "Bạn đã có gói chờ kích hoạt. Vui lòng đợi gói đó kích hoạt trước khi gia hạn tiếp."
     },
     "success": {
       "purchaseSuccess": "Đã đăng ký gói thành công!"
@@ -2197,6 +2198,10 @@
     "purchaseButton": "Mua gói hội viên",
     "noMembership": "Bạn chưa có gói hội viên nào.",
     "alreadyHasMembership": "Bạn đã có gói hội viên đang hoạt động. Đang chuyển đến trang nâng cấp...",
+    "queued": {
+      "title": "Gói chờ kích hoạt",
+      "activatesOn": "Kích hoạt ngày {date}"
+    },
     "renewal": {
       "title": "Gia hạn gói thành viên",
       "subtitle": "Gia hạn gói {packageName} thêm 1 tháng với giá hiện hành.",
@@ -2214,14 +2219,26 @@
         "danger": "Gói còn rất ít thời gian — gia hạn ngay!",
         "critical": "Gói vừa hết hạn — gia hạn ngay để khôi phục quyền lợi."
       },
-      "renewalNote": "Gói mới sẽ bắt đầu ngay sau ngày hết hạn của gói hiện tại. Không bị mất ngày."
+      "renewalNote": "Gói mới sẽ bắt đầu ngay sau ngày hết hạn của gói hiện tại. Không bị mất ngày.",
+      "alreadyQueuedNote": "Bạn đã có gói chờ kích hoạt vào ngày {date}. Không thể gia hạn thêm cho đến khi gói đó bắt đầu."
     }
   },
   "membershipUpgrade": {
     "title": "Nâng cấp gói hội viên",
     "subtitle": "Chọn gói hội viên cao cấp hơn và nhận chiết khấu dựa trên thời gian còn lại của gói hiện tại.",
+    "context": {
+      "queuedBanner": {
+        "title": "Nâng cấp gói chờ",
+        "description": "Gói hiện tại của bạn không bị ảnh hưởng. Gói mới sẽ kích hoạt vào {date}."
+      },
+      "currentBanner": {
+        "title": "Nâng cấp áp dụng ngay",
+        "description": "Gói hiện tại của bạn sẽ được thay thế ngay lập tức. Bạn nhận chiết khấu dựa trên thời gian còn lại."
+      }
+    },
     "savePercent": "Tiết kiệm {percent}%",
     "daysRemaining": "Còn {days} ngày trong gói hiện tại",
+    "queuedBadge": "Gói chờ",
     "upgradingFrom": "Nâng cấp từ {currentPlan}",
     "originalPrice": "Giá gốc",
     "discount": "Chiết khấu của bạn",
@@ -2238,6 +2255,7 @@
     "discountExplanation": {
       "title": "Chiết khấu thông minh",
       "description": "Bạn còn {days} ngày trong gói hiện tại. Chúng tôi tặng bạn chiết khấu {percent}% để bạn không bị mất giá trị khi nâng cấp!",
+      "descriptionQueued": "Đây là gói chờ chưa kích hoạt. Chiết khấu {percent}% chính là số tiền bạn đã thanh toán cho gói chờ này.",
       "howItWorks": "Chiết khấu của bạn được tính dựa trên thời gian chưa sử dụng trong gói hội viên hiện tại. Thời gian còn lại càng nhiều, chiết khấu càng lớn.",
       "savings": "Tổng tiết kiệm: {amount}"
     },
@@ -2446,6 +2464,9 @@
           }
         },
         "renewButton": "Gia hạn gói",
+        "queuedBadge": "Đang chờ kích hoạt",
+        "queuedActivatesOn": "Kích hoạt ngày {date}",
+        "alreadyQueued": "Bạn đã có gói chờ kích hoạt. Vui lòng đợi gói đó kích hoạt trước khi gia hạn tiếp.",
         "renewDialog": {
           "title": "Gia hạn gói hội viên",
           "description": "Gia hạn gói hiện tại của bạn thêm 1 tháng. Bạn sẽ được chuyển đến cổng thanh toán.",

--- a/src/pages/sellernet/membership/index.tsx
+++ b/src/pages/sellernet/membership/index.tsx
@@ -18,7 +18,8 @@ const MembershipPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { user } = useAuthContext()
 
-  const { data: membership, isLoading } = useMyMembership(user?.userId)
+  const { data: myMembership, isLoading } = useMyMembership(user?.userId)
+  const membership = myMembership?.current ?? null
 
   const pageTitle = useMemo(() => `${tPage('title')} – Sellernet`, [tPage])
 


### PR DESCRIPTION
BE now returns { current, queued } from GET /my-membership instead of a single membership object — renewal enqueues the next period as a queued ACTIVE slot rather than replacing the current one. Update every consumer to read .current, add queued-slot UI (dashboard card, membership page, renewal tab), gate the renew action on queued absence, surface the new 14009 (queued already exists) error, and distinguish CURRENT vs QUEUED upgrade context in the upgrade grid/preview.