### PR TITLE
feat(compare): remove expired listings from compare list on page load

### DIFF
--- a/src/components/templates/compareTemplate/index.tsx
+++ b/src/components/templates/compareTemplate/index.tsx
@@ -1,16 +1,26 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { GitCompare, Trash2 } from 'lucide-react'
 
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/atoms/dialog'
 import { PageContainer } from '@/components/atoms/pageContainer'
 import { Typography } from '@/components/atoms/typography'
 import CompareTable from '@/components/organisms/compareTable'
 import EmptyCompareState from '@/components/organisms/emptyCompareState'
 import { useCompareStore } from '@/store/compare/useCompareStore'
+import { ListingService } from '@/api/services/listing.service'
+import { POST_STATUS } from '@/api/types/property.type'
 
 /**
  * CompareTemplate
@@ -19,13 +29,49 @@ import { useCompareStore } from '@/store/compare/useCompareStore'
  */
 const CompareTemplate: React.FC = () => {
   const t = useTranslations('compare')
-  const { compareList, clearCompare } = useCompareStore()
+  const { compareList, clearCompare, removeFromCompare } = useCompareStore()
   const [isMounted, setIsMounted] = useState(false)
+  const [expiredTitles, setExpiredTitles] = useState<string[]>([])
+  const hasCheckedExpiry = useRef(false)
 
   // Handle hydration: Wait for Zustand store to hydrate from localStorage
   useEffect(() => {
     setIsMounted(true)
   }, [])
+
+  // Re-validate compare list against live listing status once, after hydration.
+  // Expired listings are silently stale in sessionStorage until we check.
+  useEffect(() => {
+    if (!isMounted || hasCheckedExpiry.current || compareList.length === 0) {
+      return
+    }
+    hasCheckedExpiry.current = true
+
+    const checkExpiredListings = async () => {
+      const responses = await Promise.all(
+        compareList.map((listing) => ListingService.getById(listing.listingId)),
+      )
+
+      const expired: string[] = []
+      responses.forEach((response, index) => {
+        const listing = compareList[index]
+        const isExpired =
+          response.data?.expired === true ||
+          response.data?.listingStatus === POST_STATUS.EXPIRED
+
+        if (isExpired) {
+          expired.push(listing.title)
+          removeFromCompare(listing.listingId)
+        }
+      })
+
+      if (expired.length > 0) {
+        setExpiredTitles(expired)
+      }
+    }
+
+    checkExpiredListings()
+  }, [isMounted, compareList, removeFromCompare])
 
   // Don't render until mounted to avoid hydration mismatch
   if (!isMounted) {
@@ -76,6 +122,34 @@ const CompareTemplate: React.FC = () => {
       ) : (
         <EmptyCompareState />
       )}
+
+      <Dialog
+        open={expiredTitles.length > 0}
+        onOpenChange={(open) => {
+          if (!open) setExpiredTitles([])
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('expiredDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('expiredDialog.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <ul className='list-disc pl-5 space-y-1'>
+            {expiredTitles.map((title) => (
+              <li key={title} className='text-sm text-foreground'>
+                {title}
+              </li>
+            ))}
+          </ul>
+          <DialogFooter>
+            <Button onClick={() => setExpiredTitles([])}>
+              {t('expiredDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </PageContainer>
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3934,6 +3934,11 @@
       "items": "{count} item",
       "items_plural": "{count} items",
       "compareNow": "Compare Now"
+    },
+    "expiredDialog": {
+      "title": "Some listings have expired",
+      "description": "The following listings have expired and were removed from your comparison:",
+      "confirm": "Got it"
     }
   },
   "notification": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3934,6 +3934,11 @@
       "items": "{count} tin",
       "items_plural": "{count} tin",
       "compareNow": "So sánh ngay"
+    },
+    "expiredDialog": {
+      "title": "Một số tin đã hết hạn",
+      "description": "Các tin sau đã hết hạn và đã được xoá khỏi danh sách so sánh:",
+      "confirm": "Đã hiểu"
     }
   },
   "notification": {


### PR DESCRIPTION
Fetch live status for each listing when the compare page mounts and drop any that have expired, showing a dialog listing what was removed so users aren't comparing against stale data cached in sessionStorage.