### PR TITLE
feat(seller-listings): add direct link to public listing detail

### DIFF
--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { RankDisplay } from '@/components/atoms/rank-display'
 import { VerificationBadge } from '@/components/atoms/verification-badge'
@@ -7,6 +8,12 @@ import { Badge } from '@/components/atoms/badge'
 import { Typography } from '@/components/atoms/typography'
 import { ListingCardActions } from '@/components/molecules/listingCardActions'
 import { Card, CardContent } from '@/components/atoms/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/atoms/tooltip'
 import { cn } from '@/lib/utils'
 import { toISO, formatISO } from '@/utils/date/safe'
 import { formatByLocale } from '@/utils/currency/convert'
@@ -18,9 +25,17 @@ import {
   ModerationStatusBadge,
   ModerationBanner,
 } from '@/components/molecules/moderation'
-import { MapPin, Calendar, Maximize2, Bed, Bath } from 'lucide-react'
+import {
+  MapPin,
+  Calendar,
+  Maximize2,
+  Bed,
+  Bath,
+  ExternalLink,
+} from 'lucide-react'
 import { DEFAULT_IMAGE } from '@/constants/common'
 import { AMENITIES_CONFIG } from '@/constants/amenities'
+import { buildApartmentDetailRoute } from '@/constants/route'
 import {
   Dialog,
   DialogContent,
@@ -211,6 +226,24 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 )}
                 {verified && (
                   <VerificationBadge verified={verified} type='verified' />
+                )}
+                {property.listingStatus === POST_STATUS.DISPLAYING && (
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Link
+                          href={buildApartmentDetailRoute(listingId.toString())}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          aria-label={t('viewListing')}
+                          className='inline-flex items-center justify-center w-6 h-6 rounded-full border border-border/60 text-muted-foreground hover:text-primary hover:border-primary/50 transition-colors'
+                        >
+                          <ExternalLink className='w-3.5 h-3.5' />
+                        </Link>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('viewListing')}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
                 {showRank && (
                   <RankDisplay rank={{ page: 1, position: rankOfVipType }} />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2681,6 +2681,7 @@
         "bathrooms": "Bathrooms",
         "amenities": "Amenities",
         "more": "more",
+        "viewListing": "View listing",
         "views": "Views",
         "contacts": "Contacts",
         "customers": "Customers",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2681,6 +2681,7 @@
         "bathrooms": "Phòng tắm",
         "amenities": "Tiện nghi",
         "more": "nữa",
+        "viewListing": "Xem tin đăng",
         "views": "Lượt xem",
         "contacts": "Liên hệ",
         "customers": "Khách hàng",


### PR DESCRIPTION
Show an external-link icon next to the verified badge on each seller listing card, but only for listings currently DISPLAYING, so sellers can jump straight to the live public page.