### PR TITLE
fix(i18n): add missing membershipUpgrade.preview.queuedBadge key

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1997,6 +1997,7 @@
       "description": "Review the details of your membership upgrade before confirming.",
       "currentPlan": "Current Plan",
       "newPlan": "New Plan",
+      "queuedBadge": "Queued",
       "daysRemaining": "{days} days remaining",
       "duration": "{days} days duration",
       "pricing": "Pricing",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2292,6 +2292,7 @@
       "description": "Xem lại chi tiết nâng cấp gói hội viên trước khi xác nhận.",
       "currentPlan": "Gói hiện tại",
       "newPlan": "Gói mới",
+      "queuedBadge": "Gói chờ",
       "daysRemaining": "Còn {days} ngày",
       "duration": "Thời hạn {days} ngày",
       "pricing": "Giá cả",


### PR DESCRIPTION
The upgrade preview dialog reads t('queuedBadge') from the membershipUpgrade.preview namespace, but the key only existed at the top-level membershipUpgrade namespace, leaving the badge untranslated.