### PR TITLE
fix(transactions): parse naive backend timestamps as UTC

### DIFF
--- a/src/utils/date/formatters.ts
+++ b/src/utils/date/formatters.ts
@@ -2,6 +2,22 @@
  * Date formatting utilities
  */
 
+const HAS_TIMEZONE_MARKER = /(Z|[+-]\d{2}:?\d{2})$/
+
+/**
+ * Backend timestamps (e.g. `created_at`) are UTC instants but some endpoints
+ * still serialize them as a naive `LocalDateTime` string with no `Z`/offset
+ * suffix (e.g. `2026-07-04T10:30:00`). `new Date()` parses a naive string as
+ * browser-local time instead of UTC, which shifts the displayed value by the
+ * viewer's UTC offset. Treat any string missing a timezone marker as UTC.
+ */
+const toDate = (dateString: string): Date => {
+  const normalized = HAS_TIMEZONE_MARKER.test(dateString)
+    ? dateString
+    : `${dateString}Z`
+  return new Date(normalized)
+}
+
 /**
  * Format date string to Vietnamese locale format
  * @param dateString - ISO date string or undefined
@@ -9,7 +25,7 @@
  */
 export const formatDate = (dateString?: string): string => {
   if (!dateString) return ''
-  return new Date(dateString).toLocaleDateString('vi-VN')
+  return toDate(dateString).toLocaleDateString('vi-VN')
 }
 
 /**
@@ -23,7 +39,7 @@ export const formatDateWithLocale = (
   locale: string = 'vi-VN',
 ): string => {
   if (!dateString) return ''
-  return new Date(dateString).toLocaleDateString(locale)
+  return toDate(dateString).toLocaleDateString(locale)
 }
 
 /**
@@ -37,7 +53,7 @@ export const formatDateTimeWithLocale = (
   locale: string = 'vi-VN',
 ): string => {
   if (!dateString) return ''
-  return new Date(dateString).toLocaleString(locale, {
+  return toDate(dateString).toLocaleString(locale, {
     dateStyle: 'short',
     timeStyle: 'short',
   })


### PR DESCRIPTION
Backend serializes created_at/completedAt/etc as a naive LocalDateTime string with no timezone marker even though the stored value is UTC. new Date() was interpreting that as browser-local time, shifting the displayed created_at on /seller/transactions by the viewer's UTC offset. Treat any timestamp string missing a Z/offset suffix as UTC before parsing.