### PR TITLE
fix(ui): widen upgrade preview dialog for longer plan names

### DIFF
--- a/src/components/molecules/upgradePreviewModal/index.tsx
+++ b/src/components/molecules/upgradePreviewModal/index.tsx
@@ -90,7 +90,7 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
           'flex flex-col p-0',
           isMobile
             ? 'w-full h-screen max-w-full rounded-none m-0'
-            : 'sm:max-w-[600px] max-h-[90vh]',
+            : 'sm:max-w-[640px] max-h-[90vh]',
         )}
         showCloseButton={!isLoading}
         onInteractOutside={(e) => {


### PR DESCRIPTION
The current/new plan cards split the dialog width evenly, so a longer package name (e.g. "Gói Tiêu Chuẩn") felt cramped. Bump the dialog's max width from 600px to 640px to give both cards more room.