### PR TITLE
fix(sellernet): make phone/tax/name optional on personal info edit

### DIFF
--- a/src/components/molecules/emailField/index.tsx
+++ b/src/components/molecules/emailField/index.tsx
@@ -20,6 +20,7 @@ interface EmailFieldProps {
   className?: string
   id?: string
   required?: boolean
+  disabled?: boolean
 }
 
 const EmailField = (props: EmailFieldProps) => {
@@ -34,6 +35,7 @@ const EmailField = (props: EmailFieldProps) => {
     control,
     placeholder,
     required = true,
+    disabled = false,
   } = props
 
   const t = useTranslations()
@@ -80,6 +82,7 @@ const EmailField = (props: EmailFieldProps) => {
         <Input
           {...field}
           id={fieldId}
+          disabled={disabled}
           placeholder={
             placeholder || t('homePage.auth.common.emailPlaceholder')
           }

--- a/src/components/molecules/personalInfoForm/index.tsx
+++ b/src/components/molecules/personalInfoForm/index.tsx
@@ -48,7 +48,11 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
     firstName: yup
       .string()
       .trim()
-      .required(t('homePage.auth.validation.firstNameRequired'))
+      .test(
+        'requiredIfHadValue',
+        t('homePage.auth.validation.firstNameRequired'),
+        (value) => !initialData?.firstName?.trim() || Boolean(value),
+      )
       .test(
         'notDefault',
         t('homePage.auth.validation.firstNameInvalid'),
@@ -57,7 +61,11 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
     lastName: yup
       .string()
       .trim()
-      .required(t('homePage.auth.validation.lastNameRequired'))
+      .test(
+        'requiredIfHadValue',
+        t('homePage.auth.validation.lastNameRequired'),
+        (value) => !initialData?.lastName?.trim() || Boolean(value),
+      )
       .test(
         'notDefault',
         t('homePage.auth.validation.lastNameInvalid'),
@@ -72,10 +80,19 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
       ),
     contactPhoneNumber: yup
       .string()
-      .required(t('homePage.auth.validation.phoneNumberRequired'))
-      .matches(VIETNAM_PHONE_REGEX, t('homePage.auth.validation.phoneInvalid')),
+      .trim()
+      .test(
+        'requiredIfHadValue',
+        t('homePage.auth.validation.phoneNumberRequired'),
+        (value) => !initialData?.contactPhoneNumber?.trim() || Boolean(value),
+      )
+      .matches(VIETNAM_PHONE_REGEX, {
+        message: t('homePage.auth.validation.phoneInvalid'),
+        excludeEmptyString: true,
+      }),
     idDocument: yup
       .string()
+      .trim()
       .optional()
       .test(
         'idDocumentMinLength',
@@ -185,7 +202,6 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
                   'homePage.auth.accountManagement.personalInfo.firstName',
                 ) /* Họ */
               }
-              required
               placeholder={t('homePage.auth.register.firstNamePlaceholder')}
               error={errors.firstName?.message}
               {...firstNameController.field}
@@ -196,7 +212,6 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
                   'homePage.auth.accountManagement.personalInfo.lastName',
                 ) /* Tên */
               }
-              required
               placeholder={t('homePage.auth.register.lastNamePlaceholder')}
               error={errors.lastName?.message}
               {...lastNameController.field}
@@ -211,7 +226,6 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
               label={t(
                 'homePage.auth.accountManagement.personalInfo.phoneNumber',
               )}
-              required
               placeholder={t('homePage.auth.common.phoneNumberPlaceholder')}
               error={errors.contactPhoneNumber?.message}
             />
@@ -220,6 +234,7 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
               control={control}
               label={t('homePage.auth.accountManagement.personalInfo.email')}
               required
+              disabled
               placeholder={t('homePage.auth.common.emailPlaceholder')}
               error={errors.email?.message}
             />

--- a/src/components/molecules/phoneField/index.tsx
+++ b/src/components/molecules/phoneField/index.tsx
@@ -20,6 +20,7 @@ interface PhoneFieldProps {
   className?: string
   id?: string
   required?: boolean
+  disabled?: boolean
 }
 
 const PhoneField = (props: PhoneFieldProps) => {
@@ -34,6 +35,7 @@ const PhoneField = (props: PhoneFieldProps) => {
     control,
     placeholder,
     required = false,
+    disabled = false,
   } = props
 
   const t = useTranslations()
@@ -79,6 +81,7 @@ const PhoneField = (props: PhoneFieldProps) => {
         <Input
           {...field}
           id={fieldId}
+          disabled={disabled}
           placeholder={
             placeholder || t('homePage.auth.common.phoneNumberPlaceholder')
           }

--- a/src/hooks/useAuth/useUpdateProfile.ts
+++ b/src/hooks/useAuth/useUpdateProfile.ts
@@ -100,13 +100,17 @@ export const useUpdateProfile = () => {
       // distinguish null vs missing here.
       setPhase('saving-profile')
       // Empty strings would otherwise hit the BE unique constraint on
-      // id_document / tax_number. Omitting the field tells PATCH to leave it.
+      // id_document / tax_number, or needlessly reset contactPhoneVerified
+      // on every save. Omitting the field tells PATCH to leave it unchanged.
+      // The form blocks submission if firstName/lastName/contactPhoneNumber
+      // were previously set and got cleared, so those only reach here blank
+      // when they never had a value to begin with.
       const response = await UserService.updateProfile({
-        firstName: data.firstName,
-        lastName: data.lastName,
+        firstName: data.firstName?.trim(),
+        lastName: data.lastName?.trim(),
         idDocument: data.idDocument?.trim() || undefined,
         taxNumber: data.taxNumber?.trim() || undefined,
-        contactPhoneNumber: data.contactPhoneNumber,
+        contactPhoneNumber: data.contactPhoneNumber?.trim() || undefined,
         avatarMediaId,
       })
 


### PR DESCRIPTION
Phone number, tax code (idDocument), first name and last name are no longer forced required on the seller personal-info edit form, matching the backend which already treats them as optional partial-update fields. A field can still not be cleared back to blank once it already had a value - only fields that started empty stay optional. Email is disabled since it isn't part of the profile update payload sent to the backend. Whitespace-only input is normalized via trim() so it can't slip past validation as real content.