### PR TITLE
fix(sellernet): trim email in personal info validation schema

### DIFF
--- a/src/components/molecules/personalInfoForm/index.tsx
+++ b/src/components/molecules/personalInfoForm/index.tsx
@@ -73,6 +73,7 @@ const PersonalInfoForm: React.FC<PersonalInfoFormProps> = ({
       ),
     email: yup
       .string()
+      .trim()
       .required(t('homePage.auth.validation.emailRequired'))
       .matches(
         VALIDATION_PATTERNS.EMAIL,


### PR DESCRIPTION
firstName, lastName, contactPhoneNumber and idDocument already trim before validating so whitespace-only input can't slip through as real content. email was missing the same trim() transform - add it for consistency across all fields on the form.