### PR TITLE
fix(report): stop leaking raw backend error message on unmapped repor…

### DIFF
--- a/src/components/molecules/reportListingDialog/index.tsx
+++ b/src/components/molecules/reportListingDialog/index.tsx
@@ -173,11 +173,7 @@ export const ReportListingDialog: React.FC<ReportListingDialogProps> = ({
             onOpenChange(false)
             setListingUnavailableOpen(true)
           } else {
-            toast.error(
-              (response?.message as string) ||
-                t('report.submitError') ||
-                'Gửi báo cáo thất bại',
-            )
+            toast.error(t('report.submitError'))
           }
         },
         onError: (error: Error) => {


### PR DESCRIPTION
…t failure

The fallback branch for unrecognized report error codes showed response.message straight from the backend (e.g. a raw Java exception string when moderation data was corrupted), instead of a translated message. Fall back to the existing report.submitError i18n key.