### PR TITLE
fix(news): remove hashtag prefix from article tag badges

### DIFF
--- a/src/components/molecules/newsTagList/index.tsx
+++ b/src/components/molecules/newsTagList/index.tsx
@@ -33,7 +33,7 @@ const NewsTagList: React.FC<NewsTagListProps> = ({ tags, className }) => {
               variant='secondary'
               className='cursor-pointer px-3 py-1 text-sm rounded-full hover:bg-primary/10 hover:text-primary transition-colors'
             >
-              #{tag}
+              {tag}
             </Badge>
           </Link>
         ))}


### PR DESCRIPTION
Tags rendered as "#tag" reads like Facebook/Instagram hashtags instead of a news-site tag list.