### PR TITLE
fix(dashboard): disable stale-data caching on phone-click and saved-l…

### DIFF
--- a/src/hooks/usePhoneClickDetails/useOwnerListingAnalytics.ts
+++ b/src/hooks/usePhoneClickDetails/useOwnerListingAnalytics.ts
@@ -39,8 +39,8 @@ export const useOwnerListingsAnalyticsSummary = () => {
       )
     },
     retry: false,
-    staleTime: 30 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }
@@ -71,8 +71,8 @@ export const useOwnerListingAnalytics = (
     },
     enabled: !!listingId,
     retry: false,
-    staleTime: 30 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }
@@ -114,8 +114,8 @@ export const useOwnerListingsAnalyticsPage = (params: {
       return response.data
     },
     retry: false,
-    staleTime: 10 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }

--- a/src/hooks/useSavedListings/useOwnerSavedListingsAnalytics.ts
+++ b/src/hooks/useSavedListings/useOwnerSavedListingsAnalytics.ts
@@ -35,8 +35,8 @@ export const useOwnerSavedListingsAnalyticsSummary = () => {
       }
     },
     retry: false,
-    staleTime: 30 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }
@@ -61,8 +61,8 @@ export const useOwnerListingSavesTrend = (
     },
     enabled: !!listingId,
     retry: false,
-    staleTime: 30 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }
@@ -98,8 +98,8 @@ export const useOwnerSavedListingsAnalyticsPage = (params: {
       return response.data
     },
     retry: false,
-    staleTime: 10 * 1000,
-    gcTime: 5 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: 'always',
   })
 }


### PR DESCRIPTION
…isting analytics

Owner analytics on the seller dashboard (phone-click and saved-listing sections) used a 10-30s staleTime with a 5min gcTime, so switching tabs or coming back after triggering a new click/save/view elsewhere could show a stale count for a while. These queries back live stat cards, so set staleTime/gcTime to 0 on the 6 hooks that feed them, forcing a fresh fetch every time instead of serving cached data.

Also audited the "Tổng lượt xem" (views) figure end-to-end: the FE now calls POST /v1/views on every detail-page mount (view.service.ts), and AnalyticsServiceImpl.getListingAnalytics scopes both totalClicks and totalViews to the same time window, so the number and its conversion rate are computed correctly from the same period.