### PR TITLE
fix(auth): shorten magic link login button text for mobile

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -433,7 +433,7 @@
         "submitButton": "Log In",
         "submittingButton": "Logging In…",
         "googleButton": "Log in with Google",
-        "magicLinkButton": "Log in with email link",
+        "magicLinkButton": "Log in via email",
         "noAccount": "Don't have an account?",
         "signUp": "Sign up now",
         "registerLink": "Register",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -433,7 +433,7 @@
         "submitButton": "Đăng nhập",
         "submittingButton": "Đang đăng nhập…",
         "googleButton": "Đăng nhập với Google",
-        "magicLinkButton": "Đăng nhập bằng liên kết qua email",
+        "magicLinkButton": "Đăng nhập qua email",
         "noAccount": "Chưa có tài khoản?",
         "signUp": "Đăng ký ngay",
         "registerLink": "Đăng ký",


### PR DESCRIPTION
The full-length label wrapped awkwardly next to the email icon on narrow screens; shortened while keeping the meaning intact.