### PR TITLE
fix(notifications): subscribe to private /user/queue destination — closes notification IDOR (audit #5)

### DIFF
--- a/src/hooks/useNotifications/useNotificationWebSocket.ts
+++ b/src/hooks/useNotifications/useNotificationWebSocket.ts
@@ -7,7 +7,9 @@ import type { NotificationItem } from '@/api/types/notification.type'
 
 /**
  * WebSocket hook for realtime notification push via STOMP/SockJS.
- * Subscribes to /topic/notifications/{userId} and fires onNotification callback.
+ * Subscribes to the private /user/queue/notifications destination (the server
+ * routes to this session by its authenticated STOMP Principal) and fires the
+ * onNotification callback.
  */
 export function useNotificationWebSocket(
   userId: string | undefined,
@@ -36,7 +38,11 @@ export function useNotificationWebSocket(
       onConnect: () => {
         console.log('[Notification WS] Connected')
 
-        client.subscribe(`/topic/notifications/${userId}`, (message) => {
+        // Session-private user-destination. The backend routes here via
+        // convertAndSendToUser based on the STOMP Principal it set from the JWT in
+        // connectHeaders above, so a client only ever receives its OWN notifications
+        // (no guessable public topic → no cross-user notification leak).
+        client.subscribe('/user/queue/notifications', (message) => {
           try {
             const notification = JSON.parse(message.body) as NotificationItem
             callbackRef.current(notification)


### PR DESCRIPTION
Cặp FE cho backend PR #364 (vá **notification IDOR**, CROSS_REPO_AUDIT Critical #5).

Hook notification đang subscribe `/topic/notifications/{userId}` — topic công khai đoán được, client ẩn danh nào cũng đọc được noti người khác. Đổi sang **user-destination riêng** `/user/queue/notifications`; backend route tới đó bằng `convertAndSendToUser` dựa trên STOMP Principal nó xác thực từ JWT (token FE **đã gửi sẵn** trong `connectHeaders`). Chỉ 1 file, +8/-2.

## ⚠️ Deploy CÙNG backend PR #364
Đổi kênh nhận/gửi → BE + FE phải lên cùng lúc, không thì notification realtime ngừng chạy.

## Verify
`tsc --noEmit` (ở cây FE có node_modules) exit 0 ✅.