### PR TITLE
feat(chat): starter suggestions + anchor-to-top scroll UX

### DIFF
--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -20,6 +20,8 @@ type TAiChatInterfaceProps = {
   streamingStatus?: TStreamingStatus
   scrollRef: RefObject<HTMLDivElement | null>
   bottomRef: RefObject<HTMLDivElement | null>
+  contentRef: RefObject<HTMLDivElement | null>
+  reservedSpace: number
   isAtBottom: boolean
   onScrollToBottom: () => void
   onInputChange: (value: string) => void
@@ -40,6 +42,8 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
   streamingStatus,
   scrollRef,
   bottomRef,
+  contentRef,
+  reservedSpace,
   isAtBottom,
   onScrollToBottom,
   onInputChange,
@@ -119,6 +123,7 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
         >
           <div className='flex min-h-full flex-col justify-end'>
             <div
+              ref={contentRef}
               className={cn('flex flex-col py-2', isMobile ? 'gap-1' : 'gap-2')}
             >
               {messages.map((message, index) => {
@@ -163,6 +168,10 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
               )}
             </div>
           </div>
+
+          {/* Reserved space: lets the just-sent message anchor to the top of
+              the viewport; shrinks to fit once the turn completes. */}
+          <div aria-hidden style={{ height: reservedSpace }} />
 
           {/* Bottom sentinel for IntersectionObserver */}
           <div ref={bottomRef} className='h-px' />

--- a/src/components/organisms/aiChatWidget/index.tsx
+++ b/src/components/organisms/aiChatWidget/index.tsx
@@ -40,6 +40,8 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
     inputValue,
     scrollRef,
     bottomRef,
+    contentRef,
+    reservedSpace,
     isAtBottom,
     scrollToBottom,
     sendMessage,
@@ -146,6 +148,8 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
                 streamingStatus={streamingStatus}
                 scrollRef={scrollRef}
                 bottomRef={bottomRef}
+                contentRef={contentRef}
+                reservedSpace={reservedSpace}
                 isAtBottom={isAtBottom}
                 onScrollToBottom={scrollToBottom}
                 onInputChange={handleInputChange}
@@ -203,6 +207,8 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
                   streamingStatus={streamingStatus}
                   scrollRef={scrollRef}
                   bottomRef={bottomRef}
+                  contentRef={contentRef}
+                  reservedSpace={reservedSpace}
                   isAtBottom={isAtBottom}
                   onScrollToBottom={scrollToBottom}
                   onInputChange={handleInputChange}

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -75,9 +75,15 @@ export const useChatLogic = () => {
   const t = useTranslations('aiChat')
   const { isAuthenticated, user } = useAuth()
 
-  // Initialize with welcome message
-  const initialMessage: TChatMessage = useMemo(
-    () => ({
+  // Initialize with welcome message + curated starter suggestions so a fresh
+  // chat offers one-tap entry points (the backend only sends suggestions after
+  // a real turn). Stored as plain strings in i18n; label === query here.
+  const initialMessage: TChatMessage = useMemo(() => {
+    const starters = (t.raw('starterSuggestions') as string[]).map((s) => ({
+      label: s,
+      query: s,
+    }))
+    return {
       id: 'welcome-msg-initial',
       content:
         locale === 'vi'
@@ -85,9 +91,9 @@ export const useChatLogic = () => {
           : 'Hello! I am SmartRent AI assistant. I can help you find rooms and apartments that suit your needs. What type of property are you looking for?',
       sender: 'bot',
       timestamp: new Date(),
-    }),
-    [locale],
-  )
+      suggestions: starters,
+    }
+  }, [locale, t])
 
   // Use session storage for message persistence
   const { messages, addMessage, updateMessage, clearSession } =
@@ -101,15 +107,17 @@ export const useChatLogic = () => {
 
   const abortRef = useRef<AbortController | null>(null)
 
-  const { scrollRef, bottomRef, isAtBottom, scrollToMessage, scrollToBottom } =
-    useChatScroll()
-
-  // Mirror isAtBottom into a ref so streaming callbacks read the current value
-  // without re-creating sendMessage on every scroll change.
-  const isAtBottomRef = useRef(isAtBottom)
-  useEffect(() => {
-    isAtBottomRef.current = isAtBottom
-  }, [isAtBottom])
+  const {
+    scrollRef,
+    bottomRef,
+    contentRef,
+    isAtBottom,
+    reservedSpace,
+    scrollToMessage,
+    scrollToBottom,
+    anchorMessageToTop,
+    finalizeReservedSpace,
+  } = useChatScroll()
 
   // Abort any in-flight stream on unmount
   useEffect(() => {
@@ -164,7 +172,10 @@ export const useChatLogic = () => {
       setIsTyping(true)
       setStreamingStatus(null)
 
-      scrollToBottom()
+      // Anchor the just-sent message near the top of the viewport (reserving a
+      // viewport of space below) so the question stays visible while the
+      // answer streams in beneath it.
+      anchorMessageToTop(userMessage.id)
 
       const conversationHistory: ChatMessage[] = messages
         .filter((msg) => msg.sender === 'user' || msg.sender === 'bot')
@@ -193,38 +204,6 @@ export const useChatLogic = () => {
         const botMessageId = generateMessageId()
         let botMessageAdded = false
 
-        // Scroll-follow: capture user's intent ONCE at stream start. Listen
-        // for wheel/touchmove to detect a real user-initiated scroll-up, then
-        // back off. rAF wraps the actual scrollTop write so we read
-        // scrollHeight AFTER React commits the latest delta.
-        const scrollContainer = scrollRef.current
-        let followBottom = isAtBottomRef.current
-        const handleUserScroll = () => {
-          followBottom = false
-        }
-        scrollContainer?.addEventListener('wheel', handleUserScroll, {
-          passive: true,
-        })
-        scrollContainer?.addEventListener('touchmove', handleUserScroll, {
-          passive: true,
-        })
-        const teardownScrollFollow = () => {
-          scrollContainer?.removeEventListener('wheel', handleUserScroll)
-          scrollContainer?.removeEventListener('touchmove', handleUserScroll)
-        }
-        // Coalesce scroll-follow across bursty deltas: only one rAF in flight
-        // at a time, so 100 deltas in a single frame collapse to a single
-        // scrollTop write at next paint (instead of 100 queued writes).
-        let scrollRafPending = false
-        const followScrollToBottom = () => {
-          if (!followBottom || !scrollContainer || scrollRafPending) return
-          scrollRafPending = true
-          requestAnimationFrame(() => {
-            scrollRafPending = false
-            scrollContainer.scrollTop = scrollContainer.scrollHeight
-          })
-        }
-
         const ensureBotMessage = () => {
           if (botMessageAdded) return
           botMessageAdded = true
@@ -235,7 +214,6 @@ export const useChatLogic = () => {
             timestamp: new Date(),
           })
           setIsTyping(false)
-          scrollToMessage(botMessageId)
         }
 
         try {
@@ -258,7 +236,6 @@ export const useChatLogic = () => {
                   ...m,
                   content: m.content + delta,
                 }))
-                followScrollToBottom()
               },
               onListings: (payload) => {
                 ensureBotMessage()
@@ -268,7 +245,6 @@ export const useChatLogic = () => {
                   totalCount: payload.totalCount ?? payload.listings.length,
                   aiRankings: payload.aiRankings ?? [],
                 }))
-                followScrollToBottom()
               },
               onSuggestions: (payload) => {
                 ensureBotMessage()
@@ -276,7 +252,6 @@ export const useChatLogic = () => {
                   ...m,
                   suggestions: payload.items,
                 }))
-                followScrollToBottom()
               },
               onDone: (data) => {
                 ensureBotMessage()
@@ -288,7 +263,7 @@ export const useChatLogic = () => {
                 setIsTyping(false)
                 setIsLoading(false)
                 setStreamingStatus(null)
-                teardownScrollFollow()
+                finalizeReservedSpace()
               },
               onError: (msg) => {
                 if (botMessageAdded) {
@@ -307,18 +282,19 @@ export const useChatLogic = () => {
                 setIsTyping(false)
                 setIsLoading(false)
                 setStreamingStatus(null)
-                teardownScrollFollow()
+                finalizeReservedSpace()
               },
             },
             controller.signal,
           )
         } catch (error: unknown) {
-          // Aborts are expected (user cancelled / new send / unmount).
+          // Aborts are expected (user cancelled / new send / unmount). Leave
+          // the reserved space alone: a new send re-anchors it, and
+          // cancelStream finalizes it on its own.
           if ((error as Error)?.name === 'AbortError') {
             setIsTyping(false)
             setIsLoading(false)
             setStreamingStatus(null)
-            teardownScrollFollow()
             return
           }
           // onError handler already updated UI for stream-level errors;
@@ -328,7 +304,7 @@ export const useChatLogic = () => {
             setIsLoading(false)
             setStreamingStatus(null)
           }
-          teardownScrollFollow()
+          finalizeReservedSpace()
           console.error('[useChatLogic] Chat stream error:', error)
         }
         return
@@ -355,7 +331,7 @@ export const useChatLogic = () => {
           setIsTyping(false)
           setIsLoading(false)
           addMessage(errorMessage)
-          scrollToMessage(errorMessage.id)
+          finalizeReservedSpace()
           return
         }
         // Check if listings exist and have data
@@ -383,7 +359,7 @@ export const useChatLogic = () => {
 
         // Add bot message to session (always add, even if no listings)
         addMessage(botMessage)
-        scrollToMessage(botMessage.id)
+        finalizeReservedSpace()
       } catch (error: unknown) {
         // Handle network errors or actual exceptions
         console.error('[useChatLogic] Chat API error:', error)
@@ -405,15 +381,16 @@ export const useChatLogic = () => {
         setIsTyping(false)
         setIsLoading(false)
         addMessage(errorMessage)
-        scrollToMessage(errorMessage.id)
+        finalizeReservedSpace()
       }
     },
     [
       isLoading,
       isAuthenticated,
       user?.userId,
-      scrollToBottom,
       scrollToMessage,
+      anchorMessageToTop,
+      finalizeReservedSpace,
       messages,
       addMessage,
       updateMessage,
@@ -448,7 +425,10 @@ export const useChatLogic = () => {
     setIsTyping(false)
     setIsLoading(false)
     setStreamingStatus(null)
-  }, [])
+    // Collapse the reserved space around whatever partial answer was received
+    // so the cancelled turn doesn't leave a viewport of blank tail.
+    finalizeReservedSpace()
+  }, [finalizeReservedSpace])
 
   const clearMessages = useCallback(() => {
     abortRef.current?.abort()
@@ -466,7 +446,9 @@ export const useChatLogic = () => {
     inputValue,
     scrollRef,
     bottomRef,
+    contentRef,
     isAtBottom,
+    reservedSpace,
     scrollToBottom,
     sendMessage,
     viewListingDetail,

--- a/src/hooks/useChatAi/useChatScroll.ts
+++ b/src/hooks/useChatAi/useChatScroll.ts
@@ -2,13 +2,23 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 
 /**
  * Encapsulates all scroll behavior for the chat interface.
- * Uses IntersectionObserver for passive bottom-detection (no onScroll perf cost)
- * and scrollIntoView for reliable, native scroll positioning.
+ * Uses IntersectionObserver for passive bottom-detection (no onScroll perf
+ * cost) and scrollIntoView for reliable, native scroll positioning.
+ *
+ * Send-time UX: the just-sent message is anchored near the top of the
+ * viewport (ChatGPT/Claude style). A dynamic bottom spacer (`reservedSpace`)
+ * provides the scrollable room a short turn needs to reach the top, then
+ * shrinks to fit once the turn completes.
  */
 export const useChatScroll = () => {
   const scrollRef = useRef<HTMLDivElement>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  // Id of the message currently anchored to the top, so finalize can measure
+  // the completed turn without the caller re-supplying it.
+  const anchoredIdRef = useRef<string | null>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
+  const [reservedSpace, setReservedSpace] = useState(0)
 
   // IntersectionObserver: passively detects if the bottom sentinel is visible
   useEffect(() => {
@@ -24,7 +34,8 @@ export const useChatScroll = () => {
     return () => observer.disconnect()
   }, [])
 
-  // Scroll to the start of a specific message (for bot responses)
+  // Scroll to the start of a specific message (used by the login-required and
+  // non-streaming fallback error paths).
   const scrollToMessage = useCallback((messageId: string) => {
     requestAnimationFrame(() => {
       const el = scrollRef.current?.querySelector(
@@ -36,14 +47,61 @@ export const useChatScroll = () => {
     })
   }, [])
 
-  // Scroll to absolute bottom (for user messages + scroll-to-bottom button).
-  // Pass 'auto' for instant scroll during streaming so the view tracks new
-  // tokens without smooth-animation lag stacking up across deltas.
+  // Scroll to absolute bottom (scroll-to-bottom button).
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     requestAnimationFrame(() => {
       bottomRef.current?.scrollIntoView({ behavior })
     })
   }, [])
 
-  return { scrollRef, bottomRef, isAtBottom, scrollToMessage, scrollToBottom }
+  // Anchor a just-sent message to the top of the viewport, reserving a
+  // viewport's worth of space below so even a short turn can scroll up.
+  const anchorMessageToTop = useCallback((messageId: string) => {
+    const container = scrollRef.current
+    if (!container) return
+    anchoredIdRef.current = messageId
+    setReservedSpace(container.clientHeight)
+    requestAnimationFrame(() => {
+      const el = container.querySelector(`[data-message-id="${messageId}"]`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    })
+  }, [])
+
+  // Once the turn is complete (or cancelled), shrink the reserved spacer to
+  // just enough to hold the anchored message at the top — no excess blank
+  // tail. Drop it entirely when the turn already fills the viewport. Targets
+  // the message last passed to `anchorMessageToTop`; the turn spans from it to
+  // the bottom of the rendered content.
+  const finalizeReservedSpace = useCallback(() => {
+    requestAnimationFrame(() => {
+      const container = scrollRef.current
+      const content = contentRef.current
+      const id = anchoredIdRef.current
+      const anchor = id
+        ? container?.querySelector<HTMLElement>(`[data-message-id="${id}"]`)
+        : null
+      if (!container || !content || !anchor) {
+        setReservedSpace(0)
+        return
+      }
+      const turnHeight =
+        content.getBoundingClientRect().bottom -
+        anchor.getBoundingClientRect().top
+      setReservedSpace(Math.max(0, container.clientHeight - turnHeight))
+    })
+  }, [])
+
+  return {
+    scrollRef,
+    bottomRef,
+    contentRef,
+    isAtBottom,
+    reservedSpace,
+    scrollToMessage,
+    scrollToBottom,
+    anchorMessageToTop,
+    finalizeReservedSpace,
+  }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -56,7 +56,13 @@
     "scrollToBottom": "Scroll to bottom",
     "expandTable": "View full",
     "expandTableTitle": "Comparison Details",
-    "suggestionsLabel": "Suggested follow-ups"
+    "suggestionsLabel": "Suggested follow-ups",
+    "starterSuggestions": [
+      "Find rooms in District 7 under 5M",
+      "2-bedroom apartments near HCMUT",
+      "Whole houses in Binh Thanh 10-15M",
+      "Compare rent in District 1 vs District 3"
+    ]
   },
   "chat": {
     "title": "AI Property Assistant",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -56,7 +56,13 @@
     "scrollToBottom": "Cuộn xuống cuối",
     "expandTable": "Xem đầy đủ",
     "expandTableTitle": "Chi tiết so sánh",
-    "suggestionsLabel": "Gợi ý tiếp theo"
+    "suggestionsLabel": "Gợi ý tiếp theo",
+    "starterSuggestions": [
+      "Tìm phòng trọ Quận 7 dưới 5 triệu",
+      "Căn hộ 2PN gần Đại học Bách Khoa",
+      "Nhà nguyên căn Bình Thạnh 10-15 triệu",
+      "So sánh giá thuê Quận 1 và Quận 3"
+    ]
   },
   "chat": {
     "title": "Trợ Lý Tìm Nhà AI",


### PR DESCRIPTION
## Tóm tắt

Hai cải tiến UX cho AI chat widget (frontend-only, không đụng backend/AI service):

1. **Gợi ý mở đầu** — chip gợi ý curated hiện trên tin chào khi mới mở chat, cho người dùng điểm bắt đầu 1-chạm thay vì ô nhập trống. Tái dùng UI chip sẵn có (`isBot && isLast`); chip tự ẩn sau lượt chat đầu. Lưu dạng array-of-strings trong `en.json`/`vi.json` (label === query) để không vướng `i18n:check`.
2. **Scroll ghim-lên-đỉnh** (kiểu ChatGPT/Claude) — tin vừa gửi trượt lên gần đỉnh viewport, chừa spacer động bên dưới cho câu trả lời stream vào; spacer thu gọn vừa khít khi lượt hoàn tất. Bỏ auto-follow-đáy để giữ mỏ neo đọc ổn định. `finalizeReservedSpace()` bám message đã anchor qua ref nội bộ nên nút × (cancel), lỗi, và fallback non-streaming đều thu spacer đúng.

## File thay đổi

- `src/messages/en.json`, `src/messages/vi.json` — thêm `aiChat.starterSuggestions`
- `src/hooks/useChatAi/useChatScroll.ts` — spacer + `anchorMessageToTop` / `finalizeReservedSpace`
- `src/hooks/useChatAi/useChatLogic.ts` — anchor lúc gửi, gỡ auto-follow, finalize on done/error/cancel/fallback
- `src/components/organisms/aiChatInterface/index.tsx` — render spacer + `contentRef`
- `src/components/organisms/aiChatWidget/index.tsx` — truyền props

## Kiểm thử

- ✅ `npm run typecheck` (exit 0)
- ✅ `npx eslint` trên 4 file đụng tới (0 lỗi/cảnh báo)
- ✅ `npm run i18n:check` (en/vi khớp, 3042 keys)
- ✅ `npx vitest run` (4 passed)
- ✅ Pre-commit hook pass (typecheck + i18n + lint-staged)
- ✅ Kiểm duyệt trực quan trên browser (tác giả)