### PR TITLE
fix(chat): roomier padding on suggestion chips

### DIFF
--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -392,7 +392,7 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
                   type='button'
                   variant='outline'
                   size='sm'
-                  className='h-auto rounded-full border-primary/30 bg-gradient-to-br from-primary-50 to-primary-100 px-2.5 py-0.5 text-2xs font-medium text-primary shadow-sm transition-colors hover:border-primary/40 hover:from-primary-100 hover:to-primary-200 hover:text-primary'
+                  className='h-auto rounded-full border-primary/30 bg-gradient-to-br from-primary-50 to-primary-100 px-3.5 py-1.5 text-2xs font-medium leading-normal text-primary shadow-sm transition-colors hover:border-primary/40 hover:from-primary-100 hover:to-primary-200 hover:text-primary'
                   onClick={() => onSuggestionClick?.(suggestion.query)}
                 >
                   {suggestion.label}


### PR DESCRIPTION
## Vấn đề

Chip gợi ý mở đầu dùng `px-2.5 py-0.5` (dọc chỉ 2px) nên chữ sát viền pill, trông chật/xấu.

## Thay đổi

- `py-0.5` → `py-1.5` (2px → 6px): nới trên/dưới
- `px-2.5` → `px-3.5` (10px → 14px): nới ngang cho cân đối kiểu pill
- thêm `leading-normal`

Cỡ chữ giữ nguyên (`text-2xs`) — cảm giác "chữ to" trước đó là do thiếu padding nên chip ôm sát chữ.

Chỉ đổi className ở `aiChatBubble` (chip gợi ý). Pre-commit (typecheck + i18n:check + eslint/prettier) pass.