### PR TITLE
perf(maps): cut map-view latency and stop request pile-up

### DIFF
--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -687,6 +687,7 @@ export class ListingService {
   static async getMapBounds(
     request: MapBoundsRequest,
     instance?: AxiosInstance,
+    signal?: AbortSignal,
   ): Promise<ApiResponse<MapBoundsResponse>> {
     return apiRequest<MapBoundsResponse>(
       {
@@ -694,6 +695,9 @@ export class ListingService {
         url: PATHS.LISTING.MAP_BOUNDS,
         data: request,
         skipAuth: true, // Public API - không cần authentication
+        // Lets the caller abort a superseded viewport request instead of
+        // leaving slow map-bounds queries to pile up while the user pans.
+        signal,
       },
       instance,
     )

--- a/src/components/organisms/apartmentDetail/MapPicker.tsx
+++ b/src/components/organisms/apartmentDetail/MapPicker.tsx
@@ -37,7 +37,9 @@ const MapPicker: React.FC<MapPickerProps> = ({
     return { lat: 10.8231, lng: 106.6297 }
   }, [coords])
 
-  const apiKey = process.env.GOOGLE_MAP_KEY
+  // Must be NEXT_PUBLIC_ so Next.js exposes it to the browser bundle; the bare
+  // GOOGLE_MAP_KEY is undefined client-side, which loaded the map without a key.
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAP_KEY
 
   const handleMapClick = ({
     lat,

--- a/src/components/templates/mapView/index.tsx
+++ b/src/components/templates/mapView/index.tsx
@@ -42,7 +42,7 @@ const USER_LOCATION_ZOOM = 14
 // closes in on the exact spot (and the pin breaks out of any cluster).
 const LOCATE_LISTING_ZOOM = 16
 const MAP_HEIGHT = 'h-[calc(100vh-80px)]'
-const MAP_INTERACTION_DEBOUNCE_MS = 1000
+const MAP_INTERACTION_DEBOUNCE_MS = 400
 const MAP_LISTINGS_LIMIT = 200
 // Max cards shown in the side panel at once (the map itself shows every cached
 // pin via clustering; the list stays bounded for scroll performance).
@@ -873,27 +873,35 @@ const MapViewTemplate: React.FC = () => {
       return
     }
 
-    let isSubscribed = true
+    // Abort a superseded request when the viewport changes again before it
+    // resolves, so slow map-bounds queries don't pile up as the user pans.
+    const controller = new AbortController()
 
     setIsLoading(true)
     setError(null)
 
     const fetchMapBoundsListings = async () => {
       try {
-        const response = await ListingService.getMapBounds({
-          ...normalizedViewport,
-          limit: MAP_LISTINGS_LIMIT,
-          verifiedOnly: mapFilters.verifiedOnly,
-          categoryId: mapFilters.categoryId,
-          vipType: mapFilters.vipType,
-        })
+        const response = await ListingService.getMapBounds(
+          {
+            ...normalizedViewport,
+            limit: MAP_LISTINGS_LIMIT,
+            verifiedOnly: mapFilters.verifiedOnly,
+            categoryId: mapFilters.categoryId,
+            vipType: mapFilters.vipType,
+          },
+          undefined,
+          controller.signal,
+        )
+
+        // Aborted requests resolve here too — drop them silently rather than
+        // surfacing a "failed to load" error for a viewport we no longer show.
+        if (controller.signal.aborted) {
+          return
+        }
 
         if (!response.success || !response.data) {
           throw new Error(response.message || 'Failed to load properties')
-        }
-
-        if (!isSubscribed) {
-          return
         }
 
         // Merge (not replace), and keep the existing object reference for pins
@@ -927,7 +935,7 @@ const MapViewTemplate: React.FC = () => {
         setTotalCount(response.data.totalCount)
         setHasMore(response.data.hasMore)
       } catch (err) {
-        if (!isSubscribed) {
+        if (controller.signal.aborted) {
           return
         }
 
@@ -937,7 +945,7 @@ const MapViewTemplate: React.FC = () => {
             : 'An error occurred while loading properties',
         )
       } finally {
-        if (isSubscribed) {
+        if (!controller.signal.aborted) {
           setIsLoading(false)
         }
       }
@@ -946,7 +954,7 @@ const MapViewTemplate: React.FC = () => {
     fetchMapBoundsListings()
 
     return () => {
-      isSubscribed = false
+      controller.abort()
     }
   }, [debouncedViewport, mapFilters, filterKey])
 
@@ -1027,7 +1035,11 @@ const MapViewTemplate: React.FC = () => {
           <Map
             defaultCenter={VIETNAM_CENTER}
             defaultZoom={DEFAULT_ZOOM}
-            mapId={ENV.GOOGLE_MAP_KEY}
+            // A real Cloud Map ID (not the API key). Passing the API key here
+            // made Google try to resolve a non-existent map style on every load,
+            // logging an error and paying an extra round trip before falling
+            // back. DEMO_MAP_ID keeps AdvancedMarkers working when unconfigured.
+            mapId={ENV.GOOGLE_MAP_ID || 'DEMO_MAP_ID'}
             disableDefaultUI={false}
             gestureHandling='greedy'
             className='w-full h-full outline-none'

--- a/src/constants/env/index.ts
+++ b/src/constants/env/index.ts
@@ -2,6 +2,10 @@ import { PATHS } from '@/api/paths'
 
 export const ENV = {
   GOOGLE_MAP_KEY: process.env.NEXT_PUBLIC_GOOGLE_MAP_KEY || '',
+  // Cloud-based Map Style ID (NOT the API key). Required for the vector map +
+  // AdvancedMarkers on the /maps view. Leave unset to fall back to Google's
+  // DEMO_MAP_ID, which still enables AdvancedMarkers without any cloud setup.
+  GOOGLE_MAP_ID: process.env.NEXT_PUBLIC_GOOGLE_MAP_ID || '',
   IS_PRODUCTION: process.env.NEXT_PUBLIC_DEPLOY_ENV || '',
   URL_API_AI: process.env.NEXT_PUBLIC_URL_API_AI || 'http://localhost:8000/',
   URL_API_BASE:

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -14,7 +14,11 @@ const STATIC_PRECONNECT_ORIGINS = [
   'https://lh3.googleusercontent.com',
 ]
 
-const STATIC_DNS_PREFETCH_ORIGINS = [
+// Google Maps origins. Preconnect warms the TLS handshake so the map script
+// and tiles load sooner; dns-prefetch stays as a fallback for browsers that
+// ignore preconnect. No crossOrigin: the Maps JS loads as a plain script, so an
+// anonymous-CORS preconnect would open a separate, unused connection.
+const GOOGLE_MAPS_ORIGINS = [
   'https://maps.googleapis.com',
   'https://maps.gstatic.com',
 ]
@@ -85,7 +89,10 @@ export default function Document() {
             crossOrigin='anonymous'
           />
         ))}
-        {STATIC_DNS_PREFETCH_ORIGINS.map((origin) => (
+        {GOOGLE_MAPS_ORIGINS.map((origin) => (
+          <link key={`mpc-${origin}`} rel='preconnect' href={origin} />
+        ))}
+        {GOOGLE_MAPS_ORIGINS.map((origin) => (
           <link key={`dp-${origin}`} rel='dns-prefetch' href={origin} />
         ))}
       </Head>


### PR DESCRIPTION
## Bối cảnh

Trang `/maps` chậm khi kéo bản đồ. Network cho thấy `map-bounds` mất **1–23 giây** và payload **500–600 kB** mỗi lần. Nguyên nhân gốc nặng nhất nằm ở backend (N+1 query address — xử lý ở PR backend riêng). PR này gom các cải thiện phía frontend.

## Thay đổi

- **Debounce 1000ms → 400ms**: danh sách cập nhật nhanh hơn sau khi ngừng kéo bản đồ.
- **Huỷ request cũ (AbortController)**: khi viewport đổi trước lúc request cũ trả về, request cũ bị huỷ thay vì chồng chất; response đã huỷ được bỏ qua lặng lẽ, không hiện lỗi "load failed". Đây cũng là lý do giảm debounce an toàn.
- **`mapId` dùng Map ID thật** thay vì nhét API key: trước đây Google phải resolve một map style không tồn tại mỗi lần load (lỗi + round-trip thừa). Thêm `ENV.GOOGLE_MAP_ID` (`NEXT_PUBLIC_GOOGLE_MAP_ID`), fallback `DEMO_MAP_ID` để AdvancedMarkers vẫn chạy khi chưa cấu hình.
- **Sửa `MapPicker`** đọc `process.env.GOOGLE_MAP_KEY` (undefined ở client) → `NEXT_PUBLIC_GOOGLE_MAP_KEY`.
- **Preconnect** tới `maps.googleapis.com` / `maps.gstatic.com` (giữ `dns-prefetch` làm fallback) để làm ấm TLS trước khi bản đồ tải.

## Cấu hình cần thêm (không bắt buộc)

Đặt `NEXT_PUBLIC_GOOGLE_MAP_ID` = một Cloud Map ID thật (Google Cloud Console → Map Management) để có style riêng và bỏ hẳn cảnh báo DEMO. Chưa đặt thì vẫn chạy bằng `DEMO_MAP_ID`.

## Kiểm chứng

- `tsc --noEmit`: pass
- `eslint`: pass
- pre-commit (typecheck, i18n, eslint, prettier): pass

Lưu ý: độ trễ theo giây cần đo lại trên môi trường có dữ liệu thật; đòn bẩy chính là PR backend (N+1). PR này cải thiện độ mượt FE và thời điểm bản đồ hiện lần đầu.