### PR TITLE
feat(auth): centered success overlay for login & logout

### DIFF
--- a/src/components/molecules/authSuccessOverlay/index.tsx
+++ b/src/components/molecules/authSuccessOverlay/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import { useTranslations } from 'next-intl'
+import { Check } from 'lucide-react'
+import { Typography } from '@/components/atoms/typography'
+import { useAuthFeedback } from '@/store/authFeedback/index.store'
+
+// How long the confirmation stays before auto-dismissing. Short on purpose:
+// login/logout happen often, so the overlay should reassure and get out of the
+// way rather than block.
+const AUTO_DISMISS_MS = 1600
+
+// App-level centered success confirmation for auth actions. Mounted once in
+// _app; raised via useAuthFeedback().show('login' | 'logout') from the login
+// form and the logout flow. Auto-dismisses, or closes on backdrop click.
+const AuthSuccessOverlay = () => {
+  const t = useTranslations('homePage.auth')
+  const success = useAuthFeedback((s) => s.success)
+  const clear = useAuthFeedback((s) => s.clear)
+
+  useEffect(() => {
+    if (!success) return
+    const timer = window.setTimeout(clear, AUTO_DISMISS_MS)
+    return () => window.clearTimeout(timer)
+  }, [success, clear])
+
+  if (!success) return null
+
+  const message =
+    success === 'login' ? t('login.successMessage') : t('logoutSuccessMessage')
+
+  return (
+    <div
+      role='status'
+      aria-live='polite'
+      onClick={clear}
+      className='fixed inset-0 z-[200] flex items-center justify-center bg-black/40 backdrop-blur-sm animate-in fade-in-0 duration-200'
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className='mx-4 flex flex-col items-center gap-4 rounded-2xl bg-card px-10 py-8 shadow-2xl animate-in fade-in-0 zoom-in-95 duration-300'
+      >
+        <div className='flex size-16 items-center justify-center rounded-full bg-emerald-500 text-white shadow-lg animate-in zoom-in-50 duration-300'>
+          <Check className='size-9' strokeWidth={3} />
+        </div>
+        <Typography
+          variant='h6'
+          className='text-center font-semibold text-foreground'
+        >
+          {message}
+        </Typography>
+      </div>
+    </div>
+  )
+}
+
+export default AuthSuccessOverlay

--- a/src/components/molecules/loginForm/index.tsx
+++ b/src/components/molecules/loginForm/index.tsx
@@ -14,6 +14,7 @@ import dynamic from 'next/dynamic'
 import SeparatorOr from '@/components/atoms/separatorOr'
 import { useLogin, useResendOtp, useRequestMagicLink } from '@/hooks/useAuth'
 import { toast } from 'sonner'
+import { useAuthFeedback } from '@/store/authFeedback/index.store'
 import { VALIDATION_PATTERNS, API_ERROR_CODES } from '@/api/types/auth.type'
 import { googleOAuthURL } from '@/utils/googleOAuth2'
 import { useState, useCallback } from 'react'
@@ -97,7 +98,9 @@ const LoginForm: NextPage<LoginFormProps> = (props) => {
 
       if (result.success) {
         onSuccess?.()
-        toast.success(t('homePage.auth.login.successMessage'))
+        // Centered success overlay (see AuthSuccessOverlay) instead of the
+        // corner toast, matching the logout confirmation.
+        useAuthFeedback.getState().show('login')
       } else if (result.code === API_ERROR_CODES.USER_NOT_VERIFIED) {
         // Account not verified — resend OTP and switch to verify UI
         setVerifyEmail(data.email)

--- a/src/hooks/useAuth/index.tsx
+++ b/src/hooks/useAuth/index.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useShallow } from 'zustand/react/shallow'
 import { useAuthStore } from '@/store/auth/index.store'
+import { useAuthFeedback } from '@/store/authFeedback/index.store'
 import { AuthService } from '@/api/services/auth.service'
 import {
   LoginRequest,
@@ -196,6 +197,11 @@ export const useLogout = () => {
 
     // Clear local state FIRST (optimistic) — triggers immediate UI update
     logout()
+
+    // Centered success confirmation (see AuthSuccessOverlay). Raised right
+    // after the local clear so it shows for every path (guest / no-token /
+    // normal), regardless of the background server call's outcome.
+    useAuthFeedback.getState().show('logout')
 
     // If no access token, nothing to notify the server about
     if (!accessToken) {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -609,6 +609,7 @@
         "authentication_failed": "Authentication failed"
       },
       "logout": "Log Out",
+      "logoutSuccessMessage": "Logged out successfully!",
       "profile": "Profile",
       "settings": "Settings",
       "user": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -609,6 +609,7 @@
         "authentication_failed": "Xác thực thất bại"
       },
       "logout": "Đăng xuất",
+      "logoutSuccessMessage": "Đăng xuất thành công!",
       "profile": "Hồ sơ",
       "settings": "Cài đặt",
       "user": {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from 'next-intl'
 import SwitchLanguageProvider from '@/contexts/switchLanguage'
 import vi from '@/messages/vi.json'
 import { Toaster } from '@/components/atoms/sonner'
+import AuthSuccessOverlay from '@/components/molecules/authSuccessOverlay'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
 import { AuthDialogProvider } from '@/contexts/authDialog'
 import { fontVariables } from '@/theme/fonts'
@@ -131,6 +132,7 @@ function AppContent({ Component, pageProps }: AppPropsWithLayout) {
                 <AuthRouteGate />
                 {getLayout(<Component {...pageProps} />)}
                 <Toaster />
+                <AuthSuccessOverlay />
                 {showChatWidget && <AiChatWidget position='bottom-right' />}
               </AuthDialogProvider>
             </AuthProvider>

--- a/src/store/authFeedback/index.store.ts
+++ b/src/store/authFeedback/index.store.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+
+// Which auth event the centered success overlay is currently confirming, or
+// null when the overlay is hidden. Login and logout are triggered from
+// different places (login dialog vs. user dropdown / mobile drawer), so a tiny
+// global store lets any of them raise the single app-level overlay.
+export type AuthFeedbackVariant = 'login' | 'logout'
+
+interface AuthFeedbackState {
+  success: AuthFeedbackVariant | null
+  show: (variant: AuthFeedbackVariant) => void
+  clear: () => void
+}
+
+export const useAuthFeedback = create<AuthFeedbackState>()((set) => ({
+  success: null,
+  show: (variant) => set({ success: variant }),
+  clear: () => set({ success: null }),
+}))


### PR DESCRIPTION
## What

Login success showed a **corner sonner toast** (which looked out of place); logout had **no feedback at all**. This replaces both with a single **centered success confirmation**: an animated green check + "Đăng nhập / Đăng xuất thành công", a dim backdrop, auto-dismiss ~1.6s (or click to close).

## How

- **`useAuthFeedback`** (`src/store/authFeedback`) — tiny zustand store: `show('login' | 'logout')` / `clear()`. Login and logout fire from different places (login dialog vs user dropdown / mobile drawer), so a global store raises one app-level overlay.
- **`AuthSuccessOverlay`** — mounted once in `_app`, reads the store and translates per variant. Uses the same `tw-animate-css` entrance classes as the shadcn dialog. `role="status"` + `aria-live`.
- **`loginForm`** — on success calls `show('login')` (was `toast.success`). Error / not-verified paths keep their existing toasts.
- **`useLogout`** — `show('logout')` right after the optimistic local clear, so every path (guest / no-token / normal) confirms regardless of the background server call.
- **i18n** — reuse `homePage.auth.login.successMessage`; add `homePage.auth.logoutSuccessMessage` (en + vi).

Scope is only login/logout success; all other toasts unchanged.

## Verification

`typecheck` ✅ · `i18n:check` ✅ (3043 keys in sync) · `eslint` on touched files ✅ (pre-commit hook green).