### PR TITLE
refactor(icons): replace emoji-as-icons with lucide

### DIFF
--- a/src/components/atoms/status-badge/index.constants.ts
+++ b/src/components/atoms/status-badge/index.constants.ts
@@ -1,3 +1,15 @@
+import {
+  AlarmClock,
+  AlertTriangle,
+  Archive,
+  CircleDot,
+  Eye,
+  Hourglass,
+  Wallet,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react'
+
 export type StatusType =
   | 'active'
   | 'expired'
@@ -62,13 +74,13 @@ export const STATUS_BADGE_STYLES = {
   glow: 'shadow-lg shadow-current/20',
 } as const
 
-export const STATUS_ICONS = {
-  active: '●',
-  expired: '⚠',
-  expiring: '⏰',
-  pending: '⏳',
-  review: '👁',
-  payment: '💰',
-  rejected: '❌',
-  archived: '📦',
-} as const
+export const STATUS_ICONS: Record<StatusType, LucideIcon> = {
+  active: CircleDot,
+  expired: AlertTriangle,
+  expiring: AlarmClock,
+  pending: Hourglass,
+  review: Eye,
+  payment: Wallet,
+  rejected: XCircle,
+  archived: Archive,
+}

--- a/src/components/atoms/status-badge/index.tsx
+++ b/src/components/atoms/status-badge/index.tsx
@@ -23,7 +23,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
 }) => {
   const t = useTranslations()
   const config = STATUS_CONFIG[status]
-  const icon = STATUS_ICONS[status]
+  const Icon = STATUS_ICONS[status]
 
   return (
     <span
@@ -38,11 +38,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
       role='status'
       aria-label={t(config.labelKey)}
     >
-      {showIcon && (
-        <span className='mr-1' aria-hidden='true'>
-          {icon}
-        </span>
-      )}
+      {showIcon && <Icon className='mr-1 size-3.5' aria-hidden='true' />}
       {t(config.labelKey)}
     </span>
   )

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Link from 'next/link'
-import { Maximize2 } from 'lucide-react'
+import { Maximize2, Phone } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { TChatMessage } from '@/hooks/useChatAi'
@@ -76,7 +76,11 @@ const renderLink = (
         onClick={(e) => e.stopPropagation()}
         {...props}
       >
-        📞 {children}
+        <Phone
+          className='mr-1 inline size-4 align-text-bottom'
+          aria-hidden='true'
+        />
+        {children}
       </a>
     )
   }

--- a/src/components/molecules/brokerVerificationForm/index.tsx
+++ b/src/components/molecules/brokerVerificationForm/index.tsx
@@ -16,6 +16,7 @@ import { useAuth } from '@/hooks/useAuth'
 import {
   AlertCircle,
   CheckCircle2,
+  Clock,
   FileCheck2,
   IdCard,
   Loader2,
@@ -869,7 +870,11 @@ const BrokerVerificationForm: React.FC<BrokerVerificationFormProps> = ({
               'border-amber-300/80 text-amber-900 dark:text-amber-200',
           )}
         >
-          <AlertCircle className='size-4' />
+          {currentStatus === 'PENDING' ? (
+            <Clock className='size-4' />
+          ) : (
+            <AlertCircle className='size-4' />
+          )}
           <AlertTitle>
             {currentStatus === 'APPROVED' &&
               safeT(

--- a/src/components/molecules/mobileFilter/addressFilterView.tsx
+++ b/src/components/molecules/mobileFilter/addressFilterView.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
+import { Lightbulb } from 'lucide-react'
 import {
   useLegacyProvinces,
   useLegacyProvincesSearch,
@@ -385,11 +386,13 @@ const NewAddressSection: React.FC<AddressSectionProps> = ({
         isLoadingMore={newWardsQuery.isFetchingNextPage}
       />
 
-      <div className='rounded-lg bg-blue-50 p-3 text-sm text-muted-foreground dark:bg-blue-950'>
-        💡{' '}
-        {t('structureToggle.newDescription', {
-          count: provinces.length,
-        })}
+      <div className='flex items-start gap-2 rounded-lg bg-blue-50 p-3 text-sm text-muted-foreground dark:bg-blue-950'>
+        <Lightbulb className='mt-0.5 size-4 shrink-0' aria-hidden='true' />
+        <span>
+          {t('structureToggle.newDescription', {
+            count: provinces.length,
+          })}
+        </span>
       </div>
     </div>
   )

--- a/src/components/organisms/updatePostSections/packageConfigSection.tsx
+++ b/src/components/organisms/updatePostSections/packageConfigSection.tsx
@@ -13,18 +13,32 @@ import {
 import { Label } from '@/components/atoms/label'
 import { Typography } from '@/components/atoms/typography'
 import { Input } from '@/components/atoms/input'
-import { Calendar, Check, Loader2, AlertCircle, Lock } from 'lucide-react'
+import {
+  Calendar,
+  Check,
+  Loader2,
+  AlertCircle,
+  Lock,
+  FileText,
+  Medal,
+  Crown,
+  Gem,
+  type LucideIcon,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface PackageConfigSectionProps {
   className?: string
 }
 
-const TIER_ICONS: Record<string, string> = {
-  NORMAL: '📄',
-  SILVER: '🥈',
-  GOLD: '🥇',
-  DIAMOND: '💎',
+// Tiered line icons (lucide) instead of emoji — cleaner and on-brand with the
+// rest of the app's icon set. Mirrors the create-post twin. Rendered white on
+// the tier gradient.
+const TIER_ICONS: Record<string, LucideIcon> = {
+  NORMAL: FileText,
+  SILVER: Medal,
+  GOLD: Crown,
+  DIAMOND: Gem,
 }
 
 const TIER_BACKGROUNDS: Record<string, string> = {
@@ -130,13 +144,15 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
               >
                 <Card
                   className={cn(
-                    'w-12 h-12 rounded-lg flex items-center justify-center text-2xl mb-3 border-0',
+                    'w-12 h-12 rounded-lg flex items-center justify-center mb-3 border-0',
                     TIER_BACKGROUNDS[tier.tierCode] || TIER_BACKGROUNDS.NORMAL,
                   )}
                 >
-                  <Typography as='span'>
-                    {TIER_ICONS[tier.tierCode] || TIER_ICONS.NORMAL}
-                  </Typography>
+                  {(() => {
+                    const TierIcon =
+                      TIER_ICONS[tier.tierCode] || TIER_ICONS.NORMAL
+                    return <TierIcon className='w-6 h-6 text-white' />
+                  })()}
                 </Card>
                 <Typography
                   variant='h4'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -725,7 +725,7 @@
           "statusLoadErrorHint": "You can still upload and submit documents. We will retry status sync later.",
           "refreshStatus": "Refresh status",
           "approvedBadge": "✓ Verified Broker",
-          "pendingBadge": "🕐 Verification in Progress",
+          "pendingBadge": "Verification in Progress",
           "rejectedBadge": "Registration Rejected",
           "approvedMessage": "Your broker profile has been verified successfully.",
           "pendingMessage": "Your broker verification application is under manual review.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -725,7 +725,7 @@
           "statusLoadErrorHint": "Bạn vẫn có thể tải ảnh và gửi hồ sơ. Hệ thống sẽ đồng bộ trạng thái lại sau.",
           "refreshStatus": "Làm mới trạng thái",
           "approvedBadge": "✓ Môi giới được xác nhận",
-          "pendingBadge": "🕐 Đang xác minh",
+          "pendingBadge": "Đang xác minh",
           "rejectedBadge": "Đơn bị từ chối",
           "approvedMessage": "Hồ sơ môi giới của bạn đã được xác minh thành công.",
           "pendingMessage": "Hồ sơ xác minh môi giới của bạn đang được xét duyệt thủ công.",

--- a/src/utils/payment/payment.utils.ts
+++ b/src/utils/payment/payment.utils.ts
@@ -325,17 +325,6 @@ export const PAYMENT_STATUS_COLORS = {
 } as const
 
 /**
- * Payment status to icon mapping
- */
-export const PAYMENT_STATUS_ICONS = {
-  COMPLETED: '✅',
-  PENDING: '⏳',
-  FAILED: '❌',
-  CANCELLED: '🚫',
-  REFUNDED: '↩️',
-} as const
-
-/**
  * Get color for payment status
  *
  * @param status - Payment status
@@ -348,20 +337,6 @@ export function getPaymentStatusColor(
     PAYMENT_STATUS_COLORS[
       status.toUpperCase() as keyof typeof PAYMENT_STATUS_COLORS
     ] || 'gray'
-  )
-}
-
-/**
- * Get icon for payment status
- *
- * @param status - Payment status
- * @returns Icon emoji
- */
-export function getPaymentStatusIcon(status: string): string {
-  return (
-    PAYMENT_STATUS_ICONS[
-      status.toUpperCase() as keyof typeof PAYMENT_STATUS_ICONS
-    ] || '❓'
   )
 }
 


### PR DESCRIPTION
The repo convention is `lucide-react` for icons; these spots still used emoji as UI icons. Replaced them (and deleted a dead emoji map).

| Where | Before | After |
|---|---|---|
| `StatusBadge` `STATUS_ICONS` | ● ⚠ ⏰ ⏳ 👁 💰 ❌ 📦 | `CircleDot` / `AlertTriangle` / `AlarmClock` / `Hourglass` / `Eye` / `Wallet` / `XCircle` / `Archive` — rendered as the icon component instead of an emoji span |
| updatePost `packageConfigSection` `TIER_ICONS` | 📄 🥈 🥇 💎 | `FileText` / `Medal` / `Crown` / `Gem` — matches the **create-post twin** that already migrated (its comment: *"lucide instead of emoji — cleaner and on-brand"*) |
| `aiChatBubble` tel link | 📞 | `Phone` |
| `addressFilterView` hint | 💡 | `Lightbulb` |
| `payment.utils` `PAYMENT_STATUS_ICONS` + `getPaymentStatusIcon` | ✅ ⏳ ❌ 🚫 ↩️ ❓ | **deleted** — dead code, no call sites |

Not touched (out of scope / intentional): the `🕐` in the `brokerVerification.pendingBadge` i18n string (group ②), and text symbols `✓ ↑ ↓ →` (kbd hints, price chart, keyboard-nav copy).

## Verification
`typecheck` ✅ · `i18n:check` ✅ · `eslint` on touched files ✅ (the lone remaining `text-2xl` warning in packageConfigSection is pre-existing and unrelated; this change removed one such warning). Pre-commit hook green.