### PR TITLE
fix(map): rebalance compact card type scale (fix oversized labels)

### DIFF
--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -43,7 +43,13 @@ const StatPill: React.FC<{
     )}
   >
     <span className='text-primary'>{icon}</span>
-    <Typography variant='small' className='font-semibold text-foreground'>
+    <Typography
+      variant='small'
+      className={classNames(
+        'font-semibold text-foreground',
+        compact && 'text-xs',
+      )}
+    >
       {value}
     </Typography>
   </div>
@@ -133,7 +139,7 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
             {verified && (
               <Badge
                 className={classNames(
-                  'bg-emerald-500/90 text-white text-2xs rounded-full shadow-md flex items-center backdrop-blur-sm',
+                  'bg-emerald-500/90 text-white text-[11px] rounded-full shadow-md flex items-center backdrop-blur-sm',
                   compact ? 'px-1.5 py-0.5 gap-0.5' : 'px-2.5 py-1 gap-1',
                 )}
               >
@@ -146,7 +152,7 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
             {isPriority && (
               <Badge
                 className={classNames(
-                  'bg-gradient-to-r from-primary to-primary/80 text-primary-foreground text-2xs rounded-full shadow-md flex items-center backdrop-blur-sm',
+                  'bg-gradient-to-r from-primary to-primary/80 text-primary-foreground text-[11px] rounded-full shadow-md flex items-center backdrop-blur-sm',
                   compact ? 'px-1.5 py-0.5 gap-0.5' : 'px-2.5 py-1 gap-1',
                 )}
               >
@@ -177,7 +183,10 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
       >
         <Typography
           variant='h6'
-          className='text-foreground leading-tight font-semibold line-clamp-2'
+          className={classNames(
+            'text-foreground leading-tight font-semibold line-clamp-2',
+            compact && 'text-sm',
+          )}
         >
           {title}
         </Typography>
@@ -187,7 +196,10 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
             <MapPin className='w-3 h-3 flex-shrink-0 text-muted-foreground mt-0.5' />
             <Typography
               variant='small'
-              className='text-muted-foreground line-clamp-1 leading-snug'
+              className={classNames(
+                'text-muted-foreground line-clamp-1 leading-snug',
+                compact && 'text-xs',
+              )}
             >
               {displayAddress}
             </Typography>
@@ -246,7 +258,10 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
             {userName && (
               <Typography
                 variant='small'
-                className='font-medium truncate block leading-tight'
+                className={classNames(
+                  'font-medium truncate block leading-tight',
+                  compact && 'text-xs',
+                )}
               >
                 {userName}
               </Typography>


### PR DESCRIPTION
The map sidebar's 3-per-row compact cards looked oversized/unbalanced. Two things:

**Root cause of the "labels too big":** the verified/priority badges used `text-2xs` — a **dead class**. It's only defined in `tailwind.config.js`, which Tailwind v4 doesn't load; the v4 `@theme` defines `text-micro` (11px) for chips/badges instead. So `text-2xs` produced no reliable size and the badge fell back to a wrong (larger) size.

**Fix + rebalance** (compact/sidebar only — the roomy selected-pin overlay is unchanged). At the real 16:9-laptop card width (~232px: sidebar `xl:w-[760px]` ÷ 3 minus padding/gap), a clean hierarchy:

| Element | Before | After |
|---|---|---|
| Badge (Đã xác minh / Ưu tiên) | `text-2xs` (dead) | **`text-[11px]`** |
| Price | 16px | **16px** (anchor, unchanged) |
| Title | 16px | **14px** (`text-sm`) |
| Address | 14px | **12px** (`text-xs`) |
| Stat pills (2 · 2 · 87m²) | 14px | **12px** |
| Agent name | 14px | **12px** |

→ price 16 > title 14 > address/specs/agent 12 > badge 11.

Uses twMerge-safe classes (`text-[11px]` / `text-sm` / `text-xs`) rather than the `@theme` tokens (`text-micro`/`text-meta`), because `cn()` is a plain `twMerge` that doesn't recognise the custom tokens for className overrides (they wouldn't reliably beat the variant's size).

## Verification
`typecheck` ✅ · `i18n:check` ✅ · `eslint` on the touched file ✅ (pre-commit hook green).