### PR TITLE
feat(customers): inline copy on email/phone, drop the Actions column

### DIFF
--- a/src/components/templates/customerManagementTemplate/index.tsx
+++ b/src/components/templates/customerManagementTemplate/index.tsx
@@ -322,9 +322,6 @@ const CustomerManagementTemplate = () => {
                     <th className='px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider'>
                       {t('table.clickedListings')}
                     </th>
-                    <th className='px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider'>
-                      {t('table.actions')}
-                    </th>
                   </tr>
                 </thead>
                 <tbody className='bg-card divide-y divide-border'>
@@ -367,6 +364,20 @@ const CustomerManagementTemplate = () => {
                             <span className='text-sm text-foreground'>
                               {customer.email}
                             </span>
+                            {customer.email && (
+                              <button
+                                type='button'
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleCopyToClipboard(customer.email, 'email')
+                                }}
+                                className='p-1 rounded-md text-muted-foreground opacity-0 transition-all hover:bg-primary/10 hover:text-primary group-hover:opacity-100'
+                                title={t('table.copyEmail')}
+                                aria-label={t('table.copyEmail')}
+                              >
+                                <Copy className='h-3.5 w-3.5' />
+                              </button>
+                            )}
                           </div>
                         </td>
                         <td className='px-6 py-4'>
@@ -379,6 +390,23 @@ const CustomerManagementTemplate = () => {
                               <CheckCircle2 className='h-4 w-4 text-green-600' />
                             ) : (
                               <XCircle className='h-4 w-4 text-muted-foreground/50' />
+                            )}
+                            {customer.contactPhone && (
+                              <button
+                                type='button'
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleCopyToClipboard(
+                                    customer.contactPhone,
+                                    'phone',
+                                  )
+                                }}
+                                className='p-1 rounded-md text-muted-foreground opacity-0 transition-all hover:bg-primary/10 hover:text-primary group-hover:opacity-100'
+                                title={t('table.copyPhone')}
+                                aria-label={t('table.copyPhone')}
+                              >
+                                <Copy className='h-3.5 w-3.5' />
+                              </button>
                             )}
                           </div>
                         </td>
@@ -439,35 +467,6 @@ const CustomerManagementTemplate = () => {
                                 +{customer.clickedListings.length - 2} more
                               </div>
                             )}
-                          </div>
-                        </td>
-                        <td className='px-6 py-4 text-right'>
-                          <div className='flex justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200'>
-                            {customer.contactPhone && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleCopyToClipboard(
-                                    customer.contactPhone,
-                                    'phone',
-                                  )
-                                }}
-                                className='p-2 hover:bg-primary/10 rounded-md transition-colors'
-                                title={t('table.copyPhone')}
-                              >
-                                <Copy className='h-4 w-4 text-primary' />
-                              </button>
-                            )}
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                handleCopyToClipboard(customer.email, 'email')
-                              }}
-                              className='p-2 hover:bg-primary/10 rounded-md transition-colors'
-                              title={t('table.copyEmail')}
-                            >
-                              <Mail className='h-4 w-4 text-primary' />
-                            </button>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
On the seller **Khách hàng** table, the trailing **HÀNH ĐỘNG** (Actions) column held two copy buttons — copy phone and copy email. This moves them inline and removes the column.

- **Copy button after the email value** (only when the customer has an email).
- **Copy button after the phone value** (only when the customer has a phone).
- Both use the `Copy` icon, reveal on row hover, and call the existing `handleCopyToClipboard` (same clipboard + toast behaviour as before).
- The now-empty **Actions** column (header + cell) is removed → the table goes from 6 to 5 columns.

Behaviour and copy targets are unchanged; only the placement moved. Desktop table only (the mobile card view already shows email/phone without an actions column).

## Verification
`typecheck` ✅ · `i18n:check` ✅ · `eslint` (pre-commit hook) ✅.