### PR TITLE
fix(chat): reset AI chat session on identity change to stop cross-account leak

### DIFF
--- a/src/hooks/useAuth/index.tsx
+++ b/src/hooks/useAuth/index.tsx
@@ -20,6 +20,7 @@ import {
   clearAuthProfileQueries,
   resolveAuthenticatedUser,
 } from '@/utils/auth/session'
+import { clearChatSessionStorage } from '@/hooks/useChatAi/useChatSession'
 
 export { useAuthGuard, useForceLogout } from './useAuthGuard'
 export { useChangePassword } from './useChangePassword'
@@ -63,12 +64,9 @@ export const useLogin = () => {
         const user = await resolveAuthenticatedUser(tokens, queryClient)
         login(user, tokens)
 
-        // Clear AI chat session when login successfully
-        try {
-          sessionStorage.removeItem('smart-rent-ai-chat-session')
-        } catch (error) {
-          console.warn('[useLogin] Failed to clear AI chat session:', error)
-        }
+        // Clear AI chat session so the new account never inherits the previous
+        // (or guest) conversation.
+        clearChatSessionStorage()
 
         return result
       } catch (error) {
@@ -113,15 +111,9 @@ export const useAdminLogin = () => {
         const user = await resolveAuthenticatedUser(tokens, queryClient)
         login(user, tokens)
 
-        // Clear AI chat session when login successfully
-        try {
-          sessionStorage.removeItem('smart-rent-ai-chat-session')
-        } catch (error) {
-          console.warn(
-            '[useAdminLogin] Failed to clear AI chat session:',
-            error,
-          )
-        }
+        // Clear AI chat session so the new account never inherits the previous
+        // (or guest) conversation.
+        clearChatSessionStorage()
 
         return result
       } catch (error) {
@@ -186,12 +178,8 @@ export const useLogout = () => {
     // Snapshot the guest flag before logout() resets it.
     const wasGuest = useAuthStore.getState().isGuest
 
-    // Clear AI chat session on logout
-    try {
-      sessionStorage.removeItem('smart-rent-ai-chat-session')
-    } catch (error) {
-      console.warn('[Logout] Failed to clear AI chat session:', error)
-    }
+    // Clear AI chat session on logout so the next account starts clean.
+    clearChatSessionStorage()
 
     clearAuthProfileQueries(queryClient)
 
@@ -405,14 +393,9 @@ export const useVerifyMagicLink = () => {
         const user = await resolveAuthenticatedUser(tokens, queryClient)
         login(user, tokens)
 
-        try {
-          sessionStorage.removeItem('smart-rent-ai-chat-session')
-        } catch (error) {
-          console.warn(
-            '[useVerifyMagicLink] Failed to clear AI chat session:',
-            error,
-          )
-        }
+        // Clear AI chat session so the new account never inherits the previous
+        // (or guest) conversation.
+        clearChatSessionStorage()
 
         return result
       } catch (error) {

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -95,9 +95,13 @@ export const useChatLogic = () => {
     }
   }, [locale, t])
 
-  // Use session storage for message persistence
-  const { messages, addMessage, updateMessage, clearSession } =
-    useChatSession(initialMessage)
+  // Use session storage for message persistence. Passing the auth identity in
+  // lets the session wipe itself on login / logout / account switch instead of
+  // leaking one account's chat into the next.
+  const { messages, addMessage, updateMessage, clearSession } = useChatSession(
+    initialMessage,
+    { isAuthenticated, userId: user?.userId ?? null },
+  )
 
   //Init state hook
   const [isLoading, setIsLoading] = useState(false)

--- a/src/hooks/useChatAi/useChatSession.test.ts
+++ b/src/hooks/useChatAi/useChatSession.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useChatSession } from './useChatSession'
+import type { TChatMessage } from './useChatLogic'
+
+const CHAT_SESSION_KEY = 'smart-rent-ai-chat-session'
+const CHAT_OWNER_KEY = 'smart-rent-ai-chat-owner'
+
+const initialMessage: TChatMessage = {
+  id: 'welcome-msg-initial',
+  content: 'welcome',
+  sender: 'bot',
+  timestamp: new Date('2020-01-01T00:00:00Z'),
+}
+
+const userMsg = (id: string): TChatMessage => ({
+  id,
+  content: `msg-${id}`,
+  sender: 'user',
+  timestamp: new Date('2020-01-01T00:00:00Z'),
+})
+
+type Auth = { isAuthenticated: boolean; userId?: string | number | null }
+
+const render = (initialAuth: Auth) =>
+  renderHook(({ auth }) => useChatSession(initialMessage, auth), {
+    initialProps: { auth: initialAuth },
+  })
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe('useChatSession identity reset', () => {
+  it('clears guest history when a guest logs in', () => {
+    const { result, rerender } = render({ isAuthenticated: false })
+
+    act(() => {
+      result.current.addMessage(userMsg('guest-1'))
+    })
+    expect(result.current.messages).toHaveLength(2)
+
+    // Guest logs in -> guest "please login" history must be wiped
+    rerender({ auth: { isAuthenticated: true, userId: 'u1' } })
+
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0].id).toBe('welcome-msg-initial')
+  })
+
+  it('clears history on logout', () => {
+    const { result, rerender } = render({
+      isAuthenticated: true,
+      userId: 'u1',
+    })
+
+    act(() => {
+      result.current.addMessage(userMsg('u1-1'))
+    })
+    expect(result.current.messages).toHaveLength(2)
+
+    rerender({ auth: { isAuthenticated: false } })
+
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0].id).toBe('welcome-msg-initial')
+  })
+
+  it('clears history when switching directly to another account', () => {
+    const { result, rerender } = render({
+      isAuthenticated: true,
+      userId: 'u1',
+    })
+
+    act(() => {
+      result.current.addMessage(userMsg('u1-1'))
+    })
+    expect(result.current.messages).toHaveLength(2)
+
+    rerender({ auth: { isAuthenticated: true, userId: 'u2' } })
+
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0].id).toBe('welcome-msg-initial')
+  })
+
+  it('does NOT wipe restored history on reload of the same user (hydration)', () => {
+    // Simulate a same-tab reload: sessionStorage still holds u1's messages,
+    // tagged with u1 as owner. Auth starts unauthenticated (hydrating) then
+    // resolves back to the same u1 via the async auth init.
+    sessionStorage.setItem(
+      CHAT_SESSION_KEY,
+      JSON.stringify([initialMessage, userMsg('u1-1')]),
+    )
+    sessionStorage.setItem(CHAT_OWNER_KEY, 'u1')
+
+    const { result, rerender } = render({ isAuthenticated: false })
+
+    // Restored on mount before auth resolves
+    expect(result.current.messages).toHaveLength(2)
+
+    // Hydration completes -> re-authenticated as the SAME user
+    rerender({ auth: { isAuthenticated: true, userId: 'u1' } })
+
+    // History must be preserved, not reset to welcome
+    expect(result.current.messages).toHaveLength(2)
+  })
+})

--- a/src/hooks/useChatAi/useChatSession.ts
+++ b/src/hooks/useChatAi/useChatSession.ts
@@ -3,6 +3,13 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import type { TChatMessage } from './useChatLogic'
 
 const CHAT_SESSION_KEY = 'smart-rent-ai-chat-session'
+// Records which identity the persisted messages belong to, so a login/logout/
+// account-switch can wipe another identity's chat while a same-tab reload
+// (which re-resolves to the same owner) keeps its restored history.
+const CHAT_OWNER_KEY = 'smart-rent-ai-chat-owner'
+// Sentinel owner for the unauthenticated (guest) state. Never collides with a
+// real numeric userId.
+const GUEST_OWNER = 'guest'
 
 // Debounce window for sessionStorage writes. Streaming bot responses can fire
 // 50-200 state updates per turn (one per text delta from the SSE stream). A
@@ -12,7 +19,35 @@ const CHAT_SESSION_KEY = 'smart-rent-ai-chat-session'
 // long enough to coalesce a full streaming response into one write.
 const PERSIST_DEBOUNCE_MS = 400
 
-export const useChatSession = (initialMessage: TChatMessage) => {
+type ChatSessionAuth = {
+  isAuthenticated: boolean
+  userId?: string | number | null
+}
+
+/** Clears both the persisted messages and the owner tag. Exposed so auth
+ *  handlers can wipe the chat on login/logout even when the widget (and its
+ *  in-memory reset effect) is not mounted on the current route. */
+export const clearChatSessionStorage = () => {
+  try {
+    sessionStorage.removeItem(CHAT_SESSION_KEY)
+    sessionStorage.removeItem(CHAT_OWNER_KEY)
+  } catch {
+    // Silent fail - session storage might be unavailable
+  }
+}
+
+function readStoredOwner(): string | null {
+  try {
+    return sessionStorage.getItem(CHAT_OWNER_KEY)
+  } catch {
+    return null
+  }
+}
+
+export const useChatSession = (
+  initialMessage: TChatMessage,
+  auth?: ChatSessionAuth,
+) => {
   const [sessionMessages, setSessionMessages] = useState<TChatMessage[]>(() => {
     try {
       const savedSession = sessionStorage.getItem(CHAT_SESSION_KEY)
@@ -37,6 +72,13 @@ export const useChatSession = (initialMessage: TChatMessage) => {
   // without being re-created (and re-scheduled) on every state change.
   const messagesRef = useRef(sessionMessages)
   messagesRef.current = sessionMessages
+
+  // Owner of the currently loaded messages. Seeded once from storage so a
+  // reload knows who the restored history belongs to.
+  const ownerRef = useRef<string | null | undefined>(undefined)
+  if (ownerRef.current === undefined) {
+    ownerRef.current = readStoredOwner()
+  }
 
   useEffect(() => {
     if (sessionMessages.length === 0) return
@@ -80,6 +122,58 @@ export const useChatSession = (initialMessage: TChatMessage) => {
       window.removeEventListener('pagehide', flush)
     }
   }, [])
+
+  // Reset the chat to its welcome state and re-stamp who now owns the session.
+  const resetForOwner = useCallback(
+    (owner: string) => {
+      try {
+        sessionStorage.removeItem(CHAT_SESSION_KEY)
+        sessionStorage.setItem(CHAT_OWNER_KEY, owner)
+      } catch {
+        // Silent fail
+      }
+      ownerRef.current = owner
+      setSessionMessages([initialMessage])
+    },
+    [initialMessage],
+  )
+
+  // Wipe the conversation whenever the effective identity changes
+  // (login / logout / account switch). The chat only serves authenticated
+  // users, so a guest's "please login" history is cleared on login too.
+  //
+  // The tricky part is a same-tab reload: the auth store boots as
+  // unauthenticated and only re-resolves the logged-in user asynchronously
+  // (false -> true edge). We must NOT treat that as a fresh login, or every
+  // refresh would wipe the restored history. Two guards handle it:
+  //   - When authenticated, compare the (reliable) userId against the stored
+  //     owner: a reload resolves to the same owner (no reset); a real login /
+  //     switch resolves to a different owner (reset).
+  //   - When unauthenticated, only reset on an actual authenticated -> guest
+  //     edge (explicit logout). The initial `false` may just be the hydration
+  //     window of a logged-in user, so it must not wipe anything.
+  const isAuthenticated = auth?.isAuthenticated ?? false
+  const userId = auth?.userId
+  const prevAuthRef = useRef(isAuthenticated)
+
+  useEffect(() => {
+    const wasAuthenticated = prevAuthRef.current
+    prevAuthRef.current = isAuthenticated
+
+    if (isAuthenticated) {
+      const identity =
+        userId !== null && userId !== undefined ? String(userId) : GUEST_OWNER
+      if (ownerRef.current !== identity) {
+        resetForOwner(identity)
+      }
+      return
+    }
+
+    // Unauthenticated: only a genuine logout edge counts as an identity change.
+    if (wasAuthenticated && ownerRef.current !== GUEST_OWNER) {
+      resetForOwner(GUEST_OWNER)
+    }
+  }, [isAuthenticated, userId, resetForOwner])
 
   const clearSession = useCallback(() => {
     try {


### PR DESCRIPTION
## Vấn đề
Đăng nhập account1 → chat → đăng xuất → đăng nhập account2 vẫn thấy nguyên message của account1.

## Root cause
`AiChatWidget` mount cố định trên public page và login/logout là SPA (không reload). Message hiển thị đến từ **React state in-memory** trong `useChatSession`, state này chỉ seed từ `sessionStorage` **một lần lúc mount**. Code cũ chỉ `removeItem` lớp storage khi login/logout — **không đụng in-memory state** — nên đổi account widget vẫn giữ hội thoại cũ và ghi ngược lại vào storage.

## Cách fix
Reset session **reactive theo identity** (login / logout / switch account, kể cả guest), né được bẫy **reload cùng tab** (auth store boot ra `isAuthenticated=false` rồi mới async `login()` lại):

- Thêm **owner tag** (`smart-rent-ai-chat-owner`) cho session.
- Khi `authenticated`: so `userId` với owner đã lưu → reload trùng owner ⇒ giữ; login mới/switch khác owner ⇒ reset.
- Khi `unauthenticated`: chỉ reset trên edge `true→false` (logout thật), bỏ qua `false` ban đầu (cửa sổ hydration).
- Guest chat (chỉ nhận "vui lòng đăng nhập") cũng bị xóa khi login.
- Gộp các chỗ clear storage rải rác trong `useAuth` về `clearChatSessionStorage()` (xóa cả owner key) để phủ trường hợp widget chưa mount (vd. logout ở trang dashboard); dẹp luôn literal key trùng lặp.

## Files
- `src/hooks/useChatAi/useChatSession.ts` — owner tag, `resetForOwner`, effect reset-theo-identity, export `clearChatSessionStorage()`.
- `src/hooks/useChatAi/useChatLogic.ts` — truyền `{ isAuthenticated, userId }` vào session.
- `src/hooks/useAuth/index.tsx` — dùng `clearChatSessionStorage()`.
- `src/hooks/useChatAi/useChatSession.test.ts` — test mới.

## Test
`useChatSession.test.ts` (4/4 pass): guest→login, logout, switch account, và **guard giữ lịch sử khi reload**.

| Gate | Kết quả |
|---|---|
| `tsc --noEmit` | ✅ exit 0 |
| `eslint` | ✅ exit 0 |
| `i18n:check` | ✅ 3043 keys |
| `vitest` (chat session) | ✅ 4/4 |

Chưa drive app thật trên browser; verify qua unit test đúng các kịch bản identity.