### PR TITLE
feat(chat): let guests send 5 AI messages before a login gate

### DIFF
--- a/docs/superpowers/specs/2026-07-10-guest-chat-quota-design.md
+++ b/docs/superpowers/specs/2026-07-10-guest-chat-quota-design.md
@@ -1,0 +1,238 @@
+# Guest Chat Quota — allow N anonymous messages before requiring login
+
+- **Date:** 2026-07-10
+- **Status:** Approved (design), pending implementation plan
+- **Repos touched:** `smartrent-fe` (primary), `smartrent-backend` (narrow security change)
+- **Repos verified, no change:** `smartrent-ai`
+- **Depends on:** PR #397 (`fix/ai-chat-session-account-leak`) — extends
+  `clearChatSessionStorage()` and the identity-reset effect it introduced.
+
+## 1. Problem
+
+Today an unauthenticated visitor cannot use the AI chatbot at all. The
+frontend short-circuits every guest message in
+`useChatLogic.sendMessage` (`src/hooks/useChatAi/useChatLogic.ts:146`) and
+returns a "please login" bot bubble without ever calling the API.
+
+We want guests to **try** the assistant: a guest may send **5 messages**;
+after that the input is gated behind login.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- A guest can send up to 5 messages and receive real AI answers.
+- On the 6th attempt the input is blocked and an inline login CTA is shown.
+- Logging in (or out) resets the guest allowance and clears guest chat, in
+  step with the session-reset behaviour from PR #397.
+
+**Non-goals**
+
+- Hardened, un-bypassable server-side per-guest quota. The gate is a
+  frontend UX/conversion control; abuse/cost is bounded by the existing
+  backend per-IP rate limiter (`ChatRateLimitService`).
+- Changing the authenticated user experience (still unlimited, still
+  personalised, still per-user rate-limited).
+- Enabling the non-stream fallback endpoint for guests.
+
+## 3. Locked decisions
+
+| Decision            | Value                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Limit N             | **5** guest **user** messages                                                                                   |
+| Enforcement         | **Frontend-only** soft gate; backend IP rate-limit is the abuse backstop                                        |
+| Counter persistence | **`sessionStorage`** (per browser tab)                                                                          |
+| At limit            | **Disable the input** + show an inline bot CTA message with a **"Đăng nhập"** button that opens the auth dialog |
+
+## 4. Architecture overview
+
+```
+Guest sends message
+  └─ useChatLogic.sendMessage
+       ├─ if !isAuthenticated:
+       │     ├─ limitReached? → add login-CTA message, stop
+       │     └─ else → increment guest counter, continue (user_id = null)
+       └─ streamChat → POST /v1/ai/chat/stream (no Bearer)
+            └─ [BE] SecurityConfig: optional-auth POST → anon allowed,
+                     IP rate-limit, no user_id injected
+                 └─ [AI] require_internal_key (proxy auth) → user_id=None OK
+                      └─ auth-only tools return "please login" hints, no crash
+```
+
+## 5. Frontend design (`smartrent-fe`)
+
+### 5.1 New hook — `useGuestChatQuota`
+
+`src/hooks/useChatAi/useGuestChatQuota.ts`
+
+- Constant `GUEST_MESSAGE_LIMIT = 5`.
+- `sessionStorage` key `smart-rent-ai-guest-msg-count`.
+- Signature: `useGuestChatQuota(isAuthenticated: boolean)`.
+- State `count`, seeded once from `sessionStorage` (lazy `useState`
+  initialiser).
+- Returns `{ count, limitReached, increment }` where
+  `limitReached = !isAuthenticated && count >= GUEST_MESSAGE_LIMIT`.
+- `increment()` → `count + 1`, persisted to `sessionStorage`.
+- **Reset effect:** track previous `isAuthenticated` in a ref; when the value
+  changes (login _or_ logout edge) reset `count` to 0 and clear storage.
+  - The subtle owner-tag guard used for chat _history_ is **not** needed for
+    the counter: the counter is only meaningful for guests, and a stale
+    authenticated count is never read. A genuine guest reload produces no
+    auth edge, so its count is preserved; a logged-in reload's
+    `false→true` hydration edge merely resets an unused counter.
+- Export `clearGuestQuotaStorage()` so auth handlers can wipe the counter
+  even when the widget is unmounted (mirrors `clearChatSessionStorage`).
+
+### 5.2 `useChatLogic.sendMessage`
+
+Replace the current guest short-circuit
+(`src/hooks/useChatAi/useChatLogic.ts:146-156`):
+
+```ts
+if (!isAuthenticated) {
+  if (guestQuota.limitReached) return // input is already disabled; no-op guard
+  guestQuota.increment() // consume one guest turn, then fall through
+}
+// ... existing streaming path; user_id already sent as `user?.userId ?? null`
+```
+
+- The counter is consumed at **dispatch** time (one increment per guest
+  user message). A failed/aborted stream still consumes the turn — accepted
+  as a simplification; revisit only if it proves annoying in testing.
+- Expose `guestLimitReached` from the hook for the input-disable wiring.
+
+### 5.3 Login CTA message
+
+- Extend `TChatMessage` with an optional `action?: 'login'` field.
+- CTA message: `{ id: 'guest-limit-cta', content: t('guestLimitReached'),
+sender: 'bot', action: 'login' }`. The stable id makes `addMessage`
+  dedupe it (idempotent).
+- **When shown:** an effect in `useChatLogic` adds the CTA once when
+  `guestLimitReached && !isLoading` — i.e. _after_ the 5th answer finishes
+  streaming, not mid-stream.
+- `AiChatBubble` (`src/components/molecules/aiChatBubble/index.tsx`): when
+  `message.action === 'login'`, render a "Đăng nhập" button that calls
+  `useAuthDialog().openAuth('login')`.
+
+### 5.4 Input disable
+
+- Thread `guestLimitReached` from `useChatLogic` → `AiChatWidget` →
+  `AiChatInterface` → `AiChatInput`.
+- `AiChatInput` gains a `disabled?: boolean` prop and a distinct disabled
+  placeholder ("Đăng nhập để tiếp tục chat"). Effective disabled state =
+  `isLoading || disabled`.
+
+### 5.5 i18n
+
+Add to **both** `messages/en.json` and `messages/vi.json` under `aiChat`:
+
+- `guestLimitReached` — CTA bubble text.
+- `loginToContinue` — button label + disabled-input placeholder.
+
+### 5.6 Interaction with PR #397
+
+- On login/logout the chat session already resets to the welcome message
+  (identity-reset effect in `useChatSession`). We add the guest counter to
+  the same lifecycle: `clearChatSessionStorage()` also calls
+  `clearGuestQuotaStorage()`, and `useGuestChatQuota`'s own edge effect
+  resets the in-memory count. Net effect: after login the guest's history
+  _and_ allowance are gone and the CTA disappears.
+
+## 6. Backend design (`smartrent-backend`)
+
+The controller already handles anonymous callers: `chatStream`
+(`ChatController.java:161-178`) derives identity from the JWT when present,
+else the client IP, rate-limits per identity, and only injects
+`user_id`/`auth_token` when authenticated.
+
+The only blocker is Spring Security. `/v1/ai/chat/stream` is **not** in the
+public POST allowlist of the base `application.yml` (only in
+`application-local.yaml`), so anonymous requests get 401 in dev/prod.
+
+**Pitfall:** simply adding it to the public POST allowlist is wrong. The
+`bearerTokenResolver` (`SecurityConfig.java:122-129`) returns `null` (skips
+JWT entirely) for public POST endpoints — which would make **authenticated**
+users be treated as anonymous, losing personalisation and per-user
+rate-limiting.
+
+**Fix — optional-auth for POST** (mirror the existing GET mechanism):
+
+1. `application.yml`: add **`"/v1/ai/chat/stream"`** to
+   `authorize-ignored.methods.post` (narrow — do _not_ open `/v1/ai/**`).
+2. `SecurityConfig.java`: add
+   `OPTIONAL_AUTH_POST_PATTERNS = { "/v1/ai/chat/stream" }` and make
+   `isOptionalAuthPath` also match POST. This excludes the endpoint from the
+   "skip JWT" branch so a present Bearer token is still processed, while the
+   allowlist entry lets anonymous callers through `.authenticated()`.
+
+Result: anon → allowed, no token, IP rate-limit; authed → token processed,
+`user_id` injected, per-user rate-limit. Unchanged for everyone else.
+
+The non-stream `/v1/ai/chat` stays authenticated-only (it has no IP
+rate-limit), so guests use the streaming path only. The FE default is
+streaming (`ENV.CHAT_STREAMING_ENABLED`), so this is sufficient.
+
+## 7. AI service (`smartrent-ai`) — verified, no change
+
+Confirmed guest-safe end to end:
+
+- DTO `user_id: Optional[str] = None` (`app/dto/chat.py:25`).
+- Endpoints guarded by `require_internal_key` (`app/api/v1/chat.py:95`) —
+  proxy→AI auth, independent of the user JWT.
+- `ToolContext` accepts `None` for both fields (`app/agent/tool_context.py`).
+- All 8 auth-requiring tools guard `if not token: return {status:error, "…chưa
+đăng nhập…"}` (save_listing, get_user_info, get_recommendations,
+  notifications_inbox, report_listing, update_listing_price,
+  bulk_save_listings, my_listings_status) — no crash for guests.
+- Public tools (search_listings, get_listing_detail, compare_listings) need
+  no auth; the core guest use-case works.
+- Suggestions adapt via `build_suggestions(..., bool(auth_token))`
+  (`app/agent/orchestrator.py:859`).
+
+Action: **smoke-test once** before the demo; no code change.
+
+## 8. Edge cases
+
+- Guest hits 5, reloads: `count=5` persists (sessionStorage) → still gated.
+- Guest opens a new tab / clears storage: allowance resets. Accepted
+  (frontend-only); backend IP rate-limit remains the abuse backstop.
+- Guest reaches limit then logs in: session + counter reset, CTA gone,
+  starts fresh as an authenticated user.
+- Stream error on a guest turn: the turn is still counted (simplification).
+- 5th answer still streaming: CTA deferred until `!isLoading`; input already
+  disabled by `isLoading`.
+
+## 9. Risks & mitigations (defense framing)
+
+| Risk                                       | Severity           | Mitigation / framing                                                                                            |
+| ------------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| AI service rejects `user_id=null`          | 🟢 (verified safe) | Smoke-test before demo                                                                                          |
+| Guest bypasses FE gate                     | 🟡                 | "FE gate = conversion UX; BE per-IP rate-limit = abuse control." Know the configured bucket size.               |
+| Anonymous access to AI endpoint (cost/DoS) | 🟢                 | Narrow optional-auth (only `/v1/ai/chat/stream`); IP rate-limit; N=5 soft cap. A deliberate, defensible choice. |
+
+## 10. Testing
+
+- **`useGuestChatQuota` (vitest):** counts to 5 → `limitReached`; resets on
+  login and logout edges; preserves count on a guest "reload" (no edge).
+- **`useChatLogic` (vitest):** guest under limit dispatches (stream mock
+  called); guest at limit does not dispatch and the CTA message is added;
+  authenticated user is never gated.
+- **Backend (JUnit):** `isOptionalAuthPath` returns true for POST
+  `/v1/ai/chat/stream`; anonymous stream request is not 401; authenticated
+  request still injects `user_id`.
+- Gates: `npm run lint`, `npm run typecheck`, `npm run i18n:check`,
+  `npm run test` (FE); backend `mvn test` for the security change.
+
+## 11. Rollout / verification
+
+1. Ship FE + BE changes on a branch off `origin/main` (after PR #397 is
+   merged, so `clearChatSessionStorage` exists on main; otherwise rebase).
+2. Deploy backend security change; verify anon `POST /v1/ai/chat/stream`
+   returns `200` and an authed request still personalises.
+3. Manual e2e: guest sends 5 → answers stream → 6th blocked with CTA →
+   click "Đăng nhập" → login → chat resets, unlimited.
+
+## 12. Open follow-ups (out of scope)
+
+- Optional hardened backend per-IP guest quota (Redis) if a security-heavy
+  review later demands it. Not built now by decision.

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -3,10 +3,11 @@ import { useTranslations } from 'next-intl'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Link from 'next/link'
-import { Maximize2, Phone } from 'lucide-react'
+import { LogIn, Maximize2, Phone } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { TChatMessage } from '@/hooks/useChatAi'
+import { useAuthDialog } from '@/contexts/authDialog'
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
 import {
@@ -204,6 +205,7 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
   const hasListings = isBot && message.listings && message.listings.length > 0
   const t = useTranslations('chat')
   const tAi = useTranslations('aiChat')
+  const { openAuth } = useAuthDialog()
   const tools = message.toolsUsed || []
   const [showAllResults, setShowAllResults] = useState(false)
   const [showExpandDialog, setShowExpandDialog] = useState(false)
@@ -297,6 +299,19 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
               </p>
             )}
           </div>
+        )}
+
+        {/* Login CTA - shown on the guest message-limit prompt */}
+        {isBot && message.action === 'login' && (
+          <Button
+            type='button'
+            size='sm'
+            className='mt-1 gap-1.5'
+            onClick={() => openAuth('login')}
+          >
+            <LogIn className='w-4 h-4' aria-hidden='true' />
+            {tAi('loginToContinue')}
+          </Button>
         )}
 
         {/* Expand button - shown when message contains a markdown table */}

--- a/src/components/molecules/aiChatInput/index.tsx
+++ b/src/components/molecules/aiChatInput/index.tsx
@@ -11,6 +11,8 @@ type TAiChatInputProps = {
   onChange: (value: string) => void
   onSubmit: (value: string) => void
   isLoading?: boolean
+  /** Hard-disables the input (e.g. a guest who hit the free message limit). */
+  disabled?: boolean
   isMobile?: boolean
   className?: string
 }
@@ -20,6 +22,7 @@ const AiChatInput: FC<TAiChatInputProps> = ({
   onChange,
   onSubmit,
   isLoading = false,
+  disabled = false,
   isMobile = false,
   className,
 }) => {
@@ -28,18 +31,21 @@ const AiChatInput: FC<TAiChatInputProps> = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const t = useTranslations('aiChat')
 
+  // Blocked = mid-stream (isLoading) or gated (disabled). Both prevent sending.
+  const isBlocked = isLoading || disabled
+
   //Init event handle
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      if (value.trim() && !isLoading) {
+      if (value.trim() && !isBlocked) {
         onSubmit(value)
       }
     }
   }
 
   const handleSubmit = () => {
-    if (value.trim() && !isLoading) {
+    if (value.trim() && !isBlocked) {
       onSubmit(value)
     }
   }
@@ -75,8 +81,8 @@ const AiChatInput: FC<TAiChatInputProps> = ({
           onKeyDown={handleKeyDown}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          placeholder={t('placeholder')}
-          disabled={isLoading}
+          placeholder={disabled ? t('loginToContinue') : t('placeholder')}
+          disabled={isBlocked}
           rows={1}
           className={cn(
             'max-h-[120px] min-h-[44px] w-full resize-none bg-transparent px-3 py-3 text-sm',
@@ -93,12 +99,12 @@ const AiChatInput: FC<TAiChatInputProps> = ({
         variant='ghost'
         size='icon'
         onClick={handleSubmit}
-        disabled={!value.trim() || isLoading}
+        disabled={!value.trim() || isBlocked}
         isLoading={isLoading}
         className={cn(
           'flex-shrink-0 transition-all duration-200 text-primary',
           !value.trim() && !isLoading && 'opacity-50',
-          value.trim() && !isLoading && 'hover:scale-105',
+          value.trim() && !isBlocked && 'hover:scale-105',
         )}
         aria-label={t('send')}
       >

--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -30,6 +30,8 @@ type TAiChatInterfaceProps = {
   /** Cancel the in-flight SSE stream — wired through to the typing
    * indicator's × button. */
   onStopStreaming?: () => void
+  /** Guest hit the free message limit — disables the input behind the login CTA. */
+  guestLimitReached?: boolean
   isMobile?: boolean
   className?: string
 }
@@ -50,6 +52,7 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
   onSendMessage,
   onViewListingDetail,
   onStopStreaming,
+  guestLimitReached = false,
   isMobile = false,
   className,
 }) => {
@@ -197,6 +200,7 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
           onChange={onInputChange}
           onSubmit={onSendMessage}
           isLoading={isLoading}
+          disabled={guestLimitReached}
           isMobile={isMobile}
         />
       </div>

--- a/src/components/organisms/aiChatWidget/index.tsx
+++ b/src/components/organisms/aiChatWidget/index.tsx
@@ -38,6 +38,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
     isTyping,
     streamingStatus,
     inputValue,
+    guestLimitReached,
     scrollRef,
     bottomRef,
     contentRef,
@@ -156,6 +157,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
                 onSendMessage={sendMessage}
                 onViewListingDetail={viewListingDetail}
                 onStopStreaming={cancelStream}
+                guestLimitReached={guestLimitReached}
                 isMobile
                 className='flex-1 min-h-0'
               />
@@ -215,6 +217,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
                   onSendMessage={sendMessage}
                   onViewListingDetail={viewListingDetail}
                   onStopStreaming={cancelStream}
+                  guestLimitReached={guestLimitReached}
                   isMobile={false}
                   className='flex-1 min-h-0'
                 />

--- a/src/hooks/useChatAi/useChatLogic.guestQuota.test.ts
+++ b/src/hooks/useChatAi/useChatLogic.guestQuota.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { AiService } from '@/api/services/ai.service'
+import { useChatLogic } from './useChatLogic'
+
+const COUNT_KEY = 'smart-rent-ai-guest-msg-count'
+
+// --- Dependency isolation (auth state, DOM-coupled scroll, network, i18n) ---
+
+const { authRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      isAuthenticated: false,
+      user: null as { userId: string } | null,
+    },
+  },
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => authRef.current,
+}))
+
+vi.mock('next-intl', () => {
+  const t = ((key: string) => key) as ((key: string) => string) & {
+    raw: (key: string) => unknown
+  }
+  t.raw = () => []
+  return { useTranslations: () => t, useLocale: () => 'vi' }
+})
+
+vi.mock('./useChatScroll', () => ({
+  useChatScroll: () => ({
+    scrollRef: { current: null },
+    bottomRef: { current: null },
+    contentRef: { current: null },
+    isAtBottom: true,
+    reservedSpace: 0,
+    scrollToMessage: vi.fn(),
+    scrollToBottom: vi.fn(),
+    anchorMessageToTop: vi.fn(),
+    finalizeReservedSpace: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api/services/chatbot.service', () => ({
+  streamChat: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/services/ai.service', () => ({
+  AiService: {
+    chat: vi.fn().mockResolvedValue({
+      data: {
+        message: { content: 'ok' },
+        listings: null,
+        metadata: { tools_used: [] },
+      },
+    }),
+  },
+}))
+
+const setAuth = (isAuthenticated: boolean, userId?: string) => {
+  authRef.current = {
+    isAuthenticated,
+    user: userId ? { userId } : null,
+  }
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  vi.clearAllMocks()
+  setAuth(false)
+})
+
+describe('useChatLogic guest quota gating', () => {
+  it('blocks a guest at the limit: shows login CTA, exposes flag, does not dispatch', async () => {
+    setAuth(false)
+    sessionStorage.setItem(COUNT_KEY, '5')
+
+    const { result } = renderHook(() => useChatLogic())
+
+    expect(result.current.guestLimitReached).toBe(true)
+    expect(
+      result.current.messages.some((m) => m.id === 'guest-limit-cta'),
+    ).toBe(true)
+
+    await act(async () => {
+      await result.current.sendMessage('hello')
+    })
+
+    expect(AiService.chat).not.toHaveBeenCalled()
+    expect(result.current.messages.some((m) => m.sender === 'user')).toBe(false)
+  })
+
+  it('lets a guest under the limit send, and consumes one turn', async () => {
+    setAuth(false)
+
+    const { result } = renderHook(() => useChatLogic())
+
+    expect(result.current.guestLimitReached).toBe(false)
+
+    await act(async () => {
+      await result.current.sendMessage('tìm phòng trọ')
+    })
+
+    expect(AiService.chat).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem(COUNT_KEY)).toBe('1')
+    expect(
+      result.current.messages.some(
+        (m) => m.sender === 'user' && m.content === 'tìm phòng trọ',
+      ),
+    ).toBe(true)
+  })
+
+  it('never gates an authenticated user, even past the guest count', async () => {
+    setAuth(true, 'u1')
+    sessionStorage.setItem(COUNT_KEY, '5')
+
+    const { result } = renderHook(() => useChatLogic())
+
+    expect(result.current.guestLimitReached).toBe(false)
+
+    await act(async () => {
+      await result.current.sendMessage('hi')
+    })
+
+    expect(AiService.chat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -13,7 +13,12 @@ import type {
 import { ENV } from '@/constants'
 import { useChatSession } from './useChatSession'
 import { useChatScroll } from './useChatScroll'
+import { useGuestChatQuota, GUEST_MESSAGE_LIMIT } from './useGuestChatQuota'
 import { useAuth } from '@/hooks/useAuth'
+
+// Stable id for the one-shot login CTA shown once a guest hits the message
+// limit. A fixed id makes addMessage dedupe it (idempotent across renders).
+const GUEST_LIMIT_CTA_ID = 'guest-limit-cta'
 
 export type TChatMessage = {
   id: string
@@ -29,6 +34,9 @@ export type TChatMessage = {
   }>
   toolsUsed?: string[]
   suggestions?: ChatSuggestion[]
+  /** Marks a bot message that should render an inline action button (e.g. the
+   *  guest login CTA shown after the free message limit is reached). */
+  action?: 'login'
 }
 
 export type TChatState = {
@@ -74,6 +82,11 @@ export const useChatLogic = () => {
   const locale = useLocale() as 'vi' | 'en'
   const t = useTranslations('aiChat')
   const { isAuthenticated, user } = useAuth()
+
+  // Guest message allowance: a logged-out visitor may send a few messages
+  // before the chat is gated behind login.
+  const { limitReached: guestLimitReached, increment: incrementGuestQuota } =
+    useGuestChatQuota(isAuthenticated)
 
   // Initialize with welcome message + curated starter suggestions so a fresh
   // chat offers one-tap entry points (the backend only sends suggestions after
@@ -130,6 +143,22 @@ export const useChatLogic = () => {
     }
   }, [])
 
+  // Once a guest exhausts their free messages, surface a one-shot login CTA in
+  // the transcript (and scroll to it). Deferred until the stream settles so it
+  // lands after the final answer rather than mid-stream. addMessage dedupes on
+  // the fixed id, so this stays idempotent across renders.
+  useEffect(() => {
+    if (!guestLimitReached || isLoading) return
+    addMessage({
+      id: GUEST_LIMIT_CTA_ID,
+      content: t('guestLimitReached', { count: GUEST_MESSAGE_LIMIT }),
+      sender: 'bot',
+      timestamp: new Date(),
+      action: 'login',
+    })
+    scrollToMessage(GUEST_LIMIT_CTA_ID)
+  }, [guestLimitReached, isLoading, addMessage, t, scrollToMessage])
+
   const generateMessageId = useCallback(() => {
     const timestamp = Date.now()
     const randomBytes = new Uint8Array(8)
@@ -148,15 +177,12 @@ export const useChatLogic = () => {
       const trimmedContent = content.trim()
 
       if (!isAuthenticated) {
-        const loginRequiredMessage: TChatMessage = {
-          id: generateMessageId(),
-          content: t('loginRequired'),
-          sender: 'bot',
-          timestamp: new Date(),
-        }
-        addMessage(loginRequiredMessage)
-        scrollToMessage(loginRequiredMessage.id)
-        return
+        // At the limit the input is already disabled; this guards the
+        // programmatic path (suggestion clicks, viewListingDetail). The login
+        // CTA is surfaced by the effect below, not here.
+        if (guestLimitReached) return
+        // Under the limit — consume one guest turn and fall through to send.
+        incrementGuestQuota()
       }
 
       // Cancel any prior in-flight stream before starting a new one
@@ -391,8 +417,9 @@ export const useChatLogic = () => {
     [
       isLoading,
       isAuthenticated,
+      guestLimitReached,
+      incrementGuestQuota,
       user?.userId,
-      scrollToMessage,
       anchorMessageToTop,
       finalizeReservedSpace,
       messages,
@@ -448,6 +475,7 @@ export const useChatLogic = () => {
     isTyping,
     streamingStatus,
     inputValue,
+    guestLimitReached,
     scrollRef,
     bottomRef,
     contentRef,

--- a/src/hooks/useChatAi/useChatSession.ts
+++ b/src/hooks/useChatAi/useChatSession.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 
 import type { TChatMessage } from './useChatLogic'
+import { clearGuestQuotaStorage } from './useGuestChatQuota'
 
 const CHAT_SESSION_KEY = 'smart-rent-ai-chat-session'
 // Records which identity the persisted messages belong to, so a login/logout/
@@ -34,6 +35,9 @@ export const clearChatSessionStorage = () => {
   } catch {
     // Silent fail - session storage might be unavailable
   }
+  // The guest message allowance is part of the same chat lifecycle: wipe it on
+  // login/logout so the next identity starts with a fresh (or no) allowance.
+  clearGuestQuotaStorage()
 }
 
 function readStoredOwner(): string | null {

--- a/src/hooks/useChatAi/useGuestChatQuota.test.ts
+++ b/src/hooks/useChatAi/useGuestChatQuota.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import {
+  useGuestChatQuota,
+  clearGuestQuotaStorage,
+  GUEST_MESSAGE_LIMIT,
+} from './useGuestChatQuota'
+
+const COUNT_KEY = 'smart-rent-ai-guest-msg-count'
+
+const renderQuota = (initialAuth: boolean) =>
+  renderHook(({ auth }) => useGuestChatQuota(auth), {
+    initialProps: { auth: initialAuth },
+  })
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe('useGuestChatQuota', () => {
+  it('lets a guest send up to the limit, then flips limitReached', () => {
+    const { result } = renderQuota(false)
+
+    expect(result.current.count).toBe(0)
+    expect(result.current.limitReached).toBe(false)
+
+    for (let i = 0; i < GUEST_MESSAGE_LIMIT - 1; i++) {
+      act(() => result.current.increment())
+    }
+    expect(result.current.count).toBe(GUEST_MESSAGE_LIMIT - 1)
+    expect(result.current.limitReached).toBe(false)
+
+    act(() => result.current.increment())
+    expect(result.current.count).toBe(GUEST_MESSAGE_LIMIT)
+    expect(result.current.limitReached).toBe(true)
+    expect(sessionStorage.getItem(COUNT_KEY)).toBe(String(GUEST_MESSAGE_LIMIT))
+  })
+
+  it('never limits an authenticated user, even past the count', () => {
+    sessionStorage.setItem(COUNT_KEY, String(GUEST_MESSAGE_LIMIT))
+    const { result } = renderQuota(true)
+
+    expect(result.current.limitReached).toBe(false)
+  })
+
+  it('resets the counter when a guest logs in', () => {
+    const { result, rerender } = renderQuota(false)
+
+    for (let i = 0; i < GUEST_MESSAGE_LIMIT; i++) {
+      act(() => result.current.increment())
+    }
+    expect(result.current.limitReached).toBe(true)
+
+    rerender({ auth: true })
+
+    expect(result.current.count).toBe(0)
+    expect(result.current.limitReached).toBe(false)
+  })
+
+  it('resets the counter on logout so the next guest gets a fresh allowance', () => {
+    sessionStorage.setItem(COUNT_KEY, '3')
+    const { result, rerender } = renderQuota(false)
+
+    expect(result.current.count).toBe(3) // preserved on mount (guest, no edge)
+
+    rerender({ auth: true }) // login edge
+    expect(result.current.count).toBe(0)
+
+    rerender({ auth: false }) // logout edge
+    expect(result.current.count).toBe(0)
+  })
+
+  it('preserves the count across a guest reload (no auth edge)', () => {
+    sessionStorage.setItem(COUNT_KEY, '3')
+    const { result } = renderQuota(false)
+
+    expect(result.current.count).toBe(3)
+    expect(result.current.limitReached).toBe(false)
+  })
+
+  it('clearGuestQuotaStorage removes the stored count', () => {
+    sessionStorage.setItem(COUNT_KEY, '4')
+    clearGuestQuotaStorage()
+    expect(sessionStorage.getItem(COUNT_KEY)).toBeNull()
+  })
+})

--- a/src/hooks/useChatAi/useGuestChatQuota.ts
+++ b/src/hooks/useChatAi/useGuestChatQuota.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+// How many messages an unauthenticated visitor may send before the chat is
+// gated behind login. The gate is a frontend UX/conversion control; backend
+// per-IP rate limiting is the abuse backstop.
+export const GUEST_MESSAGE_LIMIT = 5
+
+const COUNT_KEY = 'smart-rent-ai-guest-msg-count'
+
+/** Clears the guest message counter. Exposed so auth handlers can wipe it on
+ *  login/logout even when the chat widget is unmounted (mirrors
+ *  clearChatSessionStorage). */
+export const clearGuestQuotaStorage = () => {
+  try {
+    sessionStorage.removeItem(COUNT_KEY)
+  } catch {
+    // Silent fail - session storage might be unavailable
+  }
+}
+
+function readStoredCount(): number {
+  try {
+    const raw = sessionStorage.getItem(COUNT_KEY)
+    if (!raw) return 0
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isNaN(parsed) || parsed < 0 ? 0 : parsed
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Tracks how many messages a guest has sent this browser tab and whether they
+ * have hit the login gate.
+ *
+ * The counter lives in sessionStorage (per-tab) and only matters while
+ * unauthenticated. It resets whenever `isAuthenticated` changes value
+ * (login or logout edge): a real login starts the authenticated experience
+ * fresh, and a logout hands the next guest a fresh allowance. A genuine guest
+ * reload produces no edge, so the count is preserved; a logged-in reload's
+ * `false -> true` hydration edge merely resets an unused counter.
+ */
+export const useGuestChatQuota = (isAuthenticated: boolean) => {
+  const [count, setCount] = useState<number>(() => readStoredCount())
+
+  const prevAuthRef = useRef(isAuthenticated)
+
+  useEffect(() => {
+    if (prevAuthRef.current === isAuthenticated) return
+    prevAuthRef.current = isAuthenticated
+
+    clearGuestQuotaStorage()
+    setCount(0)
+  }, [isAuthenticated])
+
+  const increment = useCallback(() => {
+    setCount((prev) => {
+      const next = prev + 1
+      try {
+        sessionStorage.setItem(COUNT_KEY, String(next))
+      } catch {
+        // Silent fail
+      }
+      return next
+    })
+  }, [])
+
+  const limitReached = !isAuthenticated && count >= GUEST_MESSAGE_LIMIT
+
+  return { count, limitReached, increment }
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -53,6 +53,8 @@
     "messageInput": "Message input",
     "attachFile": "Attach file",
     "loginRequired": "Please log in to use the AI assistant. Logging in helps us provide a better experience and save your conversation history.",
+    "guestLimitReached": "You've used all {count} free messages. Log in to keep chatting.",
+    "loginToContinue": "Log in to continue",
     "scrollToBottom": "Scroll to bottom",
     "expandTable": "View full",
     "expandTableTitle": "Comparison Details",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -53,6 +53,8 @@
     "messageInput": "Nhập tin nhắn",
     "attachFile": "Đính kèm tệp",
     "loginRequired": "Vui lòng đăng nhập để sử dụng trợ lý AI. Đăng nhập giúp chúng tôi cung cấp trải nghiệm tốt hơn và lưu lịch sử trò chuyện của bạn.",
+    "guestLimitReached": "Bạn đã dùng hết {count} tin nhắn miễn phí. Đăng nhập để tiếp tục trò chuyện.",
+    "loginToContinue": "Đăng nhập để tiếp tục",
     "scrollToBottom": "Cuộn xuống cuối",
     "expandTable": "Xem đầy đủ",
     "expandTableTitle": "Chi tiết so sánh",


### PR DESCRIPTION
## Mục tiêu
Trước đây guest (chưa đăng nhập) bị chặn hoàn toàn khỏi chatbot. Giờ guest được **gửi 5 tin** và nhận trả lời AI thật; tin thứ 6 → **disable input + tin CTA đăng nhập** inline.

## Quyết định (đã chốt với owner)
- **N = 5** tin của guest.
- **Enforce FE-only** (soft gate). Backend per-IP rate-limit (`ChatRateLimitService`) là chốt chặn abuse.
- Bộ đếm lưu **sessionStorage** (theo tab).
- Đạt hạn: disable input + tin CTA có nút **"Đăng nhập để tiếp tục"** (mở auth dialog).

## Thay đổi
- **`useGuestChatQuota.ts`** (mới) — đếm 5 tin/tab, `limitReached`, reset trên edge `isAuthenticated` (login/logout). Export `clearGuestQuotaStorage()`.
- **`useChatLogic.ts`** — guest dưới hạn → gửi thật (`user_id=null`) + consume 1 lượt; đạt hạn → chặn; effect thêm tin CTA `action:'login'` (hoãn tới khi `!isLoading`); expose `guestLimitReached`.
- **`useChatSession.ts`** — `clearChatSessionStorage()` xoá luôn quota (ăn khớp reset session lúc login/logout — nối tiếp #397).
- **`aiChatBubble`** — nút CTA đăng nhập cho message `action:'login'`.
- **`aiChatInput`** — prop `disabled` + placeholder gate; **`aiChatInterface`/`aiChatWidget`** thread `guestLimitReached`.
- **i18n** — `guestLimitReached` (ICU `{count}`) + `loginToContinue` (en + vi).

## Phụ thuộc
Cần **PR backend optional-auth whitelist `/v1/ai/chat/stream`** (repo `smartrent-backend`) để guest chạm được AI ở dev/prod (nếu không sẽ 401). AI service đã verify guest-safe, không cần sửa.

## Spec
`docs/superpowers/specs/2026-07-10-guest-chat-quota-design.md` (kèm trong PR này).

## Test (TDD)
| Gate | Kết quả |
|---|---|
| `tsc --noEmit` | ✅ |
| `eslint` (touched) | ✅ |
| `i18n:check` | ✅ 3045 keys |
| `vitest run` | ✅ 17/17 (9 test mới: quota + gating) |

9 test mới đều watch-fail trước, pass sau. Guest chat **e2e thật** cần full stack → smoke-test khi deploy (theo spec).