### PR TITLE
feat(ai-chat): denser listing cards, responsive grid, maximize toggle & image carousel

### DIFF
--- a/src/components/molecules/CardListingAIDetail/index.tsx
+++ b/src/components/molecules/CardListingAIDetail/index.tsx
@@ -15,10 +15,13 @@ import {
   DollarSign,
   Star,
   Check,
+  ChevronLeft,
+  ChevronRight,
 } from 'lucide-react'
 
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
+import { Typography } from '@/components/atoms/typography'
 import { cn } from '@/lib/utils'
 import { formatByLocale } from '@/utils/currency/convert'
 import { useLanguage } from '@/hooks/useLanguage'
@@ -34,14 +37,19 @@ export interface CardListingAIDetailProps {
   onViewDetail?: (listingId: number) => void
 }
 
-const UTILITY_LABELS: Record<
-  string,
-  { icon: React.ElementType; label: string }
-> = {
-  waterPrice: { icon: Droplets, label: 'Nước' },
-  electricityPrice: { icon: Zap, label: 'Điện' },
-  internetPrice: { icon: Wifi, label: 'Internet' },
-  serviceFee: { icon: DollarSign, label: 'DV' },
+const UTILITY_ICONS: Record<string, React.ElementType> = {
+  waterPrice: Droplets,
+  electricityPrice: Zap,
+  internetPrice: Wifi,
+  serviceFee: DollarSign,
+}
+
+// Maps the API price field to its short label key under chat.listing.utilities.
+const UTILITY_LABEL_KEYS: Record<string, string> = {
+  waterPrice: 'water',
+  electricityPrice: 'electricity',
+  internetPrice: 'internet',
+  serviceFee: 'service',
 }
 
 export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
@@ -84,8 +92,29 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
     listingStatus,
   } = listing
 
-  const primaryImage =
-    media?.find((m) => m.isPrimary)?.url || media?.[0]?.url || DEFAULT_IMAGE
+  // Gallery images, primary first, with a safe fallback so there is always
+  // at least one slide.
+  const images = React.useMemo(() => {
+    const withUrl = (media || []).filter((m) => Boolean(m.url))
+    const ordered = [...withUrl].sort(
+      (a, b) => Number(b.isPrimary) - Number(a.isPrimary),
+    )
+    const urls = ordered.map((m) => m.url)
+    return urls.length > 0 ? urls : [DEFAULT_IMAGE]
+  }, [media])
+  const totalImages = images.length
+  const [currentImageIndex, setCurrentImageIndex] = React.useState(0)
+
+  const handlePrevImage = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCurrentImageIndex((prev) => (prev === 0 ? totalImages - 1 : prev - 1))
+  }
+  const handleNextImage = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCurrentImageIndex((prev) => (prev === totalImages - 1 ? 0 : prev + 1))
+  }
 
   const formattedPrice = formatByLocale(price, language)
   const priceLabel =
@@ -123,15 +152,23 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
   return (
     <div
       className={cn(
-        'bg-card border border-border rounded-xl overflow-hidden flex flex-col',
+        'bg-card border border-border rounded-xl overflow-hidden flex flex-col w-full max-w-sm',
         'transition-shadow hover:shadow-md',
         className,
       )}
     >
       {/* ── Image hero ── */}
-      <div className='relative w-full aspect-[4/3] bg-muted'>
+      {/* Fixed height (not aspect-ratio): keeps the card from ballooning when
+          the chat window is widened, so a bigger window shows MORE cards
+          instead of a taller hero. */}
+      <div
+        className={cn(
+          'group relative w-full bg-muted',
+          compact ? 'h-36' : 'h-44',
+        )}
+      >
         <Image
-          src={primaryImage}
+          src={images[currentImageIndex]}
           alt={title}
           fill
           className='object-cover'
@@ -139,7 +176,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
         />
 
         {isVip && (
-          <span className='absolute top-2 left-2 inline-flex items-center gap-1 bg-white/95 text-foreground rounded-full px-2 py-0.5 text-xs font-semibold shadow-sm'>
+          <span className='absolute top-2 left-2 inline-flex items-center gap-1 bg-white/95 text-foreground rounded-full px-2 py-0.5 text-xs font-semibold shadow-sm z-10'>
             <Star
               className='w-3 h-3 fill-yellow-400 stroke-yellow-400'
               aria-hidden='true'
@@ -149,25 +186,48 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
         )}
 
         {isAvailable && (
-          <span className='absolute top-2 right-2 inline-flex items-center gap-1 bg-emerald-500/95 text-white rounded-full px-2 py-0.5 text-xs font-medium shadow-sm'>
+          <span className='absolute top-2 right-2 inline-flex items-center gap-1 bg-emerald-500/95 text-white rounded-full px-2 py-0.5 text-xs font-medium shadow-sm z-10'>
             <Check className='w-3 h-3' aria-hidden='true' />
-            Trống
+            {t('available')}
           </span>
         )}
 
-        {media && media.length > 1 && (
-          <span className='absolute bottom-2 right-2 bg-black/60 text-white rounded-md px-2 py-0.5 text-xs font-medium tabular-nums'>
-            1 / {media.length}
-          </span>
+        {/* Gallery controls — arrows reveal on hover (always visible on touch
+            where there is no hover), plus a live position counter. */}
+        {totalImages > 1 && (
+          <>
+            <button
+              type='button'
+              onClick={handlePrevImage}
+              aria-label={t('prevImage')}
+              className='absolute left-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100 hover:bg-background'
+            >
+              <ChevronLeft className='w-4 h-4' aria-hidden='true' />
+            </button>
+            <button
+              type='button'
+              onClick={handleNextImage}
+              aria-label={t('nextImage')}
+              className='absolute right-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100 hover:bg-background'
+            >
+              <ChevronRight className='w-4 h-4' aria-hidden='true' />
+            </button>
+            <span className='absolute bottom-2 right-2 bg-black/60 text-white rounded-md px-2 py-0.5 text-xs font-medium tabular-nums'>
+              {currentImageIndex + 1} / {totalImages}
+            </span>
+          </>
         )}
       </div>
 
       {/* ── Body ── */}
-      <div className='flex flex-col gap-2 p-3'>
+      <div className='flex flex-col gap-1.5 p-2.5'>
         {/* Title */}
-        <p className='text-sm font-semibold text-foreground line-clamp-2 leading-snug'>
+        <Typography
+          variant='p'
+          className='text-sm font-semibold text-foreground line-clamp-2 leading-snug'
+        >
           {title}
-        </p>
+        </Typography>
 
         {/* Price + key meta */}
         <div className='flex items-end justify-between gap-2 flex-wrap'>
@@ -247,9 +307,9 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
         {utilities.length > 0 && (
           <div className='flex flex-wrap gap-1.5'>
             {utilities.map(({ key, value }) => {
-              const config = UTILITY_LABELS[key]
-              if (!config) return null
-              const Icon = config.icon
+              const Icon = UTILITY_ICONS[key]
+              const labelKey = UTILITY_LABEL_KEYS[key]
+              if (!Icon || !labelKey) return null
               return (
                 <Badge
                   key={key}
@@ -258,7 +318,8 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
                 >
                   <Icon className='w-3 h-3' aria-hidden='true' />
                   <span>
-                    {config.label}: {formatByLocale(value!, language)}
+                    {t(`utilities.${labelKey}`)}:{' '}
+                    {formatByLocale(value!, language)}
                   </span>
                 </Badge>
               )
@@ -291,7 +352,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
       </div>
 
       {/* ── CTA row ── */}
-      <div className='flex items-center gap-2 px-3 pb-3 pt-1'>
+      <div className='flex items-center gap-2 px-2.5 pb-2.5 pt-0.5'>
         {onViewDetail ? (
           <Button
             type='button'
@@ -335,7 +396,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
             variant='outline'
             size='icon'
             className='h-9 w-9 flex-shrink-0 rounded-lg'
-            aria-label='Gọi điện'
+            aria-label={t('call')}
           >
             <a href={`tel:${cleanPhone}`} onClick={(e) => e.stopPropagation()}>
               <Phone
@@ -350,7 +411,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
             size='icon'
             className='h-9 w-9 flex-shrink-0 rounded-lg opacity-40 cursor-default'
             disabled
-            aria-label='Không có số điện thoại'
+            aria-label={t('noPhone')}
           >
             <Phone
               className='w-4 h-4 text-muted-foreground'

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -348,13 +348,19 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
                 >
                   {message.totalCount || listings.length} {t('foundListings')}
                 </Badge>
-                <div className='flex flex-col gap-3 w-full'>
+                {/* Responsive grid: 1 column in a narrow window, auto-adds
+                    columns as the chat window is widened — so a bigger window
+                    shows MORE listings side by side instead of larger cards.
+                    min(100%,260px) guards against overflow on tiny screens
+                    (the scroll area is overflow-x-hidden). */}
+                <div className='grid w-full gap-2.5 [grid-template-columns:repeat(auto-fill,minmax(min(100%,260px),1fr))]'>
                   {visibleListings.map((listing) => (
                     <CardListingAIDetail
                       key={listing.listingId}
                       listing={listing}
                       compact
                       onViewDetail={onViewListingDetail}
+                      className='max-w-none'
                     />
                   ))}
                 </div>
@@ -377,7 +383,7 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
           })()}
 
         {hasListings && !containsTable && listingDisplayMode === 'detail' && (
-          <div className='w-full flex flex-col gap-3 mt-1'>
+          <div className='w-full flex flex-col gap-2.5 mt-1'>
             {message.listings?.map((listing) => (
               <React.Fragment key={listing.listingId}>
                 {listing.user && <AiChatContactCard listing={listing} />}

--- a/src/components/organisms/aiChatHeader/index.tsx
+++ b/src/components/organisms/aiChatHeader/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Minus, Bot } from 'lucide-react'
+import { Minus, Bot, Maximize2, Minimize2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { cn } from '@/lib/utils'
@@ -8,10 +8,19 @@ import AiChatButton from '@/components/atoms/aiChatButton'
 
 type TAiChatHeaderProps = {
   onClose?: () => void
+  // When provided, renders an expand/collapse toggle (desktop only — the
+  // mobile chat is already full-screen so there is nothing to expand).
+  onToggleExpand?: () => void
+  isExpanded?: boolean
   className?: string
 }
 
-const AiChatHeader: FC<TAiChatHeaderProps> = ({ onClose, className }) => {
+const AiChatHeader: FC<TAiChatHeaderProps> = ({
+  onClose,
+  onToggleExpand,
+  isExpanded = false,
+  className,
+}) => {
   const t = useTranslations('aiChat')
 
   return (
@@ -33,6 +42,22 @@ const AiChatHeader: FC<TAiChatHeaderProps> = ({ onClose, className }) => {
       </div>
 
       <div className='flex items-center gap-0.5 md:gap-1'>
+        {onToggleExpand && (
+          <AiChatButton
+            variant='ghost'
+            size='icon'
+            onClick={onToggleExpand}
+            className='h-8 w-8 text-primary-foreground transition-all duration-200 hover:scale-105 hover:bg-primary-foreground/10'
+            aria-label={isExpanded ? t('collapseChat') : t('expandChat')}
+          >
+            {isExpanded ? (
+              <Minimize2 className='h-4 w-4 md:h-5 md:w-5' />
+            ) : (
+              <Maximize2 className='h-4 w-4 md:h-5 md:w-5' />
+            )}
+          </AiChatButton>
+        )}
+
         {onClose && (
           <AiChatButton
             variant='ghost'

--- a/src/components/organisms/aiChatWidget/index.tsx
+++ b/src/components/organisms/aiChatWidget/index.tsx
@@ -17,6 +17,10 @@ import AiChatHeader from '@/components/organisms/aiChatHeader'
 import AiChatInterface from '@/components/organisms/aiChatInterface'
 import AiChatButton from '@/components/atoms/aiChatButton'
 
+// Persist the desktop expand/collapse choice so reopening the widget keeps
+// the size the user last picked.
+const AI_CHAT_EXPANDED_STORAGE_KEY = 'smart-rent-ai-chat-expanded'
+
 type TAiChatWidgetProps = {
   className?: string
   position?: 'bottom-right' | 'bottom-left'
@@ -29,6 +33,10 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
   //Init state hook
   const [isOpen, setIsOpen] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem(AI_CHAT_EXPANDED_STORAGE_KEY) === '1'
+  })
   //Init use hook
   const isMobile = useMediaQuery(MEDIA_BELOW_MD)
   const t = useTranslations('aiChat')
@@ -58,6 +66,19 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
 
   const handleClose = () => {
     setIsOpen(false)
+  }
+
+  const handleToggleExpand = () => {
+    setIsExpanded((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem(AI_CHAT_EXPANDED_STORAGE_KEY, next ? '1' : '0')
+      } catch {
+        // localStorage may be unavailable (private mode / disabled); the
+        // toggle still works for the current session.
+      }
+      return next
+    })
   }
 
   //Init effect hook
@@ -185,8 +206,8 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
               : 'bottom-24 left-6',
           )}
           style={{
-            width: '500px',
-            height: '700px',
+            width: isExpanded ? 'min(1080px, 90vw)' : '500px',
+            height: isExpanded ? 'min(840px, 85vh)' : '700px',
             minWidth: '400px',
             minHeight: '540px',
             maxWidth: '90vw',
@@ -199,7 +220,12 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
           >
             <ResizablePanel defaultSize={100} minSize={50} maxSize={100}>
               <div className='flex h-full w-full flex-col overflow-hidden bg-background'>
-                <AiChatHeader onClose={handleClose} className='flex-shrink-0' />
+                <AiChatHeader
+                  onClose={handleClose}
+                  onToggleExpand={handleToggleExpand}
+                  isExpanded={isExpanded}
+                  className='flex-shrink-0'
+                />
 
                 <AiChatInterface
                   messages={messages}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -44,6 +44,8 @@
     "clearHistory": "Clear chat history",
     "close": "Close chat",
     "openChat": "Open chat",
+    "expandChat": "Expand chat",
+    "collapseChat": "Collapse chat",
     "confirmClear": "Are you sure you want to clear all chat history?",
     "confirmClearTitle": "Clear Chat History",
     "confirmClearDescription": "This action cannot be undone. All your conversation history will be permanently deleted.",
@@ -76,7 +78,18 @@
     "listing": {
       "viewDetails": "View Details",
       "month": "month",
-      "year": "year"
+      "year": "year",
+      "available": "Available",
+      "call": "Call",
+      "noPhone": "No phone number",
+      "prevImage": "Previous image",
+      "nextImage": "Next image",
+      "utilities": {
+        "water": "Water",
+        "electricity": "Electricity",
+        "internet": "Internet",
+        "service": "Service"
+      }
     },
     "compare": {
       "title": "Property Comparison",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -44,6 +44,8 @@
     "clearHistory": "Xóa lịch sử chat",
     "close": "Đóng chat",
     "openChat": "Mở chat",
+    "expandChat": "Phóng to khung chat",
+    "collapseChat": "Thu nhỏ khung chat",
     "confirmClear": "Bạn có chắc chắn muốn xóa toàn bộ lịch sử chat?",
     "confirmClearTitle": "Xóa Lịch Sử Chat",
     "confirmClearDescription": "Hành động này không thể hoàn tác. Toàn bộ lịch sử trò chuyện của bạn sẽ bị xóa vĩnh viễn.",
@@ -76,7 +78,18 @@
     "listing": {
       "viewDetails": "Xem Chi Tiết",
       "month": "tháng",
-      "year": "năm"
+      "year": "năm",
+      "available": "Trống",
+      "call": "Gọi điện",
+      "noPhone": "Không có số điện thoại",
+      "prevImage": "Ảnh trước",
+      "nextImage": "Ảnh sau",
+      "utilities": {
+        "water": "Nước",
+        "electricity": "Điện",
+        "internet": "Internet",
+        "service": "DV"
+      }
     },
     "compare": {
       "title": "So sánh bất động sản",


### PR DESCRIPTION
## Vấn đề
Khung chat AI resize được, nhưng phóng to chỉ làm **mỗi card listing to hơn** (ảnh hero cao theo bề rộng card) chứ không hiển thị thêm tin — ngược với mục tiêu ban đầu của việc cho phép mở rộng khung.

## Thay đổi
- **Card gọn**: hero đổi `aspect-[4/3]` → cao cố định `h-36`, cap `max-w-sm`. Khung rộng chỉ làm ảnh rộng ra chứ không cao thêm → card ngắn lại (~480px → ~300px).
- **Lưới co giãn**: kết quả search dùng `grid` `repeat(auto-fill, minmax(min(100%,260px),1fr))` — khung rộng tự thêm cột (1→2→3→4) thay vì phóng to card. Detail view giữ 1 cột + cap.
- **Nút phóng to** (desktop): toggle `Maximize2`/`Minimize2` trên header, chuyển khung `500×700 ↔ min(1080px,90vw)×85vh`, **nhớ qua localStorage**. Mobile ẩn (đã full-screen).
- **Carousel ảnh** trong card: index-based prev/next (hiện khi hover, luôn hiện trên touch) + đếm vị trí live, theo pattern `propertyCard` của repo.
- **Dọn i18n**: đưa chuỗi hard-code (`Trống`, `Gọi điện`, nhãn tiện ích, aria nút ảnh) qua `next-intl` (`chat.listing.*`); title dùng `<Typography>`.

## Kiểm thử
- `typecheck` ✅ · `lint` (file touched) ✅ · `i18n:check` ✅ (3056 keys, en/vi khớp) · `test:run` ✅ 17/17
- Pre-commit hook (typecheck + i18n + lint-staged) chạy sạch.
- Review hành vi qua prototype tương tác; tác giả đã xem trên app thật.

## Ảnh hưởng
Chỉ UI trong widget chat AI: `CardListingAIDetail`, `aiChatBubble`, `aiChatHeader`, `aiChatWidget`, + 2 file i18n. Không đổi API/logic.

