### PR TITLE
fix(listing): send excludeExpired on public seller-profile listing calls

### DIFF
--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -63,6 +63,7 @@ export class ListingService {
         page,
         size,
         sortBy,
+        excludeExpired: true,
       },
       instance,
     )
@@ -340,6 +341,9 @@ export class ListingService {
   /**
    * Get seller listings by a specific VIP tier (public)
    * GET /v1/listings/sellers/:userId/{diamond|gold|silver|normal}
+   * Always excludeExpired: this is the public seller-profile page, not the
+   * owner's "my listings" page, so expired posts must not be shown even
+   * though a userId is present.
    */
   static async getSellerListingsByVipType(
     userId: string,
@@ -356,7 +360,7 @@ export class ListingService {
         {
           method: 'GET',
           url,
-          params: { page, size, sortBy },
+          params: { page, size, sortBy, excludeExpired: true },
           skipAuth: true,
         },
         instance,
@@ -478,7 +482,7 @@ export class ListingService {
         {
           method: 'GET',
           url,
-          params: { limit: safeLimit },
+          params: { limit: safeLimit, excludeExpired: true },
           skipAuth: true,
         },
         instance,
@@ -497,6 +501,7 @@ export class ListingService {
           page: 1,
           size: safeLimit,
           sortBy: SortKey.NEWEST,
+          excludeExpired: true,
         },
         instance,
       )
@@ -508,6 +513,7 @@ export class ListingService {
             page: 1,
             size: safeLimit,
             sortBy: SortKey.NEWEST,
+            excludeExpired: true,
           },
           instance,
         )

--- a/src/pages/properties/seller/[userId].tsx
+++ b/src/pages/properties/seller/[userId].tsx
@@ -146,6 +146,7 @@ const SellerDetailPage: NextPageWithLayout = () => {
         page: 1,
         size: 1,
         sortBy: SortKey.NEWEST,
+        excludeExpired: true,
       })
 
       if (!response.success || !response.data) {


### PR DESCRIPTION
/properties/seller/[userId] calls ListingService.getSeller{Diamond,Gold, Silver,Normal}Listings and getSellerTopSavedListings, none of which sent excludeExpired. The backend GET tier endpoints already default it via the Lombok builder, but the fallback POST /search path (used when the tier endpoint 404s) and the profile lookup call didn't have it set explicitly. Add it everywhere this page calls the API, matching the excludeExpired: true public browsing already does elsewhere.

Note: the actual bigger bug here was backend-side (a client-supplied userId bypassing the isDraft/moderationStatus visibility gate on public seller listing queries) — fixed separately in smartrent-backend (fix/seller-profile-visibility-gate).