### PR TITLE
fix: distinguish permanent listing removal from ordinary suspend on s…

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -110,4 +110,6 @@ export {
   DURATIONDAYS,
   SortKey,
   ModerationStatus,
+  LISTING_ERROR_CODES,
+  ResubmitNotAllowedError,
 } from './property.type'

--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -95,6 +95,27 @@ export enum ModerationStatus {
   SUSPENDED = 'SUSPENDED',
 }
 
+// Listing-domain API error codes
+export const LISTING_ERROR_CODES = {
+  RESUBMIT_NOT_ALLOWED: '16003',
+} as const
+
+export type ListingErrorCode =
+  (typeof LISTING_ERROR_CODES)[keyof typeof LISTING_ERROR_CODES]
+
+/**
+ * Thrown when resubmitting a listing that cannot be resubmitted in its
+ * current state (e.g. permanently removed after a confirmed report).
+ */
+export class ResubmitNotAllowedError extends Error {
+  readonly code = LISTING_ERROR_CODES.RESUBMIT_NOT_ALLOWED
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'ResubmitNotAllowedError'
+  }
+}
+
 export interface PendingOwnerAction {
   actionId: number
   ownerActionType: string
@@ -288,6 +309,10 @@ export interface ListingOwnerDetail extends ListingApi {
   rejectionReason?: string | null
   pendingOwnerAction?: PendingOwnerAction | null
   moderationTimeline?: ModerationTimelineEvent[]
+  // True when moderationStatus is SUSPENDED as a result of a confirmed
+  // report (as opposed to an ordinary admin suspend) — the listing is
+  // permanently removed and can never be resubmitted.
+  permanentlyRemoved?: boolean
 }
 
 export interface ListingResponse {
@@ -745,6 +770,7 @@ export interface MyListingBackendItem {
   moderationStatus?: ModerationStatus
   pendingOwnerAction?: PendingOwnerAction | null
   moderationTimeline?: ModerationTimelineEvent[]
+  permanentlyRemoved?: boolean
 }
 
 /**

--- a/src/components/molecules/listingCardActions/index.tsx
+++ b/src/components/molecules/listingCardActions/index.tsx
@@ -6,6 +6,7 @@ import {
   ChevronsUp,
   SendHorizontal,
   CalendarPlus,
+  Trash2,
 } from 'lucide-react'
 import { createMenuItems } from './index.constants'
 import { Button } from '@/components/atoms/button'
@@ -29,6 +30,9 @@ export interface ListingCardActionsProps {
   showRepostButton?: boolean
   showRenewButton?: boolean
   showResubmitButton?: boolean
+  // Permanently removed listings can only be deleted — every other action
+  // (edit, promote, resubmit, copy link, take down, ...) is meaningless.
+  onlyShowDelete?: boolean
   className?: string
 }
 
@@ -45,6 +49,7 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
   showRepostButton = false,
   showRenewButton = false,
   showResubmitButton = false,
+  onlyShowDelete = false,
   className,
 }) => {
   const t = useTranslations('seller.listingManagement.card.actions')
@@ -56,6 +61,22 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
     onDelete,
     showPromoteButton,
   })
+
+  if (onlyShowDelete) {
+    return (
+      <div className={`flex items-center gap-2 ${className}`}>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={onDelete}
+          className='gap-1 border-red-500 text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-500/10 text-xs sm:text-sm'
+        >
+          <Trash2 size={14} />
+          {t('delete')}
+        </Button>
+      </div>
+    )
+  }
 
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className}`}>

--- a/src/components/molecules/moderation/ModerationBanner.tsx
+++ b/src/components/molecules/moderation/ModerationBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/router'
-import { AlertTriangle, Info, XCircle, Clock } from 'lucide-react'
+import { AlertTriangle, Info, Ban, Clock } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
 import { Typography } from '@/components/atoms/typography'
 import { cn } from '@/lib/utils'
@@ -11,6 +11,7 @@ interface ModerationBannerProps {
   moderationStatus?: ModerationStatus
   verificationNotes?: string | null
   pendingOwnerAction?: PendingOwnerAction | null
+  permanentlyRemoved?: boolean
   listingId: number
   onResubmit?: () => void
   className?: string
@@ -40,6 +41,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
   moderationStatus,
   verificationNotes,
   pendingOwnerAction,
+  permanentlyRemoved,
   listingId,
   className,
 }) => {
@@ -60,16 +62,26 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
     router.push(`/seller/update-post/${listingId}?resubmit=true`)
   }
 
+  const isOrdinarySuspend =
+    moderationStatus === ModerationStatus.SUSPENDED && !permanentlyRemoved
+
   if (
     moderationStatus === ModerationStatus.REJECTED ||
-    moderationStatus === ModerationStatus.REVISION_REQUIRED
+    moderationStatus === ModerationStatus.REVISION_REQUIRED ||
+    isOrdinarySuspend
   ) {
-    const isRejected = moderationStatus === ModerationStatus.REJECTED
+    const isSevere =
+      moderationStatus === ModerationStatus.REJECTED || isOrdinarySuspend
+    const title = isOrdinarySuspend
+      ? t('suspendedTitle')
+      : isSevere
+        ? t('rejectedTitle')
+        : t('revisionRequiredTitle')
     return (
       <div
         className={cn(
           'rounded-lg border p-4',
-          isRejected
+          isSevere
             ? 'bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-900'
             : 'bg-orange-50 border-orange-200 dark:bg-orange-950/30 dark:border-orange-900',
           className,
@@ -79,7 +91,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
           <AlertTriangle
             className={cn(
               'w-5 h-5 mt-0.5 shrink-0',
-              isRejected
+              isSevere
                 ? 'text-red-600 dark:text-red-400'
                 : 'text-orange-600 dark:text-orange-400',
             )}
@@ -89,12 +101,12 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
               variant='p'
               className={cn(
                 'font-semibold mb-1',
-                isRejected
+                isSevere
                   ? 'text-red-800 dark:text-red-300'
                   : 'text-orange-800 dark:text-orange-300',
               )}
             >
-              {isRejected ? t('rejectedTitle') : t('revisionRequiredTitle')}
+              {title}
             </Typography>
 
             {verificationNotes && (
@@ -102,7 +114,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
                 variant='small'
                 className={cn(
                   'block mb-2',
-                  isRejected
+                  isSevere
                     ? 'text-red-700 dark:text-red-400'
                     : 'text-orange-700 dark:text-orange-400',
                 )}
@@ -152,7 +164,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
               {!deadlineInfo?.expired && (
                 <Button
                   size='sm'
-                  variant={isRejected ? 'destructive' : 'default'}
+                  variant={isSevere ? 'destructive' : 'default'}
                   onClick={handleEditAndResubmit}
                   className='text-xs w-full sm:w-auto'
                 >
@@ -195,27 +207,27 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
     )
   }
 
-  if (moderationStatus === ModerationStatus.SUSPENDED) {
+  if (moderationStatus === ModerationStatus.SUSPENDED && permanentlyRemoved) {
     return (
       <div
         className={cn(
-          'rounded-lg border p-4 bg-muted border-border',
+          'rounded-lg border p-4 bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-900',
           className,
         )}
       >
         <div className='flex items-start gap-3'>
-          <XCircle className='w-5 h-5 mt-0.5 shrink-0 text-muted-foreground' />
+          <Ban className='w-5 h-5 mt-0.5 shrink-0 text-red-600 dark:text-red-400' />
           <div className='flex-1 min-w-0'>
             <Typography
               variant='p'
-              className='font-semibold mb-1 text-foreground'
+              className='font-semibold mb-1 text-red-800 dark:text-red-300'
             >
-              {t('suspendedTitle')}
+              {t('permanentlyRemovedTitle')}
             </Typography>
             {verificationNotes && (
               <Typography
                 variant='small'
-                className='block mb-2 text-muted-foreground'
+                className='block mb-2 text-red-700 dark:text-red-400'
               >
                 {verificationNotes}
               </Typography>

--- a/src/components/molecules/moderation/ModerationStatusBadge.tsx
+++ b/src/components/molecules/moderation/ModerationStatusBadge.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 
 interface ModerationStatusBadgeProps {
   status: ModerationStatus
+  permanentlyRemoved?: boolean
   className?: string
 }
 
@@ -55,12 +56,23 @@ const BADGE_CONFIG: Record<
   },
 }
 
+const PERMANENTLY_REMOVED_CONFIG = {
+  icon: Ban,
+  className:
+    'bg-red-50 text-red-700 border-red-300 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800',
+}
+
 export const ModerationStatusBadge: React.FC<ModerationStatusBadgeProps> = ({
   status,
+  permanentlyRemoved,
   className,
 }) => {
   const t = useTranslations('seller.moderation.status')
-  const config = BADGE_CONFIG[status]
+  const isPermanentlyRemoved =
+    status === ModerationStatus.SUSPENDED && permanentlyRemoved
+  const config = isPermanentlyRemoved
+    ? PERMANENTLY_REMOVED_CONFIG
+    : BADGE_CONFIG[status]
 
   if (!config) return null
 
@@ -69,7 +81,7 @@ export const ModerationStatusBadge: React.FC<ModerationStatusBadgeProps> = ({
   return (
     <Badge variant='outline' className={cn(config.className, className)}>
       <Icon className='w-3.5 h-3.5 mr-1' />
-      {t(status)}
+      {t(isPermanentlyRemoved ? 'SUSPENDED_PERMANENT' : status)}
     </Badge>
   )
 }

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -93,9 +93,13 @@ export const ListingCard: React.FC<ListingCardProps> = ({
 
   // Moderation fields
   const moderationStatus = property.moderationStatus
+  const permanentlyRemoved = property.permanentlyRemoved
+  const isPermanentlyRemoved =
+    moderationStatus === ModerationStatus.SUSPENDED && !!permanentlyRemoved
   const isResubmittable =
     moderationStatus === ModerationStatus.REJECTED ||
-    moderationStatus === ModerationStatus.REVISION_REQUIRED
+    moderationStatus === ModerationStatus.REVISION_REQUIRED ||
+    (moderationStatus === ModerationStatus.SUSPENDED && !permanentlyRemoved)
 
   const calculatedExpiryDate = React.useMemo(() => {
     if (expiryDate) return toISO(expiryDate)
@@ -178,7 +182,10 @@ export const ListingCard: React.FC<ListingCardProps> = ({
             <div className='absolute top-3 right-3'>
               {moderationStatus &&
               moderationStatus !== ModerationStatus.APPROVED ? (
-                <ModerationStatusBadge status={moderationStatus} />
+                <ModerationStatusBadge
+                  status={moderationStatus}
+                  permanentlyRemoved={permanentlyRemoved}
+                />
               ) : isExpired ? (
                 <Badge className='backdrop-blur-md bg-red-500 text-white border-red-600 shadow-md font-medium hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 dark:border-red-700'>
                   {t('status.expired')}
@@ -525,6 +532,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 moderationStatus={moderationStatus}
                 verificationNotes={property.verificationNotes}
                 pendingOwnerAction={property.pendingOwnerAction}
+                permanentlyRemoved={permanentlyRemoved}
                 listingId={property.listingId}
                 onResubmit={isResubmittable ? onResubmit : undefined}
                 className='mb-4'
@@ -558,6 +566,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 showRepostButton={showRepostButton}
                 showRenewButton={showRenewButton}
                 showResubmitButton={isResubmittable}
+                onlyShowDelete={isPermanentlyRemoved}
               />
             </div>
           </div>

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -39,6 +39,7 @@ import {
   POST_STATUS,
   ModerationStatus,
   ListingFilterRequest,
+  ResubmitNotAllowedError,
 } from '@/api/types'
 import {
   isModerationFilterStatus,
@@ -201,11 +202,14 @@ const ListingsWithPagination = () => {
           <ListingsList
             listings={listings}
             onEditListing={(listing) => {
-              // Redirect to update-post with resubmit context for rejected/revision-required listings
-              const isRejected =
+              // Redirect to update-post with resubmit context for rejected/revision-required/suspended (non-permanent) listings
+              const needsResubmitContext =
                 listing.moderationStatus === ModerationStatus.REJECTED ||
-                listing.moderationStatus === ModerationStatus.REVISION_REQUIRED
-              if (isRejected) {
+                listing.moderationStatus ===
+                  ModerationStatus.REVISION_REQUIRED ||
+                (listing.moderationStatus === ModerationStatus.SUSPENDED &&
+                  !listing.permanentlyRemoved)
+              if (needsResubmitContext) {
                 router.push(
                   `/seller/update-post/${listing.listingId}?resubmit=true`,
                 )
@@ -404,7 +408,11 @@ const ListingsWithPagination = () => {
                     refetch()
                   },
                   onError: (err) => {
-                    toast.error(err.message || tModeration('error'))
+                    toast.error(
+                      err instanceof ResubmitNotAllowedError
+                        ? tModeration('notAllowed')
+                        : err.message || tModeration('error'),
+                    )
                   },
                 },
               )

--- a/src/hooks/useListings/useResubmitListing.ts
+++ b/src/hooks/useListings/useResubmitListing.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ListingService } from '@/api/services/listing.service'
+import {
+  LISTING_ERROR_CODES,
+  ResubmitNotAllowedError,
+} from '@/api/types/property.type'
 
 interface ResubmitParams {
   listingId: string | number
@@ -13,6 +17,11 @@ export const useResubmitListing = () => {
     mutationFn: async ({ listingId, notes }: ResubmitParams) => {
       const response = await ListingService.resubmitForReview(listingId, notes)
       if (!response.success) {
+        if (response.code === LISTING_ERROR_CODES.RESUBMIT_NOT_ALLOWED) {
+          throw new ResubmitNotAllowedError(
+            response.message || 'Listing cannot be resubmitted',
+          )
+        }
         throw new Error(response.message || 'Failed to resubmit listing')
       }
       return response

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2882,7 +2882,8 @@
         "REJECTED": "Rejected",
         "REVISION_REQUIRED": "Revision Required",
         "RESUBMITTED": "Resubmitted",
-        "SUSPENDED": "Suspended"
+        "SUSPENDED": "Suspended",
+        "SUSPENDED_PERMANENT": "Permanently Removed"
       },
       "banner": {
         "rejectedTitle": "Listing Rejected",
@@ -2890,6 +2891,7 @@
         "resubmittedTitle": "Awaiting Re-review",
         "resubmittedMessage": "Your listing has been resubmitted and is awaiting admin review.",
         "suspendedTitle": "Listing Suspended",
+        "permanentlyRemovedTitle": "Listing Permanently Removed",
         "editAndResubmit": "Edit & Resubmit",
         "resubmitDirectly": "Resubmit Now",
         "contactSupport": "Contact Support",
@@ -2917,7 +2919,8 @@
         "success": "Listing resubmitted successfully",
         "successTitle": "Resubmitted Successfully",
         "successDescription": "Your listing has been updated and resubmitted for review. It is now awaiting admin approval.",
-        "error": "Failed to resubmit listing"
+        "error": "Failed to resubmit listing",
+        "notAllowed": "This listing has been permanently removed and cannot be resubmitted."
       }
     },
     "drafts": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2882,7 +2882,8 @@
         "REJECTED": "Bị từ chối",
         "REVISION_REQUIRED": "Cần chỉnh sửa",
         "RESUBMITTED": "Đã gửi lại",
-        "SUSPENDED": "Bị tạm ngưng"
+        "SUSPENDED": "Bị tạm ngưng",
+        "SUSPENDED_PERMANENT": "Đã gỡ vĩnh viễn"
       },
       "banner": {
         "rejectedTitle": "Bài đăng bị từ chối",
@@ -2890,6 +2891,7 @@
         "resubmittedTitle": "Đang chờ duyệt lại",
         "resubmittedMessage": "Bài đăng đã được gửi lại và đang chờ quản trị viên xem xét.",
         "suspendedTitle": "Bài đăng bị tạm ngưng",
+        "permanentlyRemovedTitle": "Bài đăng đã bị gỡ vĩnh viễn",
         "editAndResubmit": "Chỉnh sửa và gửi lại",
         "resubmitDirectly": "Gửi lại ngay",
         "contactSupport": "Liên hệ hỗ trợ",
@@ -2917,7 +2919,8 @@
         "success": "Bài đăng đã được gửi lại thành công",
         "successTitle": "Đã gửi lại thành công",
         "successDescription": "Tin đăng của bạn đã được cập nhật và gửi lại để duyệt. Hiện đang chờ quản trị viên phê duyệt.",
-        "error": "Không thể gửi lại bài đăng"
+        "error": "Không thể gửi lại bài đăng",
+        "notAllowed": "Tin đăng này đã bị gỡ vĩnh viễn và không thể gửi lại."
       }
     },
     "drafts": {

--- a/src/pages/seller/update-post/[id].tsx
+++ b/src/pages/seller/update-post/[id].tsx
@@ -18,6 +18,7 @@ import {
   ListingOwnerDetail,
   ModerationTimelineEvent,
   PendingOwnerAction,
+  ResubmitNotAllowedError,
 } from '@/api/types/property.type'
 import { useResubmitListing } from '@/hooks/useListings/useResubmitListing'
 import { toast } from 'sonner'
@@ -45,6 +46,7 @@ const UpdatePostPageContent = () => {
   const [moderationTimeline, setModerationTimeline] = React.useState<
     ModerationTimelineEvent[]
   >([])
+  const [permanentlyRemoved, setPermanentlyRemoved] = React.useState(false)
   const isResubmitMode = resubmit === 'true'
   const resubmitMutation = useResubmitListing()
 
@@ -90,6 +92,7 @@ const UpdatePostPageContent = () => {
               setVerificationNotes(detail.verificationNotes || null)
               setPendingOwnerAction(detail.pendingOwnerAction || null)
               setModerationTimeline(detail.moderationTimeline || [])
+              setPermanentlyRemoved(detail.permanentlyRemoved || false)
             }
           } catch {
             // Moderation detail is optional - don't block the page
@@ -127,7 +130,11 @@ const UpdatePostPageContent = () => {
           router.push('/seller/listings')
         },
         onError: (err) => {
-          toast.error(err.message || tModeration('error'))
+          toast.error(
+            err instanceof ResubmitNotAllowedError
+              ? tModeration('notAllowed')
+              : err.message || tModeration('error'),
+          )
         },
       },
     )
@@ -141,6 +148,7 @@ const UpdatePostPageContent = () => {
           moderationStatus={moderationStatus}
           verificationNotes={verificationNotes}
           pendingOwnerAction={pendingOwnerAction}
+          permanentlyRemoved={permanentlyRemoved}
           listingId={Number(listingId)}
           onResubmit={handleResubmit}
         />

--- a/src/utils/property/mapMyListingsResponse.ts
+++ b/src/utils/property/mapMyListingsResponse.ts
@@ -100,6 +100,7 @@ export function mapMyListingItem(
     rejectionReason: item.rejectionReason || null,
     pendingOwnerAction: item.pendingOwnerAction || null,
     moderationTimeline: item.moderationTimeline || [],
+    permanentlyRemoved: item.permanentlyRemoved || false,
   }
 }
 


### PR DESCRIPTION
…eller side

Backend now flags report-driven listing suspensions as permanentlyRemoved (SUSPENDED + no resubmit allowed), separate from an ordinary admin suspend where the owner can still fix and resubmit. The seller FE had no idea this field existed, so every SUSPENDED listing looked identical: no resubmit CTA for either case, and card actions (edit, promote, resubmit, ...) stayed visible even after a permanent removal, when only delete should remain.

Wire permanentlyRemoved through the listing types/mapper, let ordinary suspends resubmit like REJECTED/REVISION_REQUIRED, give permanent removal its own badge/banner copy and a delete-only action set, and surface the RESUBMIT_NOT_ALLOWED (16003) error with a clear message instead of raw backend text.