### PR TITLE
fix: align homepage carousel client staleTime with backend cache TTL

### DIFF
--- a/src/hooks/useListings/useRecommendedListingsByVip.ts
+++ b/src/hooks/useListings/useRecommendedListingsByVip.ts
@@ -41,10 +41,12 @@ export const useRecommendedListingsByVip = (
       return response.data || []
     },
     enabled: enabled,
-    // Even the NEWEST (sorted) carousel gets a non-zero staleTime so re-mounting
-    // doesn't refetch every render; 2 min is fresh enough for "newest".
-    staleTime: sortBy ? 2 * 60 * 1000 : 5 * 60 * 1000,
-    gcTime: sortBy ? 5 * 60 * 1000 : 10 * 60 * 1000,
+    // Matches the backend's shared listing.search cache TTL (5m) for every
+    // homepage-tier carousel — Nổi bật/Đề xuất/Mới all read from the same
+    // Redis bucket, so a shorter client staleTime would just refetch the
+    // same cached response.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   })
 
   return {

--- a/src/hooks/useRecommendations/index.ts
+++ b/src/hooks/useRecommendations/index.ts
@@ -33,6 +33,11 @@ export const usePersonalizedRecommendations = (topN = 5, enabled = true) => {
       if (maybeAxiosError.response?.status === 401) return false
       return failureCount < 2
     },
-    staleTime: 2 * 60 * 1000,
+    // Matches the backend's listing.recommendation.personalized cache TTL
+    // (30m) — this feed is the most expensive homepage query (interaction
+    // history + AI call), so it intentionally caches longer than the
+    // VIP-tier carousels rather than shorter.
+    staleTime: 30 * 60 * 1000,
+    gcTime: 35 * 60 * 1000,
   })
 }


### PR DESCRIPTION
Tin mới's staleTime was 2m while the backend's listing.search bucket (shared across all homepage-tier carousels) is cached for 5m — the client was refetching 2-3x per backend cache window for no benefit. Set all VIP-tier carousels to 5m to match. Personalized recommendations move from 2m to 30m to match the new backend TTL (see backend PR): the "for you" feed is the most expensive homepage query (interaction history + AI call) so it should cache longer, not shorter, than the tier carousels — freshness matters less here than avoiding repeat per-user AI calls, and per-user cache entries still get evicted early on save/click/view signals.