### PR TITLE
fix: drop dead contact-support CTA, box admin notes on moderation banner

### DIFF
--- a/src/components/molecules/moderation/ModerationBanner.tsx
+++ b/src/components/molecules/moderation/ModerationBanner.tsx
@@ -17,6 +17,53 @@ interface ModerationBannerProps {
   className?: string
 }
 
+type NoteTone = 'severe' | 'warning' | 'muted'
+
+const NOTE_BOX_TONE_CLASSES: Record<NoteTone, string> = {
+  severe: 'border-red-200 bg-white/70 dark:border-red-900/50 dark:bg-black/20',
+  warning:
+    'border-orange-200 bg-white/70 dark:border-orange-900/50 dark:bg-black/20',
+  muted: 'border-border bg-background/70',
+}
+
+const NOTE_BOX_LABEL_CLASSES: Record<NoteTone, string> = {
+  severe: 'text-red-700 dark:text-red-400',
+  warning: 'text-orange-700 dark:text-orange-400',
+  muted: 'text-muted-foreground',
+}
+
+function NoteBox({
+  label,
+  text,
+  tone,
+}: {
+  label: string
+  text: string
+  tone: NoteTone
+}) {
+  return (
+    <div
+      className={cn(
+        'mb-2 rounded-lg border p-2.5',
+        NOTE_BOX_TONE_CLASSES[tone],
+      )}
+    >
+      <Typography
+        variant='small'
+        className={cn(
+          'block text-xs font-semibold mb-0.5',
+          NOTE_BOX_LABEL_CLASSES[tone],
+        )}
+      >
+        {label}
+      </Typography>
+      <Typography variant='small' className='block text-foreground/80'>
+        {text}
+      </Typography>
+    </div>
+  )
+}
+
 function getDeadlineInfo(deadlineAt?: string | null) {
   if (!deadlineAt) return null
 
@@ -110,26 +157,19 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
             </Typography>
 
             {verificationNotes && (
-              <Typography
-                variant='small'
-                className={cn(
-                  'block mb-2',
-                  isSevere
-                    ? 'text-red-700 dark:text-red-400'
-                    : 'text-orange-700 dark:text-orange-400',
-                )}
-              >
-                {verificationNotes}
-              </Typography>
+              <NoteBox
+                label={t('adminNoteLabel')}
+                text={verificationNotes}
+                tone={isSevere ? 'severe' : 'warning'}
+              />
             )}
 
             {pendingOwnerAction?.notes && (
-              <Typography
-                variant='small'
-                className='block mb-2 text-muted-foreground'
-              >
-                {pendingOwnerAction.notes}
-              </Typography>
+              <NoteBox
+                label={t('adminNoteLabel')}
+                text={pendingOwnerAction.notes}
+                tone='muted'
+              />
             )}
 
             {deadlineInfo && (
@@ -225,16 +265,12 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
               {t('permanentlyRemovedTitle')}
             </Typography>
             {verificationNotes && (
-              <Typography
-                variant='small'
-                className='block mb-2 text-red-700 dark:text-red-400'
-              >
-                {verificationNotes}
-              </Typography>
+              <NoteBox
+                label={t('adminNoteLabel')}
+                text={verificationNotes}
+                tone='severe'
+              />
             )}
-            <Button size='sm' variant='outline' className='text-xs'>
-              {t('contactSupport')}
-            </Button>
           </div>
         </div>
       </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2892,6 +2892,7 @@
         "resubmittedMessage": "Your listing has been resubmitted and is awaiting admin review.",
         "suspendedTitle": "Listing Suspended",
         "permanentlyRemovedTitle": "Listing Permanently Removed",
+        "adminNoteLabel": "Note from admin",
         "editAndResubmit": "Edit & Resubmit",
         "resubmitDirectly": "Resubmit Now",
         "contactSupport": "Contact Support",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2892,6 +2892,7 @@
         "resubmittedMessage": "Bài đăng đã được gửi lại và đang chờ quản trị viên xem xét.",
         "suspendedTitle": "Bài đăng bị tạm ngưng",
         "permanentlyRemovedTitle": "Bài đăng đã bị gỡ vĩnh viễn",
+        "adminNoteLabel": "Ghi chú từ quản trị viên",
         "editAndResubmit": "Chỉnh sửa và gửi lại",
         "resubmitDirectly": "Gửi lại ngay",
         "contactSupport": "Liên hệ hỗ trợ",


### PR DESCRIPTION
Remove the "Liên hệ hỗ trợ" button on the permanently-removed banner — it didn't do anything (no onClick handler). Give admin notes and owner-action notes a bordered box instead of bare inline text so they read as a distinct callout on the listing card.