### PR TITLE
fix(create-post): add missing i18n keys for media upload toasts

### DIFF
--- a/src/components/molecules/createPostMedia/videoUrl.tsx
+++ b/src/components/molecules/createPostMedia/videoUrl.tsx
@@ -106,7 +106,7 @@ const VideoUrl: React.FC<VideoUrlProps> = ({ video }) => {
               />
             </div>
             <Button variant='outline' onClick={handleRemove} className='w-full'>
-              Xóa video
+              {t('video.external.remove')}
             </Button>
           </div>
         ) : (

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1249,7 +1249,7 @@
           "hint": "Drag up to 24 images or...",
           "uploadFromDevice": "Upload From Device",
           "chooseFromLibrary": "Choose From Library",
-          "note": "Max 15MB per image"
+          "note": "Max 10MB per image"
         },
         "readyToUpload": "Ready to Upload",
         "pendingImages": "Pending Images ({count})",
@@ -1276,7 +1276,10 @@
         "uploadButton": "Upload Media",
         "validation": {
           "pendingImages": "Please upload pending images before continuing",
-          "minImages": "Please upload at least 4 images (video is optional)"
+          "minImages": "Please upload at least 4 images (video is optional)",
+          "uploadInProgress": "Please wait for current image upload to finish",
+          "imageSizeExceeded": "Image size must not exceed 10MB",
+          "imageFormatInvalid": "Image must be jpeg, png, or webp format"
         },
         "video": {
           "title": "Video (Optional)",
@@ -1287,6 +1290,8 @@
             "saving": "Saving...",
             "success": "Video link saved",
             "error": "Failed to save video link",
+            "onlyYoutube": "Only YouTube links are accepted",
+            "remove": "Remove video",
             "uploadedNote": "You have added a YouTube link. Remove the link to upload a video."
           },
           "upload": {
@@ -1356,11 +1361,13 @@
           "badge": "Cover",
           "uploading": "Uploading...",
           "uploaded": {
-            "success": "Cover image added successfully"
+            "success": "Cover image added successfully",
+            "failed": "Failed to upload cover image"
           },
           "validation": {
             "imageSizeExceeded": "Cover image size must not exceed 10MB",
-            "imageFormatInvalid": "Cover image must be jpeg, png, or webp format"
+            "imageFormatInvalid": "Cover image must be jpeg, png, or webp format",
+            "uploadInProgress": "Please wait for current image upload to finish"
           }
         }
       },
@@ -1734,7 +1741,7 @@
                 "hint": "Drag up to 24 images or...",
                 "uploadFromDevice": "Upload From Device",
                 "chooseFromLibrary": "Choose From Library",
-                "note": "Min 3 images · Up to 24 · Minimum size 100x100px · Max 15MB per image"
+                "note": "Min 3 images · Up to 24 · Minimum size 100x100px · Max 10MB per image"
               },
               "uploaded": {
                 "title": "Uploaded Images",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1248,7 +1248,7 @@
           "hint": "Kéo tối đa 24 ảnh hoặc...",
           "uploadFromDevice": "Tải từ Thiết bị",
           "chooseFromLibrary": "Chọn từ Thư viện",
-          "note": "Tối đa 15MB mỗi ảnh"
+          "note": "Tối đa 10MB mỗi ảnh"
         },
         "uploaded": {
           "title": "Ảnh đã tải lên",
@@ -1276,7 +1276,10 @@
         },
         "validation": {
           "pendingImages": "Vui lòng tải lên các ảnh đang chờ trước khi tiếp tục",
-          "minImages": "Vui lòng tải lên ít nhất 4 ảnh (video là tùy chọn)"
+          "minImages": "Vui lòng tải lên ít nhất 4 ảnh (video là tùy chọn)",
+          "uploadInProgress": "Vui lòng đợi ảnh hiện tại tải lên xong",
+          "imageSizeExceeded": "Kích thước ảnh không được vượt quá 10MB",
+          "imageFormatInvalid": "Ảnh phải có định dạng jpeg, png hoặc webp"
         },
         "video": {
           "title": "Video (Tùy chọn)",
@@ -1287,6 +1290,8 @@
             "saving": "Đang lưu...",
             "success": "Đã lưu liên kết video",
             "error": "Không thể lưu liên kết video",
+            "onlyYoutube": "Chỉ chấp nhận liên kết YouTube",
+            "remove": "Xóa video",
             "uploadedNote": "Bạn đã thêm link YouTube."
           },
           "upload": {
@@ -1356,11 +1361,13 @@
           "badge": "Ảnh bìa",
           "uploading": "Đang tải lên...",
           "uploaded": {
-            "success": "Đã thêm ảnh bìa thành công"
+            "success": "Đã thêm ảnh bìa thành công",
+            "failed": "Tải ảnh bìa lên thất bại"
           },
           "validation": {
             "imageSizeExceeded": "Kích thước ảnh bìa không được vượt quá 10MB",
-            "imageFormatInvalid": "Ảnh bìa phải ở định dạng jpeg, png hoặc webp"
+            "imageFormatInvalid": "Ảnh bìa phải ở định dạng jpeg, png hoặc webp",
+            "uploadInProgress": "Vui lòng đợi ảnh hiện tại tải lên xong"
           }
         }
       },
@@ -1734,7 +1741,7 @@
                 "hint": "Kéo tối đa 24 ảnh hoặc...",
                 "uploadFromDevice": "Tải từ Thiết bị",
                 "chooseFromLibrary": "Chọn từ Thư viện",
-                "note": "Tối thiểu 3 ảnh · Tối đa 24 · Kích thước tối thiểu 100x100px · Tối đa 15MB mỗi ảnh"
+                "note": "Tối thiểu 3 ảnh · Tối đa 24 · Kích thước tối thiểu 100x100px · Tối đa 10MB mỗi ảnh"
               },
               "uploaded": {
                 "title": "Ảnh đã tải lên",


### PR DESCRIPTION
Several toast messages in the media/cover/video upload flow read keys that didn't exist at their actual nested namespace (only similarly named keys existed elsewhere), so next-intl fell back to printing the raw dotted key path instead of translated text. Adds the missing `imageSizeExceeded`, `imageFormatInvalid`, `uploadInProgress` under `sections.media.validation`, `cover.validation.uploadInProgress`, `cover.uploaded.failed`, and `video.external.remove` / `onlyYoutube` in both en.json and vi.json, and swaps a hardcoded Vietnamese string in videoUrl.tsx for the new translated key.