### PR TITLE
feat: show blocked-from-posting dialog on listing create

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -98,6 +98,8 @@ export enum ModerationStatus {
 // Listing-domain API error codes
 export const LISTING_ERROR_CODES = {
   RESUBMIT_NOT_ALLOWED: '16003',
+  // User has been blocked from posting by an admin (too many approved reports)
+  USER_POSTING_BLOCKED: '23001',
 } as const
 
 export type ListingErrorCode =

--- a/src/components/templates/createPostTemplate/index.tsx
+++ b/src/components/templates/createPostTemplate/index.tsx
@@ -13,7 +13,10 @@ import NotificationDialog from '@/components/molecules/notifications/Notificatio
 import { PostTemplateBase } from '@/components/templates/shared/PostTemplateBase'
 import PaymentMethodDialog from '@/components/molecules/paymentMethodDialog'
 import { PaymentProvider as MembershipPaymentProvider } from '@/api/types/membership.type'
-import { PAYMENT_PROVIDER } from '@/api/types/property.type'
+import {
+  PAYMENT_PROVIDER,
+  LISTING_ERROR_CODES,
+} from '@/api/types/property.type'
 import { useDialog } from '@/hooks/useDialog'
 import { toast } from 'sonner'
 import { isSePayResult, startGatewayCheckout } from '@/utils/payment'
@@ -76,6 +79,9 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   const [errorOpen, setErrorOpen] = React.useState(false)
   const [errorTitle, setErrorTitle] = React.useState<string>('')
   const [errorDesc, setErrorDesc] = React.useState<string>('')
+  // Shown when the user has been blocked from posting by an admin
+  const [blockedOpen, setBlockedOpen] = React.useState(false)
+  const [blockedDesc, setBlockedDesc] = React.useState<string>('')
 
   // Payment method dialog
   const {
@@ -135,10 +141,16 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         ...(paymentProvider && { paymentProvider }),
       }
 
-      const { success, data, message } =
+      const { success, data, message, code } =
         await ListingService.create(requestData)
 
       if (!success || !data) {
+        // User blocked from posting by an admin → show dedicated notice
+        if (code === LISTING_ERROR_CODES.USER_POSTING_BLOCKED) {
+          setBlockedDesc(message || t('blockedDescription'))
+          setBlockedOpen(true)
+          return
+        }
         setErrorTitle(t('errorTitle'))
         setErrorDesc(message || t('createFailed'))
         setErrorOpen(true)
@@ -323,6 +335,15 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         description={errorDesc}
         okText={t('ok')}
         onOpenChange={setErrorOpen}
+      />
+
+      {/* Posting Blocked Dialog */}
+      <NotificationDialog
+        open={blockedOpen}
+        title={t('blockedTitle')}
+        description={blockedDesc}
+        okText={t('ok')}
+        onOpenChange={setBlockedOpen}
       />
 
       {/* Payment Method Dialog */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1016,7 +1016,9 @@
       "successDescription": "Your listing has been successfully submitted. It is now pending approval. You will be notified once your listing is approved and visible on the website.",
       "processing": "Processing payment...",
       "createFailed": "Failed to create listing",
-      "unexpectedError": "An unexpected error occurred"
+      "unexpectedError": "An unexpected error occurred",
+      "blockedTitle": "Account blocked from posting",
+      "blockedDescription": "Your account has been blocked from posting because several of your listings were reported and confirmed as violations. Please contact an administrator for support."
     },
     "validation": {
       "categoryTypeRequired": "Category type is required",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1016,7 +1016,9 @@
       "successDescription": " Tin đăng của bạn đã được tạo thành công và đang chờ phê duyệt. Bạn sẽ nhận được thông báo khi tin đăng được phê duyệt và hiển thị trên trang web.",
       "processing": "Đang xử lý thanh toán...",
       "createFailed": "Tạo tin đăng thất bại",
-      "unexpectedError": "Đã xảy ra lỗi không mong muốn"
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn",
+      "blockedTitle": "Tài khoản bị chặn đăng tin",
+      "blockedDescription": "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin đăng vi phạm bị báo cáo và đã được duyệt. Vui lòng liên hệ quản trị viên để được hỗ trợ."
     },
     "validation": {
       "imagesUploadInProgress": "Vui lòng đợi quá trình tải ảnh hoàn tất trước khi tiếp tục",


### PR DESCRIPTION
When the backend rejects listing creation because an admin has blocked the user from posting (code 23001), show a dedicated notice dialog instead of the generic error dialog.

- Add USER_POSTING_BLOCKED to LISTING_ERROR_CODES
- Handle the code in createPostTemplate + blockedTitle/Description i18n (vi/en)