### PR TITLE
feat: gate posting for admin-blocked users, keep drafts

### DIFF
--- a/src/api/types/user.type.ts
+++ b/src/api/types/user.type.ts
@@ -14,4 +14,7 @@ export interface UserApi {
   avatarMediaId?: number
   isBroker?: boolean | null
   brokerVerificationStatus?: 'NONE' | 'PENDING' | 'APPROVED' | 'REJECTED' | null
+  // True when an admin has blocked this user from posting new listings
+  postingBlocked?: boolean
+  postingBlockedReason?: string | null
 }

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -19,6 +19,7 @@ import { toISO, formatISO } from '@/utils/date/safe'
 import { formatByLocale } from '@/utils/currency/convert'
 import { getPriceUnitTranslationKey } from '@/utils/property'
 import { useLanguage } from '@/hooks/useLanguage'
+import { useAuth } from '@/hooks/useAuth'
 import { ListingOwnerDetail } from '@/api/types'
 import { ModerationStatus, POST_STATUS } from '@/api/types/property.type'
 import {
@@ -71,6 +72,9 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   const t = useTranslations('seller.listingManagement.card')
   const tNot = useTranslations()
   const { language } = useLanguage()
+  const { user } = useAuth()
+  // Blocked users cannot re-list — hide repost/renew CTAs (backend also blocks).
+  const postingBlocked = Boolean(user?.postingBlocked)
   const [showAllAmenities, setShowAllAmenities] = React.useState(false)
 
   const {
@@ -133,13 +137,14 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   // so the seller doesn't see two near-identical "đẩy tin" buttons. For expired
   // listings the only call-to-action is "đăng lại" (repost).
   const showPromoteButton = !isExpired
-  const showRepostButton = isExpired
+  const showRepostButton = isExpired && !postingBlocked
   // Renewal is the +30-day quota top-up — restricted to listings the backend
   // has flagged EXPIRING_SOON + APPROVED. A fully-displaying listing with a
   // healthy expiry doesn't need (and shouldn't see) a renew CTA; once it
   // tips into EXPIRED the only path back is "đăng lại" (repost).
   const showRenewButton =
     !isExpired &&
+    !postingBlocked &&
     vipType !== 'NORMAL' &&
     vipType !== undefined &&
     property.listingStatus === POST_STATUS.EXPIRING_SOON &&

--- a/src/components/templates/createPostTemplate/components/NavigationButtons.tsx
+++ b/src/components/templates/createPostTemplate/components/NavigationButtons.tsx
@@ -27,6 +27,10 @@ interface NavigationButtonsProps {
   onSubmit: () => void
   onUpdateDraft?: () => void
   isUpdatingDraft?: boolean
+  // When the user is blocked from posting, the publish/payment CTA is replaced
+  // by a "save draft" action so they can still keep their work.
+  postingBlocked?: boolean
+  onSaveDraft?: () => void
 }
 
 export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
@@ -37,13 +41,16 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   onSubmit,
   onUpdateDraft,
   isUpdatingDraft = false,
+  postingBlocked = false,
+  onSaveDraft,
 }) => {
   const t = useTranslations('createPost')
   const { propertyInfo, draftId } = useCreatePost()
 
   const isLastStep = currentStep === totalSteps - 1
   const showBackButton = currentStep > 0
-  const showUpdateDraftButton = !!draftId && !!onUpdateDraft
+  // When blocked, the primary CTA already saves the draft — avoid a duplicate.
+  const showUpdateDraftButton = !!draftId && !!onUpdateDraft && !postingBlocked
 
   const getSubmitButtonText = () => {
     const hasBenefit = Array.isArray(propertyInfo?.benefitIds)
@@ -64,6 +71,33 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
     }
   }
 
+  const renderLastStepCta = () => {
+    // Blocked users cannot publish/pay — offer "save draft" instead so they
+    // keep their work. The payment + đăng tin buttons are hidden entirely.
+    if (postingBlocked) {
+      return (
+        <Button
+          onClick={() => onSaveDraft?.()}
+          disabled={isUpdatingDraft}
+          className={PRIMARY_CTA_CLASSES}
+        >
+          <Save className='size-4' aria-hidden='true' />
+          {t('saveDraft')}
+        </Button>
+      )
+    }
+    return (
+      <Button
+        onClick={handleSubmit}
+        disabled={isUpdatingDraft}
+        className={PRIMARY_CTA_CLASSES}
+      >
+        <CreditCard className='size-4' aria-hidden='true' />
+        {getSubmitButtonText()}
+      </Button>
+    )
+  }
+
   const primaryCta = !isLastStep ? (
     <Button
       onClick={onNext}
@@ -77,14 +111,7 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
       />
     </Button>
   ) : (
-    <Button
-      onClick={handleSubmit}
-      disabled={isUpdatingDraft}
-      className={PRIMARY_CTA_CLASSES}
-    >
-      <CreditCard className='size-4' aria-hidden='true' />
-      {getSubmitButtonText()}
-    </Button>
+    renderLastStepCta()
   )
 
   return (

--- a/src/components/templates/createPostTemplate/index.tsx
+++ b/src/components/templates/createPostTemplate/index.tsx
@@ -23,6 +23,7 @@ import { isSePayResult, startGatewayCheckout } from '@/utils/payment'
 import { useUpdateDraft } from '@/hooks/useListings/useUpdateDraft'
 import { useDeleteDraft } from '@/hooks/useListings/useDeleteDraft'
 import { useCreateDraft } from '@/hooks/useListings/useCreateDraft'
+import { useAuth } from '@/hooks/useAuth'
 
 interface CreatePostTemplateProps {
   className?: string
@@ -62,6 +63,9 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   const router = useRouter()
   const t = useTranslations('createPost.submit')
   const tDraft = useTranslations('createPost')
+  const { user } = useAuth()
+  // Admin-blocked users can fill the form and save drafts, but cannot publish/pay.
+  const postingBlocked = Boolean(user?.postingBlocked)
 
   const { mutate: updateDraft, isPending: isUpdatingDraft } = useUpdateDraft()
   const { mutateAsync: deleteDraft } = useDeleteDraft()
@@ -281,6 +285,42 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
     )
   }, [draftId, propertyInfo, updateDraft, tDraft])
 
+  // Save-as-draft entry point for blocked users (and general use). Updates the
+  // existing draft when editing one, otherwise creates a new draft, then routes
+  // to the drafts list so the user keeps their work without publishing.
+  const handleSaveDraft = React.useCallback(async () => {
+    if (draftId) {
+      handleUpdateDraft()
+      return
+    }
+    try {
+      const response = await createDraftAsync({
+        ...propertyInfo,
+        isDraft: true,
+      })
+      if (response.success && response.data) {
+        toast.success(tDraft('draftSaved'))
+        setIsSubmitSuccess(true)
+        resetPropertyInfo()
+        await router.push(SELLER_ROUTES.DRAFTS)
+      } else {
+        toast.error(response.message || tDraft('draftUpdateFailed'))
+      }
+    } catch (error) {
+      console.error('Failed to save draft:', error)
+      toast.error(tDraft('draftUpdateFailed'))
+    }
+  }, [
+    draftId,
+    handleUpdateDraft,
+    createDraftAsync,
+    propertyInfo,
+    tDraft,
+    setIsSubmitSuccess,
+    resetPropertyInfo,
+    router,
+  ])
+
   return (
     <PostTemplateBase
       className={className}
@@ -312,6 +352,8 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
           onSubmit={handleSubmit}
           onUpdateDraft={handleUpdateDraft}
           isUpdatingDraft={isUpdatingDraft}
+          postingBlocked={postingBlocked}
+          onSaveDraft={handleSaveDraft}
         />
       }
     >

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1863,6 +1863,13 @@
           }
         }
       }
+    },
+    "saveDraft": "Save draft",
+    "draftSaved": "Saved to drafts",
+    "blockedFromPostingDialog": {
+      "title": "Account blocked from posting",
+      "description": "Your account has been blocked from posting because several of your listings were reported and confirmed as violations. You can still save drafts, but cannot publish. Please contact an administrator for support.",
+      "ok": "Got it"
     }
   },
   "updatePost": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1863,6 +1863,13 @@
           }
         }
       }
+    },
+    "saveDraft": "Lưu nháp",
+    "draftSaved": "Đã lưu vào bản nháp",
+    "blockedFromPostingDialog": {
+      "title": "Tài khoản bị chặn đăng tin",
+      "description": "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo và đã được duyệt. Bạn vẫn có thể lưu nháp, nhưng không thể đăng tin. Vui lòng liên hệ quản trị viên để được hỗ trợ.",
+      "ok": "Đã hiểu"
     }
   },
   "footer": {

--- a/src/pages/seller/create-post/index.tsx
+++ b/src/pages/seller/create-post/index.tsx
@@ -32,9 +32,11 @@ const CreatePostPage: NextPageWithLayout = () => {
         ? rawDraftId[0] || ''
         : ''
   const t = useTranslations('createPost.profilePhoneRequiredDialog')
+  const tBlocked = useTranslations('createPost.blockedFromPostingDialog')
   const { user, isAuthenticated } = useAuth()
   const [openPhoneRequiredDialog, setOpenPhoneRequiredDialog] =
     React.useState(false)
+  const [openBlockedDialog, setOpenBlockedDialog] = React.useState(false)
 
   const { data: profileResponse, isLoading: isCheckingProfile } = useQuery({
     queryKey: ['create-post-profile-phone-check', user?.userId],
@@ -56,6 +58,12 @@ const CreatePostPage: NextPageWithLayout = () => {
     return Boolean(phone.trim())
   }, [profileResponse?.data, user?.contactPhoneNumber, user?.phoneNumber])
 
+  const isPostingBlocked = React.useMemo(
+    () =>
+      Boolean(profileResponse?.data?.postingBlocked ?? user?.postingBlocked),
+    [profileResponse?.data?.postingBlocked, user?.postingBlocked],
+  )
+
   const handleRedirectToProfile = React.useCallback(() => {
     router.replace(SELLERNET_ROUTES.PERSONAL_EDIT)
   }, [router])
@@ -65,6 +73,14 @@ const CreatePostPage: NextPageWithLayout = () => {
       setOpenPhoneRequiredDialog(true)
     }
   }, [hasPhoneNumber, isAuthenticated, isCheckingProfile])
+
+  // Blocked users are told they cannot publish, but stay on the page so they
+  // can still fill in the form and save it as a draft.
+  React.useEffect(() => {
+    if (isAuthenticated && !isCheckingProfile && isPostingBlocked) {
+      setOpenBlockedDialog(true)
+    }
+  }, [isAuthenticated, isCheckingProfile, isPostingBlocked])
 
   const handleDialogOpenChange = (nextOpen: boolean) => {
     setOpenPhoneRequiredDialog(nextOpen)
@@ -87,6 +103,23 @@ const CreatePostPage: NextPageWithLayout = () => {
           </DialogHeader>
           <DialogFooter>
             <Button onClick={handleRedirectToProfile}>{t('ok')}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={openBlockedDialog} onOpenChange={setOpenBlockedDialog}>
+        <DialogContent className='max-w-md'>
+          <DialogHeader>
+            <DialogTitle>{tBlocked('title')}</DialogTitle>
+            <DialogDescription>
+              {user?.postingBlockedReason ||
+                profileResponse?.data?.postingBlockedReason ||
+                tBlocked('description')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setOpenBlockedDialog(false)}>
+              {tBlocked('ok')}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
Read postingBlocked from the profile (already loaded) and:
- create-post: show a blocked notice on entry; hide the payment + publish CTA and offer "save draft" instead so the user keeps their work
- listing management: hide the "Đăng lại" (repost) and "Gia hạn" (renew) actions
- add postingBlocked/postingBlockedReason to the UserApi type

Entry "Đăng tin" buttons stay visible; clicking lands on the blocked notice.