### PR TITLE
fix: hide edit/resubmit when blocked, redesign blocked-posting notice

### DIFF
--- a/src/components/molecules/listingCardActions/index.tsx
+++ b/src/components/molecules/listingCardActions/index.tsx
@@ -30,6 +30,9 @@ export interface ListingCardActionsProps {
   showRepostButton?: boolean
   showRenewButton?: boolean
   showResubmitButton?: boolean
+  // Hidden when the owner is blocked from posting — editing feeds back into
+  // the same re-listing/resubmit flow the block is meant to stop.
+  showEditButton?: boolean
   // Permanently removed listings can only be deleted — every other action
   // (edit, promote, resubmit, copy link, take down, ...) is meaningless.
   onlyShowDelete?: boolean
@@ -49,6 +52,7 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
   showRepostButton = false,
   showRenewButton = false,
   showResubmitButton = false,
+  showEditButton = true,
   onlyShowDelete = false,
   className,
 }) => {
@@ -80,16 +84,18 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
 
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className}`}>
-      <Button
-        variant='ghost'
-        size='sm'
-        onClick={onEdit}
-        className='gap-1 text-muted-foreground hover:text-foreground text-xs sm:text-sm'
-      >
-        <Edit size={14} />
-        <span className='hidden xs:inline'>{t('editFull')}</span>
-        <span className='xs:hidden'>{t('edit')}</span>
-      </Button>
+      {showEditButton && (
+        <Button
+          variant='ghost'
+          size='sm'
+          onClick={onEdit}
+          className='gap-1 text-muted-foreground hover:text-foreground text-xs sm:text-sm'
+        >
+          <Edit size={14} />
+          <span className='hidden xs:inline'>{t('editFull')}</span>
+          <span className='xs:hidden'>{t('edit')}</span>
+        </Button>
+      )}
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -101,9 +101,10 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   const isPermanentlyRemoved =
     moderationStatus === ModerationStatus.SUSPENDED && !!permanentlyRemoved
   const isResubmittable =
-    moderationStatus === ModerationStatus.REJECTED ||
-    moderationStatus === ModerationStatus.REVISION_REQUIRED ||
-    (moderationStatus === ModerationStatus.SUSPENDED && !permanentlyRemoved)
+    !postingBlocked &&
+    (moderationStatus === ModerationStatus.REJECTED ||
+      moderationStatus === ModerationStatus.REVISION_REQUIRED ||
+      (moderationStatus === ModerationStatus.SUSPENDED && !permanentlyRemoved))
 
   const calculatedExpiryDate = React.useMemo(() => {
     if (expiryDate) return toISO(expiryDate)
@@ -571,6 +572,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 showRepostButton={showRepostButton}
                 showRenewButton={showRenewButton}
                 showResubmitButton={isResubmittable}
+                showEditButton={!postingBlocked}
                 onlyShowDelete={isPermanentlyRemoved}
               />
             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1867,8 +1867,11 @@
     "saveDraft": "Save draft",
     "draftSaved": "Saved to drafts",
     "blockedFromPostingDialog": {
-      "title": "Account blocked from posting",
-      "description": "Your account has been blocked from posting because several of your listings were reported and confirmed as violations. You can still save drafts, but cannot publish. Please contact an administrator for support.",
+      "title": "Posting access restricted",
+      "description": "Your account is currently unable to publish new listings due to a violation of SmartRent's posting policy.",
+      "reasonLabel": "Reason for restriction",
+      "draftNote": "You can still compose and save listings as drafts. Publishing will be available again once the restriction is lifted.",
+      "contactSupport": "To have your posting access restored, please contact SmartRent at <email>smartrent.tools@gmail.com</email>.",
       "ok": "Got it"
     }
   },

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1868,7 +1868,10 @@
     "draftSaved": "Đã lưu vào bản nháp",
     "blockedFromPostingDialog": {
       "title": "Tài khoản bị chặn đăng tin",
-      "description": "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin vi phạm bị báo cáo và đã được duyệt. Bạn vẫn có thể lưu nháp, nhưng không thể đăng tin. Vui lòng liên hệ quản trị viên để được hỗ trợ.",
+      "description": "Tài khoản của bạn hiện không thể đăng tin mới do vi phạm chính sách đăng tin của SmartRent.",
+      "reasonLabel": "Lý do bị chặn",
+      "draftNote": "Bạn vẫn có thể soạn thảo và lưu tin dưới dạng bản nháp. Chức năng đăng tin sẽ được khôi phục sau khi tài khoản được gỡ chặn.",
+      "contactSupport": "Để được mở lại quyền đăng tin, vui lòng liên hệ SmartRent qua email <email>smartrent.tools@gmail.com</email>.",
       "ok": "Đã hiểu"
     }
   },

--- a/src/pages/seller/create-post/index.tsx
+++ b/src/pages/seller/create-post/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/atoms/dialog'
 import { Button } from '@/components/atoms/button'
 import { SELLERNET_ROUTES } from '@/constants/route'
+import { AlertTriangle, FileEdit } from 'lucide-react'
 import React from 'react'
 
 const CreatePostPage: NextPageWithLayout = () => {
@@ -64,6 +65,11 @@ const CreatePostPage: NextPageWithLayout = () => {
     [profileResponse?.data?.postingBlocked, user?.postingBlocked],
   )
 
+  const blockedReason =
+    profileResponse?.data?.postingBlockedReason ||
+    user?.postingBlockedReason ||
+    ''
+
   const handleRedirectToProfile = React.useCallback(() => {
     router.replace(SELLERNET_ROUTES.PERSONAL_EDIT)
   }, [router])
@@ -107,15 +113,46 @@ const CreatePostPage: NextPageWithLayout = () => {
         </DialogContent>
       </Dialog>
       <Dialog open={openBlockedDialog} onOpenChange={setOpenBlockedDialog}>
-        <DialogContent className='max-w-md'>
+        <DialogContent className='max-w-lg'>
           <DialogHeader>
             <DialogTitle>{tBlocked('title')}</DialogTitle>
-            <DialogDescription>
-              {user?.postingBlockedReason ||
-                profileResponse?.data?.postingBlockedReason ||
-                tBlocked('description')}
-            </DialogDescription>
+            <DialogDescription>{tBlocked('description')}</DialogDescription>
           </DialogHeader>
+
+          {blockedReason && (
+            <div className='flex items-start gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-4'>
+              <AlertTriangle className='mt-0.5 h-5 w-5 shrink-0 text-destructive' />
+              <div className='min-w-0'>
+                <p className='text-xs font-semibold uppercase tracking-wide text-destructive'>
+                  {tBlocked('reasonLabel')}
+                </p>
+                <p className='mt-1 text-sm text-foreground/90'>
+                  {blockedReason}
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className='flex items-start gap-3 rounded-xl border border-border bg-muted/40 p-4'>
+            <FileEdit className='mt-0.5 h-5 w-5 shrink-0 text-muted-foreground' />
+            <p className='text-sm text-muted-foreground'>
+              {tBlocked('draftNote')}
+            </p>
+          </div>
+
+          <p className='text-sm text-muted-foreground'>
+            {tBlocked.rich('contactSupport', {
+              email: (chunks) => (
+                <a
+                  href='mailto:smartrent.tools@gmail.com'
+                  className='font-medium text-primary underline underline-offset-2'
+                >
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
+
           <DialogFooter>
             <Button onClick={() => setOpenBlockedDialog(false)}>
               {tBlocked('ok')}


### PR DESCRIPTION
- Hide "Chỉnh sửa" (edit) and "Gửi lại duyệt" (resubmit) actions on the listing card when the owner is blocked from posting — resubmit was already rejected server-side, this removes the dead-end entry point too
- Redesign the blocked-posting dialog: wider card, a dedicated framed "Lý do bị chặn" box for the admin's reason, a clearer draft-saving note, and a mailto link to smartrent.tools@gmail.com for support — copy rewritten in both locales for a more professional tone