### PR TITLE
fix: allow push and detail link for EXPIRING_SOON listings

### DIFF
--- a/src/components/molecules/pushPaymentConfirmModal/index.tsx
+++ b/src/components/molecules/pushPaymentConfirmModal/index.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Rocket, Wallet } from 'lucide-react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/atoms/dialog'
+import { Button } from '@/components/atoms/button'
+import { Typography } from '@/components/atoms/typography'
+import { cn } from '@/lib/utils'
+import { useLanguage } from '@/hooks/useLanguage'
+import { usePushDetail } from '@/hooks/usePush'
+import { formatByLocale } from '@/utils/currency/convert'
+import { PushDetailCode } from '@/api/types/push.type'
+import { ListingOwnerDetail } from '@/api/types'
+
+export interface PushPaymentConfirmModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  listing: ListingOwnerDetail | null
+  isLoading?: boolean
+  onConfirm: () => void
+}
+
+export const PushPaymentConfirmModal: React.FC<
+  PushPaymentConfirmModalProps
+> = ({ open, onOpenChange, listing, isLoading = false, onConfirm }) => {
+  const t = useTranslations('seller.listingManagement.card.pushPaymentDialog')
+  const { language } = useLanguage()
+  const { data: pushDetail, isLoading: isPriceLoading } = usePushDetail(
+    PushDetailCode.SINGLE_PUSH,
+  )
+
+  const pricePerPush = pushDetail?.data?.data?.pricePerPush
+  const priceLabel =
+    pricePerPush !== undefined ? formatByLocale(pricePerPush, language) : null
+
+  if (!listing) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-md p-0 overflow-hidden gap-0'>
+        <div className='bg-gradient-to-br from-primary to-primary/80 px-6 py-5 text-primary-foreground'>
+          <DialogHeader className='gap-1.5'>
+            <DialogTitle asChild>
+              <div className='flex items-center gap-2 text-base font-semibold'>
+                <Rocket size={18} />
+                {t('title')}
+              </div>
+            </DialogTitle>
+            <DialogDescription className='text-primary-foreground/90 text-sm'>
+              {t('description')}
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className='px-6 py-5 space-y-4'>
+          <div className='rounded-lg border border-border bg-muted/30 p-3'>
+            <Typography
+              variant='small'
+              className='text-xs text-muted-foreground'
+            >
+              {t('listingLabel')}
+            </Typography>
+            <Typography
+              variant='small'
+              className='font-semibold line-clamp-1 mt-0.5'
+            >
+              {listing.title}
+            </Typography>
+          </div>
+
+          <div
+            className={cn(
+              'rounded-lg border-2 border-primary/30 bg-primary/[0.04] p-4',
+              'flex items-center gap-3',
+            )}
+          >
+            <div className='shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-primary text-primary-foreground'>
+              <Wallet size={20} />
+            </div>
+            <div className='flex-1 min-w-0'>
+              <Typography variant='small' className='font-semibold'>
+                {t('price.title')}
+              </Typography>
+              <Typography
+                variant='small'
+                className='text-lg font-bold text-primary mt-0.5 block'
+              >
+                {isPriceLoading ? t('price.loading') : (priceLabel ?? '—')}
+              </Typography>
+            </div>
+          </div>
+
+          <Typography variant='small' className='text-xs text-muted-foreground'>
+            {t('hint')}
+          </Typography>
+        </div>
+
+        <div className='border-t border-border bg-muted/20 px-6 py-4 flex gap-3 justify-end'>
+          <Button
+            variant='outline'
+            disabled={isLoading}
+            onClick={() => onOpenChange(false)}
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            disabled={isLoading}
+            onClick={onConfirm}
+            className='min-w-[140px]'
+          >
+            {isLoading ? t('loading') : t('confirm')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default PushPaymentConfirmModal

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -134,9 +134,16 @@ export const ListingCard: React.FC<ListingCardProps> = ({
 
   const isExpired = expired || false
   const showRank = rankOfVipType > 0
-  // Pushing only applies to DISPLAYING listings — hide it for expired/taken-down
-  // so the seller doesn't see two near-identical "đẩy tin" buttons. For expired
-  // listings the only call-to-action is "đăng lại" (repost).
+  // A listing is publicly live under both DISPLAYING and EXPIRING_SOON — public
+  // visibility only gates on moderationStatus=APPROVED + not expired, independent
+  // of the "expiring within 7 days" distinction the owner view surfaces as a
+  // separate badge. Keep the detail link (and push eligibility) in sync with that.
+  const isPubliclyVisible =
+    property.listingStatus === POST_STATUS.DISPLAYING ||
+    property.listingStatus === POST_STATUS.EXPIRING_SOON
+  // Pushing only applies to DISPLAYING/EXPIRING_SOON listings — hide it for
+  // expired/taken-down so the seller doesn't see two near-identical "đẩy tin"
+  // buttons. For expired listings the only call-to-action is "đăng lại" (repost).
   const showPromoteButton = !isExpired
   const showRepostButton = isExpired && !postingBlocked
   // Renewal is the +30-day quota top-up — restricted to listings the backend
@@ -240,7 +247,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 {verified && (
                   <VerificationBadge verified={verified} type='verified' />
                 )}
-                {property.listingStatus === POST_STATUS.DISPLAYING && (
+                {isPubliclyVisible && (
                   <TooltipProvider delayDuration={300}>
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -22,6 +22,7 @@ import { PUBLIC_ROUTES } from '@/constants/route'
 import { MembershipPushDisplay } from '@/components/molecules/listings/MembershipPushDisplay'
 import { usePushListing, usePushQuota } from '@/hooks/usePush'
 import PushLimitModal from '@/components/molecules/pushLimitModal'
+import PushPaymentConfirmModal from '@/components/molecules/pushPaymentConfirmModal'
 import { PushLimitError } from '@/api/types/push.type'
 import { PageContainer } from '@/components/atoms/pageContainer'
 import { Typography } from '@/components/atoms/typography'
@@ -97,6 +98,10 @@ const ListingsWithPagination = () => {
     waitMinutes: number
     apiMessage?: string | null
   }>({ open: false, waitMinutes: 1, apiMessage: null })
+  const [pushPaymentState, setPushPaymentState] = useState<{
+    open: boolean
+    listing: ListingOwnerDetail | null
+  }>({ open: false, listing: null })
 
   const { ref: loadMoreRef } = useIntersectionObserver({
     onIntersect: () => {
@@ -119,19 +124,10 @@ const ListingsWithPagination = () => {
     }
   }
 
-  const handlePushListing = async (listing: ListingOwnerDetail) => {
-    const canPush =
-      listing.verified === true &&
-      listing.listingStatus === POST_STATUS.DISPLAYING
-
-    if (!canPush) {
-      toast.error(tSeller('card.toast.pushNotDisplaying'))
-      return
-    }
-
-    const hasQuota = quotaData?.data && quotaData.data.totalAvailable > 0
-    const useMembershipQuota = hasQuota ?? false
-
+  const runPushMutation = async (
+    listing: ListingOwnerDetail,
+    useMembershipQuota: boolean,
+  ) => {
     // On the payment path the user leaves for the gateway and returns to
     // /payment/result — leave a marker so it routes back to the listings.
     if (!useMembershipQuota) {
@@ -176,6 +172,34 @@ const ListingsWithPagination = () => {
         error instanceof Error ? error.message : tSeller('card.toast.pushError')
       toast.error(message || tSeller('card.toast.pushError'))
     }
+  }
+
+  const handlePushListing = async (listing: ListingOwnerDetail) => {
+    // A listing is publicly live under both DISPLAYING and EXPIRING_SOON — see
+    // the matching check in listing-card's `isPubliclyVisible`. Pushing an
+    // EXPIRING_SOON listing is if anything more useful, since the seller is
+    // trying to keep visibility right before it expires.
+    const canPush =
+      listing.verified === true &&
+      (listing.listingStatus === POST_STATUS.DISPLAYING ||
+        listing.listingStatus === POST_STATUS.EXPIRING_SOON)
+
+    if (!canPush) {
+      toast.error(tSeller('card.toast.pushNotDisplaying'))
+      return
+    }
+
+    const hasQuota = quotaData?.data && quotaData.data.totalAvailable > 0
+    const useMembershipQuota = hasQuota ?? false
+
+    if (!useMembershipQuota) {
+      // No quota left — show the 40k one-time push price and let the seller
+      // opt in before firing the payment mutation (and its gateway redirect).
+      setPushPaymentState({ open: true, listing })
+      return
+    }
+
+    await runPushMutation(listing, true)
   }
 
   if (isLoading && listings.length === 0) {
@@ -427,6 +451,21 @@ const ListingsWithPagination = () => {
             }
             waitMinutes={pushLimitState.waitMinutes}
             apiMessage={pushLimitState.apiMessage}
+          />
+
+          <PushPaymentConfirmModal
+            open={pushPaymentState.open}
+            onOpenChange={(open) =>
+              setPushPaymentState((prev) => ({ ...prev, open }))
+            }
+            listing={pushPaymentState.listing}
+            isLoading={pushMutation.isPending}
+            onConfirm={() => {
+              const listing = pushPaymentState.listing
+              if (!listing) return
+              setPushPaymentState({ open: false, listing: null })
+              runPushMutation(listing, false)
+            }}
           />
 
           {/* Desktop: Show Pagination */}

--- a/src/hooks/usePush/index.ts
+++ b/src/hooks/usePush/index.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { PushService } from '@/api/services/push.service'
 import { QuotaService } from '@/api/services/quota.service'
 import type {
+  PushDetailCode,
   PushListingRequest,
   PushListingResponse,
 } from '@/api/types/push.type'
@@ -94,6 +95,26 @@ export function usePushListing() {
         startGatewayCheckout(data.data)
       }
     },
+  })
+}
+
+/**
+ * Hook to fetch a single push pricing detail (e.g. the one-time SINGLE_PUSH
+ * price) — used to show the actual price before charging a seller with no
+ * quota left, instead of hardcoding it on the FE.
+ * @param detailCode - Push detail code (SINGLE_PUSH, PUSH_PACKAGE_3, etc.)
+ * @example
+ * ```tsx
+ * const { data } = usePushDetail(PushDetailCode.SINGLE_PUSH)
+ * console.log(data?.data?.data?.pricePerPush)
+ * ```
+ */
+export function usePushDetail(detailCode: PushDetailCode) {
+  return useQuery({
+    queryKey: ['pushDetail', detailCode],
+    queryFn: () => PushService.getPushDetailByCode(detailCode),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   })
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2848,6 +2848,19 @@
           "cancel": "Cancel",
           "loading": "Renewing..."
         },
+        "pushPaymentDialog": {
+          "title": "Confirm push",
+          "description": "You're out of free pushes. Push this listing now with a one-time payment.",
+          "listingLabel": "Listing",
+          "price": {
+            "title": "Push fee",
+            "loading": "Loading price..."
+          },
+          "hint": "The listing will be pushed to the top right after payment succeeds.",
+          "confirm": "Pay now",
+          "cancel": "Cancel",
+          "loading": "Processing..."
+        },
         "takeDownConfirm": {
           "title": "Take down this listing?",
           "description": "Are you sure you want to take down this listing? Please review the consequences below before confirming.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2848,6 +2848,19 @@
           "cancel": "Huỷ",
           "loading": "Đang gia hạn..."
         },
+        "pushPaymentDialog": {
+          "title": "Xác nhận đẩy tin",
+          "description": "Bạn đã dùng hết lượt đẩy tin miễn phí. Đẩy tin ngay bằng cách thanh toán một lần.",
+          "listingLabel": "Tin đăng",
+          "price": {
+            "title": "Phí đẩy tin",
+            "loading": "Đang tải giá..."
+          },
+          "hint": "Tin sẽ được đẩy lên đầu ngay sau khi thanh toán thành công.",
+          "confirm": "Thanh toán",
+          "cancel": "Huỷ",
+          "loading": "Đang xử lý..."
+        },
         "takeDownConfirm": {
           "title": "Ẩn tin đăng?",
           "description": "Bạn có chắc chắn muốn ẩn tin đăng này? Vui lòng đọc kỹ các lưu ý bên dưới trước khi xác nhận.",


### PR DESCRIPTION
Listings expiring within 7 days are still publicly live (public visibility only gates on moderationStatus=APPROVED + not expired), but listing-card's detail-page link and listingsManagementTemplate's push eligibility both strictly required listingStatus === DISPLAYING, so both disappeared for listings the seller list already showed as active under the "Đang hiển thị" tab. Widen both checks to also accept EXPIRING_SOON, matching the backend push-eligibility change in smartrent-backend.

Also replace the instant, unconfirmed redirect to the SePay checkout gateway when a seller has no push quota left with a confirmation modal (PushPaymentConfirmModal) showing the actual one-time push price (fetched from PushService.getPushDetailByCode(SINGLE_PUSH), currently 40,000 VND server-side) before the payment mutation fires.