### PR TITLE
fix: hardcode the 40,000 VND single-push price on FE

### DIFF
--- a/src/components/molecules/pushPaymentConfirmModal/index.tsx
+++ b/src/components/molecules/pushPaymentConfirmModal/index.tsx
@@ -15,10 +15,12 @@ import { Button } from '@/components/atoms/button'
 import { Typography } from '@/components/atoms/typography'
 import { cn } from '@/lib/utils'
 import { useLanguage } from '@/hooks/useLanguage'
-import { usePushDetail } from '@/hooks/usePush'
 import { formatByLocale } from '@/utils/currency/convert'
-import { PushDetailCode } from '@/api/types/push.type'
 import { ListingOwnerDetail } from '@/api/types'
+
+// Mirrors PricingConstants.PUSH_PER_TIME in the backend (smart-rent) — the
+// one-time push fee charged when a seller has no push quota left.
+const SINGLE_PUSH_PRICE_VND = 40000
 
 export interface PushPaymentConfirmModalProps {
   open: boolean
@@ -33,13 +35,7 @@ export const PushPaymentConfirmModal: React.FC<
 > = ({ open, onOpenChange, listing, isLoading = false, onConfirm }) => {
   const t = useTranslations('seller.listingManagement.card.pushPaymentDialog')
   const { language } = useLanguage()
-  const { data: pushDetail, isLoading: isPriceLoading } = usePushDetail(
-    PushDetailCode.SINGLE_PUSH,
-  )
-
-  const pricePerPush = pushDetail?.data?.data?.pricePerPush
-  const priceLabel =
-    pricePerPush !== undefined ? formatByLocale(pricePerPush, language) : null
+  const priceLabel = formatByLocale(SINGLE_PUSH_PRICE_VND, language)
 
   if (!listing) return null
 
@@ -93,7 +89,7 @@ export const PushPaymentConfirmModal: React.FC<
                 variant='small'
                 className='text-lg font-bold text-primary mt-0.5 block'
               >
-                {isPriceLoading ? t('price.loading') : (priceLabel ?? '—')}
+                {priceLabel}
               </Typography>
             </div>
           </div>

--- a/src/hooks/usePush/index.ts
+++ b/src/hooks/usePush/index.ts
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { PushService } from '@/api/services/push.service'
 import { QuotaService } from '@/api/services/quota.service'
 import type {
-  PushDetailCode,
   PushListingRequest,
   PushListingResponse,
 } from '@/api/types/push.type'
@@ -95,26 +94,6 @@ export function usePushListing() {
         startGatewayCheckout(data.data)
       }
     },
-  })
-}
-
-/**
- * Hook to fetch a single push pricing detail (e.g. the one-time SINGLE_PUSH
- * price) — used to show the actual price before charging a seller with no
- * quota left, instead of hardcoding it on the FE.
- * @param detailCode - Push detail code (SINGLE_PUSH, PUSH_PACKAGE_3, etc.)
- * @example
- * ```tsx
- * const { data } = usePushDetail(PushDetailCode.SINGLE_PUSH)
- * console.log(data?.data?.data?.pricePerPush)
- * ```
- */
-export function usePushDetail(detailCode: PushDetailCode) {
-  return useQuery({
-    queryKey: ['pushDetail', detailCode],
-    queryFn: () => PushService.getPushDetailByCode(detailCode),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
   })
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2853,8 +2853,7 @@
           "description": "You're out of free pushes. Push this listing now with a one-time payment.",
           "listingLabel": "Listing",
           "price": {
-            "title": "Push fee",
-            "loading": "Loading price..."
+            "title": "Push fee"
           },
           "hint": "The listing will be pushed to the top right after payment succeeds.",
           "confirm": "Pay now",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2853,8 +2853,7 @@
           "description": "Bạn đã dùng hết lượt đẩy tin miễn phí. Đẩy tin ngay bằng cách thanh toán một lần.",
           "listingLabel": "Tin đăng",
           "price": {
-            "title": "Phí đẩy tin",
-            "loading": "Đang tải giá..."
+            "title": "Phí đẩy tin"
           },
           "hint": "Tin sẽ được đẩy lên đầu ngay sau khi thanh toán thành công.",
           "confirm": "Thanh toán",


### PR DESCRIPTION
Drop the extra GET call to PushService.getPushDetailByCode(SINGLE_PUSH) — hardcode the price to match PricingConstants.PUSH_PER_TIME in the backend directly, removing the now-unused usePushDetail hook.