### PR TITLE
fix: translate property type badge on seller listing cards

### DIFF
--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -17,7 +17,10 @@ import {
 import { cn } from '@/lib/utils'
 import { toISO, formatISO } from '@/utils/date/safe'
 import { formatByLocale } from '@/utils/currency/convert'
-import { getPriceUnitTranslationKey } from '@/utils/property'
+import {
+  getPriceUnitTranslationKey,
+  getProductTypeTranslationKey,
+} from '@/utils/property'
 import { useLanguage } from '@/hooks/useLanguage'
 import { useAuth } from '@/hooks/useAuth'
 import { ListingOwnerDetail } from '@/api/types'
@@ -241,7 +244,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 )}
                 {productType && (
                   <Badge variant='secondary' className='font-medium'>
-                    {productType}
+                    {tNot(getProductTypeTranslationKey(productType))}
                   </Badge>
                 )}
                 {verified && (


### PR DESCRIPTION
The property type badge (Room/Apartment/Studio/...) rendered the raw PropertyType enum value straight from the API instead of a localized label — same enum, same translation keys already used by the public propertyCard, just never wired up here.