### PR TITLE
fix: fill zero-count days in saves trend chart when backend returns none

### DIFF
--- a/src/components/molecules/dashboardSavedListingsChart/index.tsx
+++ b/src/components/molecules/dashboardSavedListingsChart/index.tsx
@@ -197,9 +197,6 @@ const DashboardSavedListingsChart: React.FC<
     }
 
     const raw = trend.savesOverTime
-    if (raw.length === 0) {
-      return []
-    }
 
     const periodToDays = (p: typeof period): number | null => {
       switch (p) {


### PR DESCRIPTION
Chart was rendering completely blank whenever savesOverTime came back empty for the selected period, even though totalSaves showed a non-zero count in the header.