### PR TITLE
fix: handle null address in draft mapping to stop /my-drafts crash

### DIFF
--- a/src/api/types/draft.type.ts
+++ b/src/api/types/draft.type.ts
@@ -125,8 +125,8 @@ export interface DraftListingResponse {
   price: number
   priceUnit: PriceUnit
 
-  // Address - Now a nested object
-  address: DraftAddressResponse
+  // Address - Now a nested object (null while the draft has no address yet)
+  address: DraftAddressResponse | null
 
   // Property Specifications
   area: number

--- a/src/utils/property/mapDraftResponse.ts
+++ b/src/utils/property/mapDraftResponse.ts
@@ -63,9 +63,33 @@ export interface DraftDetail {
 }
 
 /**
- * Map backend draft address to frontend format
+ * Map backend draft address to frontend format.
+ * Drafts still being composed may not have an address yet (backend sends `null`).
  */
-function mapDraftAddress(address: DraftAddressResponse) {
+function mapDraftAddress(address: DraftAddressResponse | null) {
+  if (!address) {
+    return {
+      type: 'NEW' as const,
+      fullAddress: null,
+      fullNewAddress: null,
+      provinceId: null,
+      provinceName: null,
+      districtId: null,
+      districtName: null,
+      wardId: null,
+      wardName: null,
+      provinceCode: null,
+      wardCode: null,
+      street: null,
+      streetId: null,
+      streetName: null,
+      projectId: null,
+      projectName: null,
+      latitude: 0,
+      longitude: 0,
+    }
+  }
+
   return {
     type: address.addressType,
     fullAddress: address.fullAddress,


### PR DESCRIPTION
Drafts still being composed have address: null from the backend, but mapDraftAddress assumed a non-null object and threw, failing the whole queryFn on every draft list load — causing repeated retries and an empty seller drafts page despite the API returning valid data.