### PR TITLE
fix: skip notification WebSocket connect until a token is available

### DIFF
--- a/src/hooks/useNotifications/useNotificationWebSocket.ts
+++ b/src/hooks/useNotifications/useNotificationWebSocket.ts
@@ -30,9 +30,14 @@ export function useNotificationWebSocket(
 
     const token = getAccessToken()
 
+    // Without a token the CONNECT frame is guaranteed to be rejected, and
+    // reconnectDelay would then retry every 5s forever with the same empty
+    // header. Skip connecting until a token is actually available.
+    if (!token) return
+
     const client = new Client({
       webSocketFactory: () => new SockJS(`${wsBaseUrl}/ws`),
-      connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+      connectHeaders: { Authorization: `Bearer ${token}` },
       reconnectDelay: 5000,
 
       onConnect: () => {
@@ -53,10 +58,14 @@ export function useNotificationWebSocket(
       },
 
       onStompError: (frame) => {
-        console.error(
-          '[Notification WS] STOMP error:',
-          frame.headers['message'],
-        )
+        const message = frame.headers['message']
+        console.error('[Notification WS] STOMP error:', message)
+
+        // Auth errors won't resolve by retrying with the same stale token,
+        // so stop the built-in reconnect loop instead of retrying forever.
+        if (message && /bearer|token|auth/i.test(message)) {
+          client.deactivate()
+        }
       },
 
       onDisconnect: () => {


### PR DESCRIPTION
connectHeaders already sent the bearer token when present, but the client still activated with an empty header when getAccessToken() returned nothing (e.g. isAuthenticated flips true before the token cookie is actually readable). That guarantees a STOMP auth rejection, and reconnectDelay then retries every 5s forever with the same empty header -- same failure mode fixed on the admin site.

- don't activate the client until a token is actually available
- stop the built-in reconnect loop on auth-related STOMP errors instead of retrying forever with a stale/missing token