### PR TITLE
fix(notifications): re-read access token on WebSocket reconnect

### DIFF
--- a/src/hooks/useNotifications/useNotificationWebSocket.ts
+++ b/src/hooks/useNotifications/useNotificationWebSocket.ts
@@ -28,12 +28,23 @@ export function useNotificationWebSocket(
 
     const wsBaseUrl = ENV.URL_API_BASE.replace(/\/$/, '')
 
-    const token = getAccessToken()
-
     const client = new Client({
       webSocketFactory: () => new SockJS(`${wsBaseUrl}/ws`),
-      connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
       reconnectDelay: 5000,
+
+      // Re-read the token on EVERY (re)connect instead of snapshotting it once.
+      // The access token is short-lived and rotated by the axios refresh flow;
+      // capturing it a single time meant that after it expired the STOMP
+      // reconnect kept resending a stale/empty Authorization header, so the
+      // server rejected every attempt ("missing bearer token") in a 5s loop and
+      // realtime notifications silently died. Reading it here lets the next
+      // reconnect pick up the refreshed token and recover on its own.
+      beforeConnect: () => {
+        const token = getAccessToken()
+        client.connectHeaders = token
+          ? { Authorization: `Bearer ${token}` }
+          : {}
+      },
 
       onConnect: () => {
         console.log('[Notification WS] Connected')


### PR DESCRIPTION
## Problem

Notification WebSocket reconnect loop: `Rejected STOMP CONNECT: missing bearer token` spamming the backend logs every ~5s, and realtime notifications silently not delivered for the session.

## Root cause

- `useNotifications` activates the WS on `useAuth().isAuthenticated` — a Zustand store boolean set at login, **not** the `access_token` cookie.
- `useNotificationWebSocket` read `getAccessToken()` **once** at connect (effect deps `[userId]`), and STOMP reused that snapshot on every reconnect (`reconnectDelay: 5000`).
- The `access_token` cookie is short-lived and rotated by the axios refresh flow. Once it expired (user still "authenticated" per the store), the client kept reconnecting with a stale/empty `Authorization` header → the server rejected every CONNECT → an endless 5s loop. REST kept working (axios refreshes on 401); the WS never participated in that refresh.

## Fix

Read the token freshly in STOMP's `beforeConnect` on every (re)connect. When the axios layer rotates the cookie, the next reconnect (≤5s) picks up the new token and the client recovers on its own — no more permanent loop, and notifications resume.

## Verify

- `npm run lint` — clean
- `npm run typecheck` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
