### PR TITLE
perf(chat): defer markdown parsing until a streamed reply finishes

### DIFF
--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -202,6 +202,11 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
   onSuggestionClick,
 }) => {
   const isBot = message.sender === 'bot'
+  // While a bot message is still streaming we render it as plain text and
+  // defer markdown parsing until it settles. ReactMarkdown re-parses the
+  // whole message on every token, so parsing per delta is O(n^2) over the
+  // answer length — the main source of jank on long streamed replies.
+  const isStreaming = isBot && message.isStreaming === true
   const hasListings = isBot && message.listings && message.listings.length > 0
   const t = useTranslations('chat')
   const tAi = useTranslations('aiChat')
@@ -210,16 +215,18 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
   const [showAllResults, setShowAllResults] = useState(false)
   const [showExpandDialog, setShowExpandDialog] = useState(false)
 
-  // Process bot message content
+  // Process bot message content (skip the regex passes while streaming — the
+  // plain-text view doesn't use them and they'd run on every token).
   const processedContent = useMemo(() => {
-    if (!isBot) return message.content
+    if (!isBot || isStreaming) return message.content
     return processContent(message.content)
-  }, [isBot, message.content])
+  }, [isBot, isStreaming, message.content])
 
-  // Detect if message contains a markdown table (for expand button)
+  // Detect if message contains a markdown table (for expand button). Only
+  // meaningful once streaming settles.
   const containsTable = useMemo(
-    () => isBot && hasMarkdownTable(message.content),
-    [isBot, message.content],
+    () => isBot && !isStreaming && hasMarkdownTable(message.content),
+    [isBot, isStreaming, message.content],
   )
 
   // Dynamic bubble markdown components: hide table when expand dialog available
@@ -275,7 +282,7 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
                 : 'bg-primary text-primary-foreground rounded-br-md',
             )}
           >
-            {isBot ? (
+            {isBot && !isStreaming ? (
               <div
                 className={cn(
                   'prose prose-sm dark:prose-invert max-w-none break-words text-sm leading-relaxed',

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -37,6 +37,10 @@ export type TChatMessage = {
   /** Marks a bot message that should render an inline action button (e.g. the
    *  guest login CTA shown after the free message limit is reached). */
   action?: 'login'
+  /** True while this bot message is still receiving streamed text deltas. The
+   *  bubble renders plain text during streaming and defers markdown parsing
+   *  until the stream settles, avoiding a full re-parse on every token. */
+  isStreaming?: boolean
 }
 
 export type TChatState = {
@@ -242,6 +246,7 @@ export const useChatLogic = () => {
             content: '',
             sender: 'bot',
             timestamp: new Date(),
+            isStreaming: true,
           })
           setIsTyping(false)
         }
@@ -287,9 +292,13 @@ export const useChatLogic = () => {
                 ensureBotMessage()
                 const toolsUsed =
                   data.tools_used ?? data.metadata?.tools_used ?? []
-                if (toolsUsed.length > 0) {
-                  updateMessage(botMessageId, (m) => ({ ...m, toolsUsed }))
-                }
+                // Settle the message: switch the bubble from plain text to
+                // full markdown, and attach tool metadata if any.
+                updateMessage(botMessageId, (m) => ({
+                  ...m,
+                  isStreaming: false,
+                  ...(toolsUsed.length > 0 ? { toolsUsed } : {}),
+                }))
                 setIsTyping(false)
                 setIsLoading(false)
                 setStreamingStatus(null)
@@ -300,6 +309,7 @@ export const useChatLogic = () => {
                   updateMessage(botMessageId, (m) => ({
                     ...m,
                     content: m.content || msg || getChatErrorContent(locale, t),
+                    isStreaming: false,
                   }))
                 } else {
                   addMessage({
@@ -322,6 +332,12 @@ export const useChatLogic = () => {
           // the reserved space alone: a new send re-anchors it, and
           // cancelStream finalizes it on its own.
           if ((error as Error)?.name === 'AbortError') {
+            // A cancelled / superseded stream leaves its partial bubble mid-
+            // stream; settle it so it renders as markdown rather than staying
+            // stuck in the plain-text streaming view.
+            if (botMessageAdded) {
+              updateMessage(botMessageId, (m) => ({ ...m, isStreaming: false }))
+            }
             setIsTyping(false)
             setIsLoading(false)
             setStreamingStatus(null)
@@ -329,6 +345,9 @@ export const useChatLogic = () => {
           }
           // onError handler already updated UI for stream-level errors;
           // anything reaching here is a fatal pre-stream/network failure.
+          if (botMessageAdded) {
+            updateMessage(botMessageId, (m) => ({ ...m, isStreaming: false }))
+          }
           if (isLoading) {
             setIsTyping(false)
             setIsLoading(false)


### PR DESCRIPTION
## What
`ReactMarkdown` re-parsed the entire growing bot message on every text delta, so render cost was **O(n²)** over the reply length — the main cause of jank on long streamed answers, especially on mobile.

Now the in-flight bot message carries `isStreaming`; the bubble renders it as **plain text** while streaming and switches to full markdown only once the stream settles (done / error / abort). Also skips the per-token link/phone/table regex passes mid-stream.

## Changes
- `TChatMessage.isStreaming` flag — set on bot-message creation, cleared at every terminal path (done / error / abort / fatal) in `useChatLogic`.
- `aiChatBubble` renders plain text while `isStreaming`, markdown otherwise (single ternary — no nested-ternary Sonar issue).

## Verify
- `npm run typecheck` — OK
- `npm run lint` — 0 errors, 0 warnings on touched files
- `npm run i18n:check` — OK (no new strings)
- `npm run test` (useChatAi suites) — **13/13 pass**

## Trade-off
One-time reflow when a reply switches from plain text to formatted markdown at end-of-stream — acceptable vs per-token reparse jank. A follow-up could rAF-coalesce token renders too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
