### PR TITLE
fix: remove duplicate resubmit CTA and block editing on rejected list…

### DIFF
--- a/src/components/molecules/listingCardActions/index.tsx
+++ b/src/components/molecules/listingCardActions/index.tsx
@@ -4,7 +4,6 @@ import {
   Edit,
   MoreHorizontal,
   ChevronsUp,
-  SendHorizontal,
   CalendarPlus,
   Trash2,
 } from 'lucide-react'
@@ -22,14 +21,12 @@ export interface ListingCardActionsProps {
   onPromote?: () => void
   onRepost?: () => void
   onRenew?: () => void
-  onResubmit?: () => void
   onCopyListing?: () => void
   onTakeDown?: () => void
   onDelete?: () => void
   showPromoteButton?: boolean
   showRepostButton?: boolean
   showRenewButton?: boolean
-  showResubmitButton?: boolean
   // Hidden when the owner is blocked from posting — editing feeds back into
   // the same re-listing/resubmit flow the block is meant to stop.
   showEditButton?: boolean
@@ -44,14 +41,12 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
   onPromote,
   onRepost,
   onRenew,
-  onResubmit,
   onCopyListing,
   onTakeDown,
   onDelete,
   showPromoteButton = true,
   showRepostButton = false,
   showRenewButton = false,
-  showResubmitButton = false,
   showEditButton = true,
   onlyShowDelete = false,
   className,
@@ -156,18 +151,6 @@ export const ListingCardActions: React.FC<ListingCardActionsProps> = ({
           <ChevronsUp size={14} />
           <span className='hidden xs:inline'>{t('repostFull')}</span>
           <span className='xs:hidden'>{t('repost')}</span>
-        </Button>
-      )}
-
-      {showResubmitButton && (
-        <Button
-          onClick={onResubmit}
-          size='sm'
-          className='gap-1 bg-orange-500 hover:bg-orange-600 text-white dark:bg-orange-600 dark:hover:bg-orange-700 text-xs sm:text-sm'
-        >
-          <SendHorizontal size={14} />
-          <span className='hidden xs:inline'>{t('resubmitFull')}</span>
-          <span className='xs:hidden'>{t('resubmit')}</span>
         </Button>
       )}
     </div>

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -53,7 +53,6 @@ export interface ListingCardProps {
   onPromote?: () => void
   onRepost?: () => void
   onRenew?: () => void
-  onResubmit?: () => void
   onCopyListing?: () => void
   onTakeDown?: () => void
   onDelete?: () => void
@@ -66,7 +65,6 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   onPromote,
   onRepost,
   onRenew,
-  onResubmit,
   onCopyListing,
   onTakeDown,
   onDelete,
@@ -103,11 +101,16 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   const permanentlyRemoved = property.permanentlyRemoved
   const isPermanentlyRemoved =
     moderationStatus === ModerationStatus.SUSPENDED && !!permanentlyRemoved
-  const isResubmittable =
-    !postingBlocked &&
-    (moderationStatus === ModerationStatus.REJECTED ||
-      moderationStatus === ModerationStatus.REVISION_REQUIRED ||
-      (moderationStatus === ModerationStatus.SUSPENDED && !permanentlyRemoved))
+  // A rejected listing (either the legacy REJECTED status, or SUSPENDED with a
+  // pendingOwnerAction from the review-queue reject flow) can't be edited or
+  // resubmitted — mirrors ModerationBanner's isRejected. SUSPENDED without a
+  // pendingOwnerAction is a report-driven temporary hide, not a rejection, and
+  // editing is still allowed there.
+  const isRejected =
+    moderationStatus === ModerationStatus.REJECTED ||
+    (moderationStatus === ModerationStatus.SUSPENDED &&
+      !permanentlyRemoved &&
+      Boolean(property.pendingOwnerAction))
 
   const calculatedExpiryDate = React.useMemo(() => {
     if (expiryDate) return toISO(expiryDate)
@@ -550,7 +553,6 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 pendingOwnerAction={property.pendingOwnerAction}
                 permanentlyRemoved={permanentlyRemoved}
                 listingId={property.listingId}
-                onResubmit={isResubmittable ? onResubmit : undefined}
                 className='mb-4'
               />
             )}
@@ -574,15 +576,13 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 onPromote={onPromote}
                 onRepost={onRepost}
                 onRenew={onRenew}
-                onResubmit={onResubmit}
                 onCopyListing={onCopyListing}
                 onTakeDown={onTakeDown}
                 onDelete={onDelete}
                 showPromoteButton={showPromoteButton}
                 showRepostButton={showRepostButton}
                 showRenewButton={showRenewButton}
-                showResubmitButton={isResubmittable}
-                showEditButton={!postingBlocked}
+                showEditButton={!postingBlocked && !isRejected}
                 onlyShowDelete={isPermanentlyRemoved}
               />
             </div>

--- a/src/components/organisms/listings-list/index.tsx
+++ b/src/components/organisms/listings-list/index.tsx
@@ -11,7 +11,6 @@ export interface ListingsListProps {
   onPromoteListing?: (listing: ListingOwnerDetail) => void
   onRepostListing?: (listing: ListingOwnerDetail) => void
   onRenewListing?: (listing: ListingOwnerDetail) => void
-  onResubmitListing?: (listing: ListingOwnerDetail) => void
   onCopyListing?: (listing: ListingOwnerDetail) => void
   onTakeDown?: (listing: ListingOwnerDetail) => void
   onDelete?: (listing: ListingOwnerDetail) => void
@@ -26,7 +25,6 @@ export const ListingsList: React.FC<ListingsListProps> = ({
   onPromoteListing,
   onRepostListing,
   onRenewListing,
-  onResubmitListing,
   onCopyListing,
   onTakeDown,
   onDelete,
@@ -68,7 +66,6 @@ export const ListingsList: React.FC<ListingsListProps> = ({
           onPromote={() => onPromoteListing?.(listing)}
           onRepost={() => onRepostListing?.(listing)}
           onRenew={() => onRenewListing?.(listing)}
-          onResubmit={() => onResubmitListing?.(listing)}
           onCopyListing={() => onCopyListing?.(listing)}
           onTakeDown={() => onTakeDown?.(listing)}
           onDelete={() => onDelete?.(listing)}

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -38,7 +38,6 @@ import {
   ListingOwnerDetail,
   PostStatus,
   POST_STATUS,
-  ModerationStatus,
   ListingFilterRequest,
   ResubmitNotAllowedError,
 } from '@/api/types'
@@ -226,20 +225,7 @@ const ListingsWithPagination = () => {
           <ListingsList
             listings={listings}
             onEditListing={(listing) => {
-              // Redirect to update-post with resubmit context for rejected/revision-required/suspended (non-permanent) listings
-              const needsResubmitContext =
-                listing.moderationStatus === ModerationStatus.REJECTED ||
-                listing.moderationStatus ===
-                  ModerationStatus.REVISION_REQUIRED ||
-                (listing.moderationStatus === ModerationStatus.SUSPENDED &&
-                  !listing.permanentlyRemoved)
-              if (needsResubmitContext) {
-                router.push(
-                  `/seller/update-post/${listing.listingId}?resubmit=true`,
-                )
-              } else {
-                router.push(`/seller/update-post/${listing.listingId}`)
-              }
+              router.push(`/seller/update-post/${listing.listingId}`)
             }}
             onPromoteListing={(listing) => {
               handlePushListing(listing)
@@ -251,12 +237,6 @@ const ListingsWithPagination = () => {
             onRenewListing={(listing) => {
               setSelectedListingForRenew(listing)
               setRenewDialogOpen(true)
-            }}
-            onResubmitListing={(listing) => {
-              // Redirect to update-post with resubmit context
-              router.push(
-                `/seller/update-post/${listing.listingId}?resubmit=true`,
-              )
             }}
             onCopyListing={(listing) => {
               handleCopyListingLink(listing)

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2772,9 +2772,7 @@
           "renewFull": "Renew (+30 days)",
           "copyListing": "Copy listing link",
           "takeDown": "Take down",
-          "delete": "Delete",
-          "resubmit": "Resubmit",
-          "resubmitFull": "Resubmit for Review"
+          "delete": "Delete"
         },
         "deleteConfirm": {
           "title": "Delete Listing",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2772,9 +2772,7 @@
           "renewFull": "Gia hạn (+30 ngày)",
           "copyListing": "Sao chép link bài đăng",
           "takeDown": "Ẩn tin",
-          "delete": "Xóa tin",
-          "resubmit": "Gửi lại",
-          "resubmitFull": "Gửi lại duyệt"
+          "delete": "Xóa tin"
         },
         "deleteConfirm": {
           "title": "Xóa Tin Đăng",


### PR DESCRIPTION
…ings

The listing card rendered two separate buttons doing the exact same "edit & resubmit" navigation: the card action bar's "Gửi lại" button and ModerationBanner's own CTA, both pointed at
/seller/update-post/{id}?resubmit=true. On top of that, the generic "Edit" pencil button in the action bar stayed clickable for rejected listings, contradicting the banner's new "can't edit or resubmit" copy.

- drop the card-level resubmit button/prop chain end to end (listing-card, listings-list, listingsManagementTemplate, listingCardActions) — ModerationBanner already owns this CTA where it's actually valid (REVISION_REQUIRED)
- hide the generic edit button too when the listing is rejected (REJECTED, or SUSPENDED with a pendingOwnerAction from the reject flow)
- drop the now-dead ?resubmit=true query branching in onEditListing — ModerationBanner's visibility no longer depends on that param
- remove the resubmit i18n keys that became unused