### PR TITLE
feat: split the seller listing filter's SUSPENDED sub-tab into reject…

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -588,6 +588,13 @@ export interface ListingFilterRequest {
 
   listingStatus?: PostStatus
   moderationStatus?: ModerationStatus
+  /**
+   * Only meaningful alongside moderationStatus=SUSPENDED, which is shared by
+   * rejecting a listing in the review queue (creates a pending owner action)
+   * and temporarily hiding it under report review (doesn't). true narrows to
+   * the reject case, false narrows to the hide case.
+   */
+  hasPendingOwnerAction?: boolean
 }
 
 /**

--- a/src/components/molecules/listings/ListingStatusFilterResponsive.tsx
+++ b/src/components/molecules/listings/ListingStatusFilterResponsive.tsx
@@ -18,7 +18,6 @@ import {
   isModerationFilterStatus,
   hasSubFilters,
   getModerationStatuses,
-  toModerationFilterStatus,
   type ListingFilterStatus,
 } from '@/constants/postStatus'
 import type { PostStatus } from '@/api/types'
@@ -41,18 +40,14 @@ export const ListingStatusFilterResponsive: React.FC<
 
   // Determine which main tab is active — map MOD_ values back to their parent status
   const activeMainStatus: PostStatus = isModerationFilterStatus(value)
-    ? ((Object.entries(LISTING_STATUS_MODERATION_MAP).find(([, mods]) =>
-        (mods as string[]).some(
-          (m: string) => toModerationFilterStatus(m as any) === value,
-        ),
+    ? ((Object.entries(LISTING_STATUS_MODERATION_MAP).find(([, subFilters]) =>
+        (subFilters as ListingFilterStatus[]).includes(value),
       )?.[0] as PostStatus) ?? (value as PostStatus))
     : (value as PostStatus)
 
   // Check if the active main tab has sub-filters
   const activeHasSubFilters = hasSubFilters(activeMainStatus)
-  const activeSubFilters = getModerationStatuses(activeMainStatus).map(
-    toModerationFilterStatus,
-  )
+  const activeSubFilters = getModerationStatuses(activeMainStatus)
 
   // For mobile dropdown label
   const activeLabel =

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -43,9 +43,8 @@ import {
 } from '@/api/types'
 import {
   isModerationFilterStatus,
-  extractModerationStatus,
-  toModerationFilterStatus,
   getModerationStatuses,
+  resolveModerationFilterParams,
   LISTING_STATUS_MODERATION_MAP,
   type ListingFilterStatus,
 } from '@/constants/postStatus'
@@ -570,40 +569,41 @@ export const ListingsManagementTemplate: React.FC<
         updateFilters({
           listingStatus: undefined,
           moderationStatus: undefined,
+          hasPendingOwnerAction: undefined,
           page: 1,
         })
       } else if (isModerationFilterStatus(newStatus)) {
         // Moderation sub-filter clicked
         setStatus(newStatus)
-        const modStatus = extractModerationStatus(newStatus)
         const parentStatus = Object.entries(LISTING_STATUS_MODERATION_MAP).find(
-          ([, mods]) => (mods as string[]).includes(modStatus ?? ''),
+          ([, subFilters]) =>
+            (subFilters as ListingFilterStatus[]).includes(newStatus),
         )?.[0] as PostStatus | undefined
 
         updateFilters({
           listingStatus: parentStatus ?? (newStatus as PostStatus),
-          moderationStatus: modStatus ?? undefined,
+          ...resolveModerationFilterParams(newStatus),
           page: 1,
         })
       } else {
         const listingStatus = newStatus as PostStatus
-        const moderationStatuses = getModerationStatuses(listingStatus)
+        const subFilters = getModerationStatuses(listingStatus)
 
-        if (moderationStatuses.length > 1) {
+        if (subFilters.length > 1) {
           // Has sub-filters → default to first
-          const defaultMod = moderationStatuses[0]
-          setStatus(toModerationFilterStatus(defaultMod))
+          const defaultSub = subFilters[0]
+          setStatus(defaultSub)
           updateFilters({
             listingStatus,
-            moderationStatus: defaultMod,
+            ...resolveModerationFilterParams(defaultSub),
             page: 1,
           })
-        } else if (moderationStatuses.length === 1) {
-          // Single moderation status → pass directly
+        } else if (subFilters.length === 1) {
+          // Single sub-filter → pass directly, tab stays at the parent level
           setStatus(newStatus)
           updateFilters({
             listingStatus,
-            moderationStatus: moderationStatuses[0],
+            ...resolveModerationFilterParams(subFilters[0]),
             page: 1,
           })
         } else {
@@ -612,6 +612,7 @@ export const ListingsManagementTemplate: React.FC<
           updateFilters({
             listingStatus,
             moderationStatus: undefined,
+            hasPendingOwnerAction: undefined,
             page: 1,
           })
         }

--- a/src/constants/postStatus.ts
+++ b/src/constants/postStatus.ts
@@ -44,50 +44,20 @@ export const POST_STATUS_OPTIONS: PostStatusOption[] =
     key: getPostStatusI18nKey(s),
   }))
 
-// ── Listing Status → Moderation Status Mapping ──
-// Based on the business rules:
-//   EXPIRED         → N/A
-//   EXPIRING_SOON   → APPROVED
-//   DISPLAYING      → APPROVED
-//   IN_REVIEW       → PENDING_REVIEW | RESUBMITTED
-//   PENDING_PAYMENT → N/A
-//   REJECTED        → REVISION_REQUIRED | SUSPENDED
-//   VERIFIED        → APPROVED
-//
-// When a listing status maps to exactly 1 moderation status → pass it directly.
-// When it maps to >1 → show sub-filter tabs, default to the first entry.
-export const LISTING_STATUS_MODERATION_MAP: Partial<
-  Record<PostStatus, ModerationStatus[]>
-> = {
-  [POST_STATUS.EXPIRING_SOON]: [ModerationStatus.APPROVED],
-  [POST_STATUS.DISPLAYING]: [ModerationStatus.APPROVED],
-  [POST_STATUS.IN_REVIEW]: [
-    ModerationStatus.PENDING_REVIEW,
-    ModerationStatus.RESUBMITTED,
-  ],
-  [POST_STATUS.REJECTED]: [
-    ModerationStatus.REVISION_REQUIRED,
-    ModerationStatus.SUSPENDED,
-  ],
-  [POST_STATUS.VERIFIED]: [ModerationStatus.APPROVED],
-}
-
-// Get the moderation statuses associated with a listing status (empty if N/A)
-export const getModerationStatuses = (
-  status: PostStatus,
-): ModerationStatus[] => {
-  return LISTING_STATUS_MODERATION_MAP[status] ?? []
-}
-
-// Check if a listing status has sub-filter tabs (>1 moderation status)
-export const hasSubFilters = (status: PostStatus): boolean => {
-  return (LISTING_STATUS_MODERATION_MAP[status]?.length ?? 0) > 1
-}
-
 // ── Unified Listing Filter Status ──
 // Combines PostStatus and ModerationStatus for the seller's listing filter tabs.
 // Prefixed moderation values avoid collision with PostStatus values (e.g. both have REJECTED).
-export type ListingFilterStatus = PostStatus | `MOD_${ModerationStatus}`
+//
+// 'SUSPENDED_REJECTED' / 'SUSPENDED_HIDDEN' are UI-only synthetic values, not real
+// ModerationStatus members — moderationStatus=SUSPENDED is shared by rejecting a
+// listing in the review queue (creates a pendingOwnerAction) and temporarily hiding
+// it under report review (doesn't), so it needs two distinct tabs. See
+// resolveModerationFilterParams for how a tab resolves to actual API filter params.
+export type ModerationFilterExtra = 'SUSPENDED_REJECTED' | 'SUSPENDED_HIDDEN'
+export type ListingFilterStatus =
+  | PostStatus
+  | `MOD_${ModerationStatus}`
+  | `MOD_${ModerationFilterExtra}`
 
 // Helper to create prefixed moderation filter value
 export const toModerationFilterStatus = (
@@ -102,6 +72,8 @@ export const MODERATION_FILTER_I18N_KEY: Record<string, string> = {
   [`MOD_${ModerationStatus.SUSPENDED}`]: 'MOD_SUSPENDED',
   [`MOD_${ModerationStatus.APPROVED}`]: 'MOD_APPROVED',
   [`MOD_${ModerationStatus.REJECTED}`]: 'MOD_REJECTED',
+  MOD_SUSPENDED_REJECTED: 'MOD_SUSPENDED_REJECTED',
+  MOD_SUSPENDED_HIDDEN: 'MOD_SUSPENDED_HIDDEN',
 }
 
 // Resolve i18n key for any ListingFilterStatus value
@@ -119,12 +91,93 @@ export const isModerationFilterStatus = (
   return typeof status === 'string' && status.startsWith('MOD_')
 }
 
-// Extract the raw ModerationStatus from a prefixed filter value
+// Extract the raw ModerationStatus a filter value represents. Both
+// MOD_SUSPENDED_REJECTED and MOD_SUSPENDED_HIDDEN resolve to SUSPENDED here —
+// use resolveModerationFilterParams if hasPendingOwnerAction is also needed.
 export const extractModerationStatus = (
   status: ListingFilterStatus,
 ): ModerationStatus | null => {
+  if (
+    status === 'MOD_SUSPENDED_REJECTED' ||
+    status === 'MOD_SUSPENDED_HIDDEN'
+  ) {
+    return ModerationStatus.SUSPENDED
+  }
   if (typeof status === 'string' && status.startsWith('MOD_')) {
     return status.replace('MOD_', '') as ModerationStatus
   }
   return null
+}
+
+// ── Listing Status → Moderation Sub-Filter Mapping ──
+// Based on the business rules:
+//   EXPIRED         → N/A
+//   EXPIRING_SOON   → APPROVED
+//   DISPLAYING      → APPROVED
+//   IN_REVIEW       → PENDING_REVIEW | RESUBMITTED
+//   PENDING_PAYMENT → N/A
+//   REJECTED        → REVISION_REQUIRED | SUSPENDED_REJECTED | SUSPENDED_HIDDEN
+//   VERIFIED        → APPROVED
+//
+// Values are the tab identities shown in the UI (see ListingStatusFilterResponsive),
+// not necessarily raw ModerationStatus values — resolve them to actual API filter
+// params with resolveModerationFilterParams. When a listing status maps to exactly
+// 1 sub-filter → pass it directly. When it maps to >1 → show sub-filter tabs,
+// default to the first entry.
+export const LISTING_STATUS_MODERATION_MAP: Partial<
+  Record<PostStatus, ListingFilterStatus[]>
+> = {
+  [POST_STATUS.EXPIRING_SOON]: [
+    toModerationFilterStatus(ModerationStatus.APPROVED),
+  ],
+  [POST_STATUS.DISPLAYING]: [
+    toModerationFilterStatus(ModerationStatus.APPROVED),
+  ],
+  [POST_STATUS.IN_REVIEW]: [
+    toModerationFilterStatus(ModerationStatus.PENDING_REVIEW),
+    toModerationFilterStatus(ModerationStatus.RESUBMITTED),
+  ],
+  [POST_STATUS.REJECTED]: [
+    toModerationFilterStatus(ModerationStatus.REVISION_REQUIRED),
+    'MOD_SUSPENDED_REJECTED',
+    'MOD_SUSPENDED_HIDDEN',
+  ],
+  [POST_STATUS.VERIFIED]: [toModerationFilterStatus(ModerationStatus.APPROVED)],
+}
+
+// Get the sub-filter tabs associated with a listing status (empty if N/A)
+export const getModerationStatuses = (
+  status: PostStatus,
+): ListingFilterStatus[] => {
+  return LISTING_STATUS_MODERATION_MAP[status] ?? []
+}
+
+// Check if a listing status has sub-filter tabs (>1 entry)
+export const hasSubFilters = (status: PostStatus): boolean => {
+  return (LISTING_STATUS_MODERATION_MAP[status]?.length ?? 0) > 1
+}
+
+// Resolve a sub-filter tab identity to the actual API filter params it stands
+// for. Always returns both keys (even as undefined) so callers can spread the
+// result straight into updateFilters without leaking a stale value from a
+// previously selected tab.
+export const resolveModerationFilterParams = (
+  status: ListingFilterStatus,
+): { moderationStatus?: ModerationStatus; hasPendingOwnerAction?: boolean } => {
+  if (status === 'MOD_SUSPENDED_REJECTED') {
+    return {
+      moderationStatus: ModerationStatus.SUSPENDED,
+      hasPendingOwnerAction: true,
+    }
+  }
+  if (status === 'MOD_SUSPENDED_HIDDEN') {
+    return {
+      moderationStatus: ModerationStatus.SUSPENDED,
+      hasPendingOwnerAction: false,
+    }
+  }
+  return {
+    moderationStatus: extractModerationStatus(status) ?? undefined,
+    hasPendingOwnerAction: undefined,
+  }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2671,7 +2671,9 @@
         "MOD_RESUBMITTED": "Resubmitted",
         "MOD_REJECTED": "Rejected by Admin",
         "MOD_REVISION_REQUIRED": "Revision Required",
-        "MOD_SUSPENDED": "Suspended"
+        "MOD_SUSPENDED": "Suspended",
+        "MOD_SUSPENDED_REJECTED": "Rejected",
+        "MOD_SUSPENDED_HIDDEN": "Temporarily Hidden"
       },
       "propertyTypes": {
         "0": "All Types",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2671,7 +2671,9 @@
         "MOD_RESUBMITTED": "Đã gửi lại",
         "MOD_REJECTED": "Admin từ chối",
         "MOD_REVISION_REQUIRED": "Cần chỉnh sửa",
-        "MOD_SUSPENDED": "Bị đình chỉ"
+        "MOD_SUSPENDED": "Bị đình chỉ",
+        "MOD_SUSPENDED_REJECTED": "Bị từ chối",
+        "MOD_SUSPENDED_HIDDEN": "Đang ẩn tạm thời"
       },
       "propertyTypes": {
         "0": "Tất cả Loại",


### PR DESCRIPTION
…ed/hidden

The seller's "Bị từ chối" (REJECTED) tab showed a "Bị đình chỉ" sub-tab querying moderationStatus=SUSPENDED, mixing listings rejected in the review queue with listings temporarily hidden via report review — same root ambiguity already fixed in ModerationBanner/ModerationStatusBadge, just not in the filter tabs yet.

- postStatus.ts: LISTING_STATUS_MODERATION_MAP's REJECTED entry now lists two synthetic sub-filter identities (MOD_SUSPENDED_REJECTED / MOD_SUSPENDED_HIDDEN) instead of the single raw SUSPENDED value; resolveModerationFilterParams() turns a tab identity into the actual moderationStatus + hasPendingOwnerAction API params (backend support already shipped in smartrent-backend feat/admin-rejected-vs-hidden-filter, reused as-is here since getMyListings takes the same ListingFilterRequest)
- ListingStatusFilterResponsive / listingsManagementTemplate updated to work with the pre-resolved sub-filter identities instead of raw ModerationStatus values
- new tabs: "Bị từ chối" and "Đang ẩn tạm thời"