### PR TITLE
refactor: drive seller moderation UI off distinct statuses, add remov…

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -89,10 +89,14 @@ export type PostStatus =
 export enum ModerationStatus {
   PENDING_REVIEW = 'PENDING_REVIEW',
   APPROVED = 'APPROVED',
+  // Admin rejected in the review queue — terminal (no edit/resubmit).
   REJECTED = 'REJECTED',
   REVISION_REQUIRED = 'REVISION_REQUIRED',
   RESUBMITTED = 'RESUBMITTED',
+  // Temporarily hidden while a report is under review — owner does nothing.
   SUSPENDED = 'SUSPENDED',
+  // Permanently removed for a confirmed report violation — terminal.
+  REMOVED = 'REMOVED',
 }
 
 // Listing-domain API error codes
@@ -588,13 +592,6 @@ export interface ListingFilterRequest {
 
   listingStatus?: PostStatus
   moderationStatus?: ModerationStatus
-  /**
-   * Only meaningful alongside moderationStatus=SUSPENDED, which is shared by
-   * rejecting a listing in the review queue (creates a pending owner action)
-   * and temporarily hiding it under report review (doesn't). true narrows to
-   * the reject case, false narrows to the hide case.
-   */
-  hasPendingOwnerAction?: boolean
 }
 
 /**

--- a/src/components/molecules/moderation/ModerationBanner.tsx
+++ b/src/components/molecules/moderation/ModerationBanner.tsx
@@ -87,20 +87,15 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
     router.push(`/seller/update-post/${listingId}?resubmit=true`)
   }
 
-  // moderationStatus SUSPENDED is shared by two unrelated admin actions:
-  // rejecting a listing in the review queue (always creates a pendingOwnerAction)
-  // and temporarily hiding a listing under report review (never does). Split on
-  // that signal so the two don't render as the same "tạm ngưng" banner.
-  const isRejectedSuspend =
-    moderationStatus === ModerationStatus.SUSPENDED &&
-    !permanentlyRemoved &&
-    Boolean(pendingOwnerAction)
-  const isHiddenSuspend =
-    moderationStatus === ModerationStatus.SUSPENDED &&
-    !permanentlyRemoved &&
-    !pendingOwnerAction
+  // Each moderation state maps to exactly one banner now — the backend gives
+  // rejected / hidden / removed distinct statuses instead of overloading
+  // SUSPENDED. permanentlyRemoved is a legacy fallback for older rows that
+  // predate the REMOVED status.
+  const isRemoved =
+    moderationStatus === ModerationStatus.REMOVED || Boolean(permanentlyRemoved)
   const isRejected =
-    moderationStatus === ModerationStatus.REJECTED || isRejectedSuspend
+    !isRemoved && moderationStatus === ModerationStatus.REJECTED
+  const isHidden = !isRemoved && moderationStatus === ModerationStatus.SUSPENDED
 
   if (isRejected || moderationStatus === ModerationStatus.REVISION_REQUIRED) {
     const title = isRejected ? t('rejectedTitle') : t('revisionRequiredTitle')
@@ -177,7 +172,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
     )
   }
 
-  if (isHiddenSuspend) {
+  if (isHidden) {
     return (
       <div
         className={cn(
@@ -244,7 +239,7 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
     )
   }
 
-  if (moderationStatus === ModerationStatus.SUSPENDED && permanentlyRemoved) {
+  if (isRemoved) {
     return (
       <div
         className={cn(

--- a/src/components/molecules/moderation/ModerationStatusBadge.tsx
+++ b/src/components/molecules/moderation/ModerationStatusBadge.tsx
@@ -15,11 +15,9 @@ import { cn } from '@/lib/utils'
 
 interface ModerationStatusBadgeProps {
   status: ModerationStatus
+  // Legacy fallback: older rows that predate the REMOVED status still carry
+  // SUSPENDED + permanentlyRemoved=true. Treat those as REMOVED.
   permanentlyRemoved?: boolean
-  // moderationStatus=SUSPENDED is shared by rejecting a listing in the review
-  // queue (always creates a pendingOwnerAction) and temporarily hiding it
-  // during report review (never does) — mirrors ModerationBanner's split.
-  hasPendingOwnerAction?: boolean | null
   className?: string
 }
 
@@ -27,96 +25,64 @@ const BADGE_CONFIG: Record<
   ModerationStatus,
   {
     icon: React.ElementType
-    variant: string
     className: string
   }
 > = {
   [ModerationStatus.PENDING_REVIEW]: {
     icon: Clock,
-    variant: 'outline',
     className:
       'bg-yellow-50 text-yellow-700 border-yellow-300 dark:bg-yellow-950/30 dark:text-yellow-400 dark:border-yellow-800',
   },
   [ModerationStatus.APPROVED]: {
     icon: CheckCircle,
-    variant: 'outline',
     className:
       'bg-green-50 text-green-700 border-green-300 dark:bg-green-950/30 dark:text-green-400 dark:border-green-800',
   },
   [ModerationStatus.REJECTED]: {
     icon: XCircle,
-    variant: 'outline',
     className:
       'bg-red-50 text-red-700 border-red-300 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800',
   },
   [ModerationStatus.REVISION_REQUIRED]: {
     icon: Edit,
-    variant: 'outline',
     className:
       'bg-orange-50 text-orange-700 border-orange-300 dark:bg-orange-950/30 dark:text-orange-400 dark:border-orange-800',
   },
   [ModerationStatus.RESUBMITTED]: {
     icon: RefreshCw,
-    variant: 'outline',
     className:
       'bg-blue-50 text-blue-700 border-blue-300 dark:bg-blue-950/30 dark:text-blue-400 dark:border-blue-800',
   },
+  // SUSPENDED now means "temporarily hidden under report review".
   [ModerationStatus.SUSPENDED]: {
-    icon: Ban,
-    variant: 'outline',
-    className: 'bg-muted text-muted-foreground border-border',
+    icon: EyeOff,
+    className:
+      'bg-blue-50 text-blue-700 border-blue-300 dark:bg-blue-950/30 dark:text-blue-400 dark:border-blue-800',
   },
-}
-
-const PERMANENTLY_REMOVED_CONFIG = {
-  icon: Ban,
-  className:
-    'bg-red-50 text-red-700 border-red-300 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800',
-}
-
-const HIDDEN_CONFIG = {
-  icon: EyeOff,
-  className:
-    'bg-blue-50 text-blue-700 border-blue-300 dark:bg-blue-950/30 dark:text-blue-400 dark:border-blue-800',
+  [ModerationStatus.REMOVED]: {
+    icon: Ban,
+    className:
+      'bg-red-50 text-red-700 border-red-300 dark:bg-red-950/30 dark:text-red-400 dark:border-red-800',
+  },
 }
 
 export const ModerationStatusBadge: React.FC<ModerationStatusBadgeProps> = ({
   status,
   permanentlyRemoved,
-  hasPendingOwnerAction,
   className,
 }) => {
   const t = useTranslations('seller.moderation.status')
-  const isSuspended = status === ModerationStatus.SUSPENDED
-  const isPermanentlyRemoved = isSuspended && permanentlyRemoved
-  const isRejectedSuspend =
-    isSuspended && !permanentlyRemoved && Boolean(hasPendingOwnerAction)
-  const isHiddenSuspend =
-    isSuspended && !permanentlyRemoved && !hasPendingOwnerAction
-
-  const config = isPermanentlyRemoved
-    ? PERMANENTLY_REMOVED_CONFIG
-    : isRejectedSuspend
-      ? BADGE_CONFIG[ModerationStatus.REJECTED]
-      : isHiddenSuspend
-        ? HIDDEN_CONFIG
-        : BADGE_CONFIG[status]
+  const effectiveStatus = permanentlyRemoved ? ModerationStatus.REMOVED : status
+  const config = BADGE_CONFIG[effectiveStatus]
 
   if (!config) return null
 
   const Icon = config.icon
-  const labelKey = isPermanentlyRemoved
-    ? 'SUSPENDED_PERMANENT'
-    : isRejectedSuspend
-      ? 'REJECTED'
-      : isHiddenSuspend
-        ? 'SUSPENDED_HIDDEN'
-        : status
 
   return (
     <Badge variant='outline' className={cn(config.className, className)}>
       <Icon className='w-3.5 h-3.5 mr-1' />
-      {t(labelKey)}
+      {t(effectiveStatus)}
     </Badge>
   )
 }

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -99,18 +99,18 @@ export const ListingCard: React.FC<ListingCardProps> = ({
   // Moderation fields
   const moderationStatus = property.moderationStatus
   const permanentlyRemoved = property.permanentlyRemoved
+  // permanentlyRemoved is a legacy fallback for rows predating the REMOVED status.
   const isPermanentlyRemoved =
-    moderationStatus === ModerationStatus.SUSPENDED && !!permanentlyRemoved
-  // A rejected listing (either the legacy REJECTED status, or SUSPENDED with a
-  // pendingOwnerAction from the review-queue reject flow) can't be edited or
-  // resubmitted — mirrors ModerationBanner's isRejected. SUSPENDED without a
-  // pendingOwnerAction is a report-driven temporary hide, not a rejection, and
-  // editing is still allowed there.
-  const isRejected =
-    moderationStatus === ModerationStatus.REJECTED ||
-    (moderationStatus === ModerationStatus.SUSPENDED &&
-      !permanentlyRemoved &&
-      Boolean(property.pendingOwnerAction))
+    moderationStatus === ModerationStatus.REMOVED || !!permanentlyRemoved
+  // Rejected and removed are terminal — no edit/resubmit. SUSPENDED (temporarily
+  // hidden under report) and REVISION_REQUIRED are not "rejected".
+  const isRejected = moderationStatus === ModerationStatus.REJECTED
+  // The backend blocks generic edits on hidden/rejected/removed listings
+  // (only REVISION_REQUIRED stays editable), so hide the edit CTA for those.
+  const isEditBlocked =
+    isRejected ||
+    isPermanentlyRemoved ||
+    moderationStatus === ModerationStatus.SUSPENDED
 
   const calculatedExpiryDate = React.useMemo(() => {
     if (expiryDate) return toISO(expiryDate)
@@ -204,7 +204,6 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 <ModerationStatusBadge
                   status={moderationStatus}
                   permanentlyRemoved={permanentlyRemoved}
-                  hasPendingOwnerAction={Boolean(property.pendingOwnerAction)}
                 />
               ) : isExpired ? (
                 <Badge className='backdrop-blur-md bg-red-500 text-white border-red-600 shadow-md font-medium hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 dark:border-red-700'>
@@ -583,7 +582,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                 showPromoteButton={showPromoteButton}
                 showRepostButton={showRepostButton}
                 showRenewButton={showRenewButton}
-                showEditButton={!postingBlocked && !isRejected}
+                showEditButton={!postingBlocked && !isEditBlocked}
                 onlyShowDelete={isPermanentlyRemoved}
               />
             </div>

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -44,7 +44,7 @@ import {
 import {
   isModerationFilterStatus,
   getModerationStatuses,
-  resolveModerationFilterParams,
+  extractModerationStatus,
   LISTING_STATUS_MODERATION_MAP,
   type ListingFilterStatus,
 } from '@/constants/postStatus'
@@ -569,7 +569,6 @@ export const ListingsManagementTemplate: React.FC<
         updateFilters({
           listingStatus: undefined,
           moderationStatus: undefined,
-          hasPendingOwnerAction: undefined,
           page: 1,
         })
       } else if (isModerationFilterStatus(newStatus)) {
@@ -582,7 +581,7 @@ export const ListingsManagementTemplate: React.FC<
 
         updateFilters({
           listingStatus: parentStatus ?? (newStatus as PostStatus),
-          ...resolveModerationFilterParams(newStatus),
+          moderationStatus: extractModerationStatus(newStatus) ?? undefined,
           page: 1,
         })
       } else {
@@ -595,7 +594,7 @@ export const ListingsManagementTemplate: React.FC<
           setStatus(defaultSub)
           updateFilters({
             listingStatus,
-            ...resolveModerationFilterParams(defaultSub),
+            moderationStatus: extractModerationStatus(defaultSub) ?? undefined,
             page: 1,
           })
         } else if (subFilters.length === 1) {
@@ -603,7 +602,8 @@ export const ListingsManagementTemplate: React.FC<
           setStatus(newStatus)
           updateFilters({
             listingStatus,
-            ...resolveModerationFilterParams(subFilters[0]),
+            moderationStatus:
+              extractModerationStatus(subFilters[0]) ?? undefined,
             page: 1,
           })
         } else {
@@ -612,7 +612,6 @@ export const ListingsManagementTemplate: React.FC<
           updateFilters({
             listingStatus,
             moderationStatus: undefined,
-            hasPendingOwnerAction: undefined,
             page: 1,
           })
         }

--- a/src/constants/postStatus.ts
+++ b/src/constants/postStatus.ts
@@ -47,17 +47,10 @@ export const POST_STATUS_OPTIONS: PostStatusOption[] =
 // ── Unified Listing Filter Status ──
 // Combines PostStatus and ModerationStatus for the seller's listing filter tabs.
 // Prefixed moderation values avoid collision with PostStatus values (e.g. both have REJECTED).
-//
-// 'SUSPENDED_REJECTED' / 'SUSPENDED_HIDDEN' are UI-only synthetic values, not real
-// ModerationStatus members — moderationStatus=SUSPENDED is shared by rejecting a
-// listing in the review queue (creates a pendingOwnerAction) and temporarily hiding
-// it under report review (doesn't), so it needs two distinct tabs. See
-// resolveModerationFilterParams for how a tab resolves to actual API filter params.
-export type ModerationFilterExtra = 'SUSPENDED_REJECTED' | 'SUSPENDED_HIDDEN'
-export type ListingFilterStatus =
-  | PostStatus
-  | `MOD_${ModerationStatus}`
-  | `MOD_${ModerationFilterExtra}`
+// Every moderation sub-filter now maps to exactly one real ModerationStatus — the
+// backend gives rejected / hidden / removed distinct statuses, so no synthetic
+// filter identities are needed anymore.
+export type ListingFilterStatus = PostStatus | `MOD_${ModerationStatus}`
 
 // Helper to create prefixed moderation filter value
 export const toModerationFilterStatus = (
@@ -72,8 +65,7 @@ export const MODERATION_FILTER_I18N_KEY: Record<string, string> = {
   [`MOD_${ModerationStatus.SUSPENDED}`]: 'MOD_SUSPENDED',
   [`MOD_${ModerationStatus.APPROVED}`]: 'MOD_APPROVED',
   [`MOD_${ModerationStatus.REJECTED}`]: 'MOD_REJECTED',
-  MOD_SUSPENDED_REJECTED: 'MOD_SUSPENDED_REJECTED',
-  MOD_SUSPENDED_HIDDEN: 'MOD_SUSPENDED_HIDDEN',
+  [`MOD_${ModerationStatus.REMOVED}`]: 'MOD_REMOVED',
 }
 
 // Resolve i18n key for any ListingFilterStatus value
@@ -91,18 +83,11 @@ export const isModerationFilterStatus = (
   return typeof status === 'string' && status.startsWith('MOD_')
 }
 
-// Extract the raw ModerationStatus a filter value represents. Both
-// MOD_SUSPENDED_REJECTED and MOD_SUSPENDED_HIDDEN resolve to SUSPENDED here —
-// use resolveModerationFilterParams if hasPendingOwnerAction is also needed.
+// Extract the raw ModerationStatus a filter value represents (null for
+// PostStatus values that carry no moderation status).
 export const extractModerationStatus = (
   status: ListingFilterStatus,
 ): ModerationStatus | null => {
-  if (
-    status === 'MOD_SUSPENDED_REJECTED' ||
-    status === 'MOD_SUSPENDED_HIDDEN'
-  ) {
-    return ModerationStatus.SUSPENDED
-  }
   if (typeof status === 'string' && status.startsWith('MOD_')) {
     return status.replace('MOD_', '') as ModerationStatus
   }
@@ -116,14 +101,12 @@ export const extractModerationStatus = (
 //   DISPLAYING      → APPROVED
 //   IN_REVIEW       → PENDING_REVIEW | RESUBMITTED
 //   PENDING_PAYMENT → N/A
-//   REJECTED        → REVISION_REQUIRED | SUSPENDED_REJECTED | SUSPENDED_HIDDEN
+//   REJECTED        → REVISION_REQUIRED | REJECTED | SUSPENDED (hidden) | REMOVED
 //   VERIFIED        → APPROVED
 //
-// Values are the tab identities shown in the UI (see ListingStatusFilterResponsive),
-// not necessarily raw ModerationStatus values — resolve them to actual API filter
-// params with resolveModerationFilterParams. When a listing status maps to exactly
-// 1 sub-filter → pass it directly. When it maps to >1 → show sub-filter tabs,
-// default to the first entry.
+// Each sub-filter is a real ModerationStatus. When a listing status maps to
+// exactly 1 sub-filter → pass it directly. When it maps to >1 → show sub-filter
+// tabs, default to the first entry.
 export const LISTING_STATUS_MODERATION_MAP: Partial<
   Record<PostStatus, ListingFilterStatus[]>
 > = {
@@ -139,8 +122,9 @@ export const LISTING_STATUS_MODERATION_MAP: Partial<
   ],
   [POST_STATUS.REJECTED]: [
     toModerationFilterStatus(ModerationStatus.REVISION_REQUIRED),
-    'MOD_SUSPENDED_REJECTED',
-    'MOD_SUSPENDED_HIDDEN',
+    toModerationFilterStatus(ModerationStatus.REJECTED),
+    toModerationFilterStatus(ModerationStatus.SUSPENDED),
+    toModerationFilterStatus(ModerationStatus.REMOVED),
   ],
   [POST_STATUS.VERIFIED]: [toModerationFilterStatus(ModerationStatus.APPROVED)],
 }
@@ -155,29 +139,4 @@ export const getModerationStatuses = (
 // Check if a listing status has sub-filter tabs (>1 entry)
 export const hasSubFilters = (status: PostStatus): boolean => {
   return (LISTING_STATUS_MODERATION_MAP[status]?.length ?? 0) > 1
-}
-
-// Resolve a sub-filter tab identity to the actual API filter params it stands
-// for. Always returns both keys (even as undefined) so callers can spread the
-// result straight into updateFilters without leaking a stale value from a
-// previously selected tab.
-export const resolveModerationFilterParams = (
-  status: ListingFilterStatus,
-): { moderationStatus?: ModerationStatus; hasPendingOwnerAction?: boolean } => {
-  if (status === 'MOD_SUSPENDED_REJECTED') {
-    return {
-      moderationStatus: ModerationStatus.SUSPENDED,
-      hasPendingOwnerAction: true,
-    }
-  }
-  if (status === 'MOD_SUSPENDED_HIDDEN') {
-    return {
-      moderationStatus: ModerationStatus.SUSPENDED,
-      hasPendingOwnerAction: false,
-    }
-  }
-  return {
-    moderationStatus: extractModerationStatus(status) ?? undefined,
-    hasPendingOwnerAction: undefined,
-  }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2669,11 +2669,10 @@
         "ARCHIVED": "Archived",
         "MOD_PENDING_REVIEW": "New Submission",
         "MOD_RESUBMITTED": "Resubmitted",
-        "MOD_REJECTED": "Rejected by Admin",
+        "MOD_REJECTED": "Rejected",
         "MOD_REVISION_REQUIRED": "Revision Required",
-        "MOD_SUSPENDED": "Suspended",
-        "MOD_SUSPENDED_REJECTED": "Rejected",
-        "MOD_SUSPENDED_HIDDEN": "Temporarily Hidden"
+        "MOD_SUSPENDED": "Temporarily Hidden",
+        "MOD_REMOVED": "Permanently Removed"
       },
       "propertyTypes": {
         "0": "All Types",
@@ -2919,9 +2918,8 @@
         "REJECTED": "Rejected",
         "REVISION_REQUIRED": "Revision Required",
         "RESUBMITTED": "Resubmitted",
-        "SUSPENDED": "Suspended",
-        "SUSPENDED_HIDDEN": "Temporarily Hidden",
-        "SUSPENDED_PERMANENT": "Permanently Removed"
+        "SUSPENDED": "Temporarily Hidden",
+        "REMOVED": "Permanently Removed"
       },
       "banner": {
         "rejectedTitle": "Listing Rejected",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2669,11 +2669,10 @@
         "ARCHIVED": "Đã lưu trữ",
         "MOD_PENDING_REVIEW": "Chờ duyệt mới",
         "MOD_RESUBMITTED": "Đã gửi lại",
-        "MOD_REJECTED": "Admin từ chối",
+        "MOD_REJECTED": "Đã từ chối",
         "MOD_REVISION_REQUIRED": "Cần chỉnh sửa",
-        "MOD_SUSPENDED": "Bị đình chỉ",
-        "MOD_SUSPENDED_REJECTED": "Bị từ chối",
-        "MOD_SUSPENDED_HIDDEN": "Đang ẩn tạm thời"
+        "MOD_SUSPENDED": "Đang ẩn tạm thời",
+        "MOD_REMOVED": "Đã gỡ vĩnh viễn"
       },
       "propertyTypes": {
         "0": "Tất cả Loại",
@@ -2919,9 +2918,8 @@
         "REJECTED": "Bị từ chối",
         "REVISION_REQUIRED": "Cần chỉnh sửa",
         "RESUBMITTED": "Đã gửi lại",
-        "SUSPENDED": "Bị tạm ngưng",
-        "SUSPENDED_HIDDEN": "Ẩn tạm thời",
-        "SUSPENDED_PERMANENT": "Đã gỡ vĩnh viễn"
+        "SUSPENDED": "Đang ẩn tạm thời",
+        "REMOVED": "Đã gỡ vĩnh viễn"
       },
       "banner": {
         "rejectedTitle": "Bài đăng bị từ chối",


### PR DESCRIPTION
…ed tab

Backend now gives rejected / hidden / removed listings distinct moderationStatus values (REJECTED / SUSPENDED / REMOVED) instead of overloading SUSPENDED + pendingOwnerAction + permanentlyRemoved flags. Consume that directly:

- ModerationStatus enum gains REMOVED; SUSPENDED now means only "temporarily hidden under report review"
- ModerationBanner / ModerationStatusBadge / listing-card switch on the status alone; dropped the pendingOwnerAction/permanentlyRemoved distinguisher logic (permanentlyRemoved kept only as a legacy fallback for rows predating REMOVED)
- edit CTA now hidden for hidden/rejected/removed (backend blocks those updates); only REVISION_REQUIRED stays editable
- postStatus: removed the synthetic SUSPENDED_REJECTED/SUSPENDED_HIDDEN filter identities and resolveModerationFilterParams; the REJECTED tab's sub-filters are now four real statuses — Cần chỉnh sửa / Đã từ chối / Đang ẩn tạm thời / Đã gỡ vĩnh viễn — giving the permanently-removed tab
- dropped the hasPendingOwnerAction filter param (backend removed it)

Public listing detail is unchanged but verified: REMOVED maps to ListingStatus.REJECTED, so getListingById 404s it and the detail page falls back to listingNotFound (plus its own PUBLICLY_VISIBLE_STATUSES gate).