### PR TITLE
fix: stop AI valuation blaming missing GPS for unsupported property t…

### DIFF
--- a/src/components/organisms/createPostSections/aiValuationSection.tsx
+++ b/src/components/organisms/createPostSections/aiValuationSection.tsx
@@ -25,6 +25,7 @@ import { useHousingPredictor } from '@/hooks/useAI'
 import {
   buildHousingPredictorRequest,
   getAveragePrice,
+  isTypeSupportedForAiValuation,
 } from '@/utils/ai/housingPredictor'
 import { formatByLocale } from '@/utils/currency/convert'
 import type { HousingPredictorResponse } from '@/api/types/ai.type'
@@ -156,6 +157,15 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
   }, [propertyInfo.productType, t, tPropertyDetails])
 
   const canPredict = !!predictionRequest
+  // The housing price model only covers residential types (căn hộ / nhà / phòng
+  // trọ / studio). Office & store listings can't be valued, so when prediction is
+  // unavailable we show "not supported for this type" instead of wrongly telling
+  // the user their address/area/GPS is missing.
+  const typeSupportedForAi = isTypeSupportedForAiValuation(
+    typeof propertyInfo.productType === 'string'
+      ? propertyInfo.productType
+      : (propertyInfo.productType as unknown as string),
+  )
 
   return (
     <div className={className}>
@@ -454,8 +464,11 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
             {!canPredict && (
               <p className='text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1'>
                 <AlertCircle className='w-3 h-3' />
-                {t('propertyInfo.incompleteData') ||
-                  'Vui lòng điền đầy đủ thông tin địa chỉ, diện tích và tọa độ GPS'}
+                {typeSupportedForAi
+                  ? t('propertyInfo.incompleteData') ||
+                    'Vui lòng điền đầy đủ thông tin địa chỉ, diện tích và tọa độ GPS'
+                  : t('propertyInfo.unsupportedType') ||
+                    'Định giá AI chỉ khả dụng cho căn hộ, nhà ở, phòng trọ và studio.'}
               </p>
             )}
           </CardContent>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1726,6 +1726,7 @@
           "reevaluate": "Re-evaluate",
           "predicting": "Predicting...",
           "incompleteData": "Please fill in complete address, area and GPS coordinates information",
+          "unsupportedType": "AI valuation is only available for apartments, houses, rooms and studios.",
           "types": {
             "room": "Room",
             "apartment": "Apartment",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1726,6 +1726,7 @@
           "reevaluate": "Đánh giá lại",
           "predicting": "Đang dự đoán...",
           "incompleteData": "Vui lòng điền đầy đủ thông tin địa chỉ, diện tích và tọa độ GPS",
+          "unsupportedType": "Định giá AI chỉ khả dụng cho căn hộ, nhà ở, phòng trọ và studio.",
           "types": {
             "room": "Phòng trọ",
             "apartment": "Căn hộ",

--- a/src/utils/ai/housingPredictor.ts
+++ b/src/utils/ai/housingPredictor.ts
@@ -5,6 +5,12 @@ import type {
 
 import { CreateListingRequest } from '@/api/types'
 
+// The housing price model only covers residential types. Exposed so the UI can
+// tell "this property type isn't supported by AI valuation" apart from "required
+// data is missing" instead of showing one misleading message for both.
+export const isTypeSupportedForAiValuation = (productType?: string): boolean =>
+  normalizePropertyType(productType) !== null
+
 // Normalize product type to API enum
 const normalizePropertyType = (
   productType?: string,


### PR DESCRIPTION
…ypes

The AI housing price model only covers residential types (APARTMENT / HOUSE / ROOM / STUDIO). For an office or store listing, buildHousingPredictorRequest returns null via normalizePropertyType — but the section showed a single message claiming the address, area and GPS were missing, even when all three were filled. Confusing for the user.

- expose isTypeSupportedForAiValuation from housingPredictor
- the section now shows "Định giá AI chỉ khả dụng cho căn hộ, nhà ở, phòng trọ và studio" when the type is unsupported, and only shows the incomplete-data message when a supported type is actually missing data