### PR TITLE
fix: always show an admin-note box on a rejected listing banner

### DIFF
--- a/src/components/molecules/moderation/ModerationBanner.tsx
+++ b/src/components/molecules/moderation/ModerationBanner.tsx
@@ -147,6 +147,18 @@ export const ModerationBanner: React.FC<ModerationBannerProps> = ({
               />
             )}
 
+            {/* Always give a rejected listing an admin-note box, even when the
+                reason text is empty (e.g. older AI auto-rejects that predate
+                reason capture) — otherwise the seller sees "Bị từ chối" with no
+                explanation at all. */}
+            {isRejected && !verificationNotes && !pendingOwnerAction?.notes && (
+              <NoteBox
+                label={t('adminNoteLabel')}
+                text={t('noReasonProvided')}
+                tone='severe'
+              />
+            )}
+
             {isRejected ? (
               <Typography
                 variant='small'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2929,6 +2929,7 @@
         "hiddenTitle": "Listing Temporarily Hidden",
         "hiddenMessage": "An admin has temporarily hidden this listing while a report is under review. It will reappear automatically once resolved — no action needed from you.",
         "cannotEditNote": "You can't edit or resubmit this listing.",
+        "noReasonProvided": "This listing was rejected. The admin didn't provide a specific reason.",
         "permanentlyRemovedTitle": "Listing Permanently Removed",
         "adminNoteLabel": "Note from admin",
         "editAndResubmit": "Edit & Resubmit",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2929,6 +2929,7 @@
         "hiddenTitle": "Bài đăng đang bị ẩn tạm thời",
         "hiddenMessage": "Quản trị viên đã tạm ẩn bài đăng này để xem xét báo cáo. Bài đăng sẽ tự động hiển thị lại sau khi xử lý xong, bạn không cần thao tác gì.",
         "cannotEditNote": "Bạn không thể chỉnh sửa hoặc gửi lại bài đăng này.",
+        "noReasonProvided": "Bài đăng đã bị từ chối. Quản trị viên chưa cung cấp lý do cụ thể.",
         "permanentlyRemovedTitle": "Bài đăng đã bị gỡ vĩnh viễn",
         "adminNoteLabel": "Ghi chú từ quản trị viên",
         "editAndResubmit": "Chỉnh sửa và gửi lại",


### PR DESCRIPTION
A rejected listing's reason comes from verificationNotes (lastModerationReasonText). Manual admin rejects always set it, but older AI auto-rejects predate reason capture and leave it null, so the seller saw "Bị từ chối" with no explanation. Add a fallback note ("Bài đăng đã bị từ chối. Quản trị viên chưa cung cấp lý do cụ thể.") when a rejected listing has neither verificationNotes nor a pendingOwnerAction note, so the banner always communicates a reason.