### PR TITLE
fix: unify report form phone validation with account edit form

### DIFF
--- a/src/components/molecules/reportListingDialog/index.tsx
+++ b/src/components/molecules/reportListingDialog/index.tsx
@@ -78,9 +78,9 @@ export const ReportListingDialog: React.FC<ReportListingDialogProps> = ({
         const fullName = `${user.firstName || ''} ${user.lastName || ''}`.trim()
         setValue('reporterName', fullName)
       }
-      if (user.phoneNumber) {
-        const fullPhone = `${user.phoneCode || ''}${user.phoneNumber}`.trim()
-        setValue('reporterPhone', fullPhone)
+      const contactPhone = user.contactPhoneNumber || user.phoneNumber
+      if (contactPhone) {
+        setValue('reporterPhone', contactPhone.trim())
       }
     }
   }, [isAuthenticated, user, open, setValue])

--- a/src/components/molecules/reportListingDialog/index.tsx
+++ b/src/components/molecules/reportListingDialog/index.tsx
@@ -21,6 +21,7 @@ import { ReportCategory, ReportReason, REPORT_ERROR_CODES } from '@/api/types'
 import { toast } from 'sonner'
 import { useReportReasons, useCreateReport } from '@/hooks/useReport'
 import { useAuthContext } from '@/contexts/auth'
+import { VIETNAM_PHONE_REGEX } from '@/constants/regex'
 
 interface ReportFormData {
   reasonIds: number[]
@@ -103,8 +104,7 @@ export const ReportListingDialog: React.FC<ReportListingDialogProps> = ({
     if (!value || !value.trim()) {
       return t('report.phoneRequired')
     }
-    const phoneRegex = /^0\d{9,10}$/
-    return phoneRegex.test(value.trim()) || t('report.invalidPhone')
+    return VIETNAM_PHONE_REGEX.test(value.trim()) || t('report.invalidPhone')
   }
 
   const validateEmail = (value?: string) => {


### PR DESCRIPTION
The report-listing dialog validated phone with its own inline regex (0-prefix only), while the personal info edit form used the shared VIETNAM_PHONE_REGEX (also accepts 84-prefix). This mismatch rejected phone numbers that were valid on account settings, including the auto-filled phoneCode+phoneNumber value from the logged-in user.