### PR TITLE
fix: use standard 2xl width for upgrade preview modal

### DIFF
--- a/src/components/molecules/upgradePreviewModal/index.tsx
+++ b/src/components/molecules/upgradePreviewModal/index.tsx
@@ -90,7 +90,7 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
           'flex flex-col p-0',
           isMobile
             ? 'w-full h-screen max-w-full rounded-none m-0'
-            : 'sm:max-w-[640px] max-h-[90vh]',
+            : 'sm:max-w-2xl max-h-[90vh]',
         )}
         showCloseButton={!isLoading}
         onInteractOutside={(e) => {


### PR DESCRIPTION
UpgradePreviewModal used an arbitrary sm:max-w-[640px], a one-off value not matching any dialog width used elsewhere in the app (closest siblings like renewMembershipDialog use max-w-lg, and the comparable "compare" style dialog aiChatCompareDialog uses max-w-2xl). Given this modal shows a two-column plan comparison plus a pricing breakdown and benefit lists, sm:max-w-2xl (672px) gives that content more breathing room and aligns the width with the design system's standard scale instead of a magic pixel value.