### PR TITLE
fix: widen upgrade preview modal further, neutralize renewal tab card…

### DIFF
--- a/src/components/molecules/upgradePreviewModal/index.tsx
+++ b/src/components/molecules/upgradePreviewModal/index.tsx
@@ -90,7 +90,7 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
           'flex flex-col p-0',
           isMobile
             ? 'w-full h-screen max-w-full rounded-none m-0'
-            : 'sm:max-w-2xl max-h-[90vh]',
+            : 'sm:max-w-3xl max-h-[90vh]',
         )}
         showCloseButton={!isLoading}
         onInteractOutside={(e) => {

--- a/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipRegisterTemplate.tsx
@@ -80,6 +80,15 @@ const URGENCY_CARD_CLASSES = {
   critical: 'border-red-400 bg-red-50 dark:bg-red-950/20 dark:border-red-600',
 }
 
+// Membership card keeps the neutral theme surface (bg-card) — only the
+// border signals urgency, so the renewal tab doesn't read as a colored banner.
+const URGENCY_BORDER_CLASSES = {
+  none: '',
+  warning: 'border-yellow-400 dark:border-yellow-600',
+  danger: 'border-orange-400 dark:border-orange-600',
+  critical: 'border-red-400 dark:border-red-600',
+}
+
 const URGENCY_BADGE_CLASSES = {
   none: '',
   warning:
@@ -143,7 +152,9 @@ const RenewalTabContent: React.FC<RenewalTabContentProps> = ({
       <Card
         className={cn(
           'relative overflow-hidden border',
-          urgency !== 'none' ? URGENCY_CARD_CLASSES[urgency] : 'border-border',
+          urgency !== 'none'
+            ? URGENCY_BORDER_CLASSES[urgency]
+            : 'border-border',
         )}
       >
         <div className='absolute inset-x-0 top-0 h-px bg-primary/40' />


### PR DESCRIPTION
… background

- Bump UpgradePreviewModal desktop width from sm:max-w-2xl to sm:max-w-3xl (768px) — 2xl still read as cramped for the plan comparison + pricing breakdown content.
- Renewal tab's membership Card no longer fills with yellow/orange/red background on urgency; it keeps the theme's neutral bg-card surface (white in light mode, dark surface in dark mode) and only tints the border to signal urgency. The urgency banner and badge above still carry the color cue, so the information isn't lost — just not painted across the whole card.