### PR TITLE
fix: dialog was never actually widening despite repeated max-w bumps

### DIFF
--- a/src/components/molecules/upgradePreviewModal/index.tsx
+++ b/src/components/molecules/upgradePreviewModal/index.tsx
@@ -50,7 +50,7 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
     return (
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
         <DialogContent
-          className='sm:max-w-[500px]'
+          className='w-full sm:max-w-[500px]'
           showCloseButton={!isLoading}
         >
           <DialogHeader>
@@ -87,9 +87,9 @@ export const UpgradePreviewModal: React.FC<UpgradePreviewModalProps> = ({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <DialogContent
         className={cn(
-          'flex flex-col p-0',
+          'flex flex-col p-0 w-full',
           isMobile
-            ? 'w-full h-screen max-w-full rounded-none m-0'
+            ? 'h-screen max-w-full rounded-none m-0'
             : 'sm:max-w-3xl max-h-[90vh]',
         )}
         showCloseButton={!isLoading}


### PR DESCRIPTION
Root cause of the "upgrade preview dialog still looks small" reports (this same symptom was already patched three times: 600px, 640px, 2xl, 3xl): the shared DialogContent primitive defaults to `w-fit` (src/components/atoms/dialog.tsx), so it only ever grows to hug its content — a `max-w-*` class alone is just an unreachable upper bound, never a target width. Every previous width bump was invisible because nothing forced the box past its content's natural size.

Add `w-full` alongside `sm:max-w-*` on both DialogContent instances in this file (matching the pattern already used elsewhere, e.g. reportListingDialog's `sm:w-full sm:max-w-2xl`), so the modal now actually stretches out to its max-width instead of shrink-wrapping.