### PR TITLE
Remove university address from footer contact info

### DIFF
--- a/src/components/organisms/footer/index.tsx
+++ b/src/components/organisms/footer/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
-import { Mail, Phone, MapPin, GraduationCap } from 'lucide-react'
+import { Mail, Phone, GraduationCap } from 'lucide-react'
 
 import Logo from '@/components/atoms/logo'
 import { Button } from '@/components/atoms/button'
@@ -127,12 +127,6 @@ const Footer: React.FC = () => {
               {t('contactInfo')}
             </p>
             <div className='space-y-3'>
-              <div className='flex items-start gap-2.5'>
-                <MapPin className='w-4 h-4 mt-0.5 flex-shrink-0 text-muted-foreground' />
-                <span className='text-sm text-muted-foreground leading-snug'>
-                  {t('address')}
-                </span>
-              </div>
               <div className='flex items-center gap-2.5'>
                 <Phone className='w-4 h-4 flex-shrink-0 text-muted-foreground' />
                 <a

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2121,7 +2121,6 @@
     "paymentGuide": "Payment guide",
     "usageGuide": "Usage guide",
     "contactInfo": "Contact",
-    "address": "University of Science, Ho Chi Minh City",
     "phone": "+84 123 456 789",
     "email": "smartrent.tools@gmail.com",
     "copyright": "© 2026 SmartRent. All rights reserved.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1895,7 +1895,6 @@
     "paymentGuide": "Hướng dẫn thanh toán",
     "usageGuide": "Hướng dẫn sử dụng",
     "contactInfo": "Liên hệ",
-    "address": "ĐH Khoa học Tự nhiên, TP. Hồ Chí Minh",
     "phone": "+84 123 456 789",
     "email": "smartrent.tools@gmail.com",
     "copyright": "© 2026 Thuê Nhà Trọ. Tất cả quyền được bảo lưu.",


### PR DESCRIPTION
The footer's contact section displayed the university address instead of an actual business contact, so drop that row and its unused translation keys and icon import.