### PR TITLE
fix: remove hover effects on chips and buttons in listing cards

### DIFF
--- a/src/components/molecules/CardListingAIDetail/index.tsx
+++ b/src/components/molecules/CardListingAIDetail/index.tsx
@@ -200,7 +200,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
               type='button'
               onClick={handlePrevImage}
               aria-label={t('prevImage')}
-              className='absolute left-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100 hover:bg-background'
+              className='absolute left-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100'
             >
               <ChevronLeft className='w-4 h-4' aria-hidden='true' />
             </button>
@@ -208,7 +208,7 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
               type='button'
               onClick={handleNextImage}
               aria-label={t('nextImage')}
-              className='absolute right-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100 hover:bg-background'
+              className='absolute right-1.5 top-1/2 -translate-y-1/2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 max-md:opacity-100'
             >
               <ChevronRight className='w-4 h-4' aria-hidden='true' />
             </button>

--- a/src/components/molecules/CardListingAIMini/index.tsx
+++ b/src/components/molecules/CardListingAIMini/index.tsx
@@ -135,7 +135,7 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
               <button
                 onClick={handleSaveClick}
                 disabled={isSaveLoading}
-                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm hover:bg-background transition-all duration-200 hover:scale-110 active:scale-95 disabled:opacity-50 h-7 w-7'
+                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 disabled:opacity-50 h-7 w-7'
                 aria-label={
                   isSaved ? tSaved('actions.saved') : tSaved('actions.save')
                 }
@@ -145,14 +145,14 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
                     'w-4 h-4 transition-all duration-200',
                     isSaved
                       ? 'fill-red-500 stroke-red-500'
-                      : 'fill-none stroke-muted-foreground hover:stroke-red-500',
+                      : 'fill-none stroke-muted-foreground',
                     isSaveLoading && 'animate-pulse',
                   )}
                 />
               </button>
               <button
                 onClick={handleCompareClick}
-                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm hover:bg-background transition-all duration-200 hover:scale-110 active:scale-95 h-7 w-7'
+                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 h-7 w-7'
                 aria-label={
                   isInCompareList
                     ? tCompare('actions.removeFromCompare')
@@ -164,7 +164,7 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
                     'w-4 h-4 transition-all duration-200',
                     isInCompareList
                       ? 'rotate-45 stroke-primary'
-                      : 'stroke-muted-foreground hover:stroke-primary',
+                      : 'stroke-muted-foreground',
                   )}
                 />
               </button>

--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -120,12 +120,12 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
               listing={listing}
               variant='ghost'
               size='icon'
-              className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+              className='bg-card/80 backdrop-blur-md shadow-sm rounded-full transition-all duration-200'
             />
             <SaveListingButton
               listingId={listing.listingId}
               variant='icon'
-              className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+              className='bg-card/80 backdrop-blur-md shadow-sm rounded-full transition-all duration-200'
             />
           </div>
 

--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -57,7 +57,7 @@ const StatPill: React.FC<{
 }> = ({ icon, value, label }) => (
   <Tooltip>
     <TooltipTrigger asChild>
-      <div className='flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-muted/60 hover:bg-muted transition-colors duration-200'>
+      <div className='flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-muted/60'>
         <span className='text-primary'>{icon}</span>
         <Typography variant='small' className='font-semibold text-foreground'>
           {value}
@@ -237,7 +237,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                 <button
                   type='button'
                   onClick={handlePrevImage}
-                  className='absolute left-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-card/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 hover:bg-card shadow-sm z-10'
+                  className='absolute left-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-card/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 shadow-sm z-10'
                   aria-label='Previous image'
                 >
                   <ChevronLeft className='w-4 h-4 text-foreground' />
@@ -245,7 +245,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                 <button
                   type='button'
                   onClick={handleNextImage}
-                  className='absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-card/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 hover:bg-card shadow-sm z-10'
+                  className='absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-card/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 shadow-sm z-10'
                   aria-label='Next image'
                 >
                   <ChevronRight className='w-4 h-4 text-foreground' />
@@ -283,12 +283,12 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                 listing={listing}
                 variant='ghost'
                 size='icon'
-                className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+                className='bg-card/80 backdrop-blur-md shadow-sm rounded-full transition-all duration-200'
               />
               <SaveListingButton
                 listingId={listing.listingId}
                 variant='icon'
-                className='bg-card/80 backdrop-blur-md hover:bg-card shadow-sm rounded-full transition-all duration-200'
+                className='bg-card/80 backdrop-blur-md shadow-sm rounded-full transition-all duration-200'
               />
             </div>
 
@@ -336,7 +336,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                     {
                       'bg-primary ring-1 ring-primary/25 shadow-sm':
                         currentImageIndex === idx,
-                      'bg-transparent ring-1 ring-border/50 hover:ring-primary/40 opacity-80 hover:opacity-100':
+                      'bg-transparent ring-1 ring-border/50 opacity-80':
                         currentImageIndex !== idx,
                     },
                   )}
@@ -359,7 +359,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
                     e.stopPropagation()
                     setCurrentImageIndex(visibleThumbnails.length)
                   }}
-                  className='relative size-[68px] md:size-[76px] aspect-square shrink-0 overflow-hidden rounded-xl ring-1 ring-border/60 bg-muted/80 flex items-center justify-center cursor-pointer hover:bg-muted transition-colors'
+                  className='relative size-[68px] md:size-[76px] aspect-square shrink-0 overflow-hidden rounded-xl ring-1 ring-border/60 bg-muted/80 flex items-center justify-center cursor-pointer'
                 >
                   <div className='text-center'>
                     <Typography
@@ -412,7 +412,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
             variant='ghost'
             size='icon'
             className={classNames(
-              'bg-card/80 backdrop-blur-md rounded-full shadow-sm hover:bg-card transition-all',
+              'bg-card/80 backdrop-blur-md rounded-full shadow-sm transition-all',
               isCompact ? 'w-6 h-6' : 'w-8 h-8 sm:w-9 sm:h-9',
             )}
           />
@@ -420,7 +420,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
             listingId={listing.listingId}
             variant='icon'
             className={classNames(
-              'bg-card/80 backdrop-blur-md rounded-full shadow-sm hover:bg-card transition-all',
+              'bg-card/80 backdrop-blur-md rounded-full shadow-sm transition-all',
               isCompact
                 ? 'w-6 h-6'
                 : 'w-8 h-8 sm:top-3 sm:right-3 sm:w-9 sm:h-9',
@@ -669,7 +669,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               {furnishing && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50 hover:bg-muted transition-colors'>
+                    <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50'>
                       <Sofa className='w-3 h-3 sm:w-4 sm:h-4 text-primary flex-shrink-0' />
                       <Typography variant='small' className='font-medium'>
                         {tCreatePost(getFurnishingTranslationKey(furnishing))}
@@ -687,7 +687,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               {direction && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50 hover:bg-muted transition-colors'>
+                    <div className='flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/50'>
                       <Compass className='w-3 h-3 sm:w-4 sm:h-4 text-primary flex-shrink-0' />
                       <Typography variant='small' className='font-medium'>
                         {tCreatePost(getDirectionTranslationKey(direction))}

--- a/src/components/molecules/saveListingButton/index.tsx
+++ b/src/components/molecules/saveListingButton/index.tsx
@@ -66,9 +66,7 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
       <Heart
         className={cn(
           'transition-all duration-200',
-          isSaved
-            ? 'fill-red-500 stroke-red-500'
-            : 'fill-none stroke-current hover:stroke-red-500',
+          isSaved ? 'fill-red-500 stroke-red-500' : 'fill-none stroke-current',
           isLoading && 'animate-pulse',
           iconClassName,
         )}
@@ -93,7 +91,7 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
               disabled={disabled || isLoading || !listingId}
               className={cn(
                 'inline-flex items-center justify-center',
-                'hover:scale-110 active:scale-95',
+                'active:scale-95',
                 'transition-transform duration-200',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 className,
@@ -124,7 +122,7 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
               onClick={handleClick}
               disabled={disabled || isLoading || !listingId}
               className={cn(
-                'hover:bg-background/80 hover:scale-110 active:scale-95',
+                'active:scale-95',
                 'transition-all duration-200',
                 'rounded-full',
                 className,


### PR DESCRIPTION
Hover states on small chips (stat pills, furnishing/direction tags, thumbnail selectors) and action buttons (save, compare, image nav) inside listing cards are no longer needed.