### PR TITLE
fix(seller/drafts): translate property type badge on draft cards

### DIFF
--- a/src/components/molecules/draftCard/index.tsx
+++ b/src/components/molecules/draftCard/index.tsx
@@ -29,6 +29,7 @@ import { cn } from '@/lib/utils'
 import type { Draft } from '@/types/draft.types'
 import { DEFAULT_IMAGE } from '@/constants/common'
 import { Progress } from '@/components/atoms/progress'
+import { getProductTypeTranslationKey } from '@/utils/property'
 
 interface DraftCardProps {
   draft: Draft
@@ -44,12 +45,15 @@ export const DraftCard: React.FC<DraftCardProps> = ({
   className,
 }) => {
   const t = useTranslations('seller.drafts.card')
+  const tRoot = useTranslations()
 
   const draftTitle =
     draft.title?.trim() || t('defaultTitle', { id: String(draft.id) })
   const draftDescription = draft.description?.trim() || t('defaultDescription')
   const address = draft.address?.trim() || t('defaultAddress')
-  const propertyType = draft.propertyType?.trim() || t('defaultPropertyType')
+  const propertyType = draft.propertyType
+    ? tRoot(getProductTypeTranslationKey(draft.propertyType))
+    : t('defaultPropertyType')
 
   const hasImage = draft.images && draft.images.length > 0
   const imageUrl = hasImage ? draft.images![0] : DEFAULT_IMAGE

--- a/src/types/draft.types.ts
+++ b/src/types/draft.types.ts
@@ -1,3 +1,5 @@
+import type { PropertyType } from '@/api/types/property.type'
+
 /**
  * Draft types for listing drafts
  */
@@ -7,7 +9,7 @@ export interface Draft {
   title?: string
   description?: string
   address?: string
-  propertyType?: string
+  propertyType?: PropertyType
   price?: number
   area?: number
   bedrooms?: number

--- a/src/utils/property/mapDraftResponse.ts
+++ b/src/utils/property/mapDraftResponse.ts
@@ -2,7 +2,11 @@ import type {
   DraftListingResponse,
   DraftAddressResponse,
 } from '@/api/types/draft.type'
-import type { Amenity, MediaItem } from '@/api/types/property.type'
+import type {
+  Amenity,
+  MediaItem,
+  PropertyType,
+} from '@/api/types/property.type'
 
 /**
  * Frontend draft detail type (UI-friendly)
@@ -17,7 +21,7 @@ export interface DraftDetail {
   category: {
     id: number
   }
-  productType: string
+  productType: PropertyType
   price: number
   priceUnit: string
   address: {


### PR DESCRIPTION
The draft card badge rendered draft.productType (e.g. APARTMENT, ROOM) verbatim instead of running it through the existing getProductTypeTranslationKey mapping used by listing cards, property header, and compare table — so it showed the raw enum code instead of the localized label.