### PR TITLE
fix(create-post): enable AI valuation for office and store listings

### DIFF
--- a/src/api/types/ai.type.ts
+++ b/src/api/types/ai.type.ts
@@ -34,7 +34,13 @@ export interface ListingDescriptionResponse {
 }
 
 // Housing Price Predictor Types
-export type HousingPropertyType = 'APARTMENT' | 'HOUSE' | 'ROOM' | 'STUDIO'
+export type HousingPropertyType =
+  | 'APARTMENT'
+  | 'HOUSE'
+  | 'ROOM'
+  | 'STUDIO'
+  | 'OFFICE'
+  | 'STORE'
 
 export interface HousingPredictorRequest {
   city: string

--- a/src/components/organisms/createPostSections/aiValuationSection.tsx
+++ b/src/components/organisms/createPostSections/aiValuationSection.tsx
@@ -157,10 +157,9 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
   }, [propertyInfo.productType, t, tPropertyDetails])
 
   const canPredict = !!predictionRequest
-  // The housing price model only covers residential types (căn hộ / nhà / phòng
-  // trọ / studio). Office & store listings can't be valued, so when prediction is
-  // unavailable we show "not supported for this type" instead of wrongly telling
-  // the user their address/area/GPS is missing.
+  // AI valuation supports every listing property type. When prediction is
+  // unavailable this still distinguishes "not supported for this type" (e.g. an
+  // unrecognized/legacy value) from "required address/area/GPS data is missing".
   const typeSupportedForAi = isTypeSupportedForAiValuation(
     typeof propertyInfo.productType === 'string'
       ? propertyInfo.productType

--- a/src/components/organisms/createPostSections/index.helper.ts
+++ b/src/components/organisms/createPostSections/index.helper.ts
@@ -115,6 +115,8 @@ const PROPERTY_TYPE_OPTIONS: Array<{
   { value: 'APARTMENT', translationKey: 'apartment' },
   { value: 'HOUSE', translationKey: 'house' },
   { value: 'STUDIO', translationKey: 'studio' },
+  { value: 'OFFICE', translationKey: 'office' },
+  { value: 'STORE', translationKey: 'store' },
 ]
 
 // AI Valuation section helpers

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1726,7 +1726,7 @@
           "reevaluate": "Re-evaluate",
           "predicting": "Predicting...",
           "incompleteData": "Please fill in complete address, area and GPS coordinates information",
-          "unsupportedType": "AI valuation is only available for apartments, houses, rooms and studios.",
+          "unsupportedType": "AI valuation is not yet supported for this property type.",
           "types": {
             "room": "Room",
             "apartment": "Apartment",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1726,7 +1726,7 @@
           "reevaluate": "Đánh giá lại",
           "predicting": "Đang dự đoán...",
           "incompleteData": "Vui lòng điền đầy đủ thông tin địa chỉ, diện tích và tọa độ GPS",
-          "unsupportedType": "Định giá AI chỉ khả dụng cho căn hộ, nhà ở, phòng trọ và studio.",
+          "unsupportedType": "Định giá AI hiện chưa hỗ trợ loại bất động sản này.",
           "types": {
             "room": "Phòng trọ",
             "apartment": "Căn hộ",

--- a/src/utils/ai/housingPredictor.ts
+++ b/src/utils/ai/housingPredictor.ts
@@ -5,8 +5,8 @@ import type {
 
 import { CreateListingRequest } from '@/api/types'
 
-// The housing price model only covers residential types. Exposed so the UI can
-// tell "this property type isn't supported by AI valuation" apart from "required
+// AI valuation covers every listing property type. Exposed so the UI can tell
+// "this property type isn't supported by AI valuation" apart from "required
 // data is missing" instead of showing one misleading message for both.
 export const isTypeSupportedForAiValuation = (productType?: string): boolean =>
   normalizePropertyType(productType) !== null
@@ -22,6 +22,8 @@ const normalizePropertyType = (
     'HOUSE',
     'ROOM',
     'STUDIO',
+    'OFFICE',
+    'STORE',
   ]
   if (allowed.includes(pt as HousingPropertyType)) {
     return pt as HousingPropertyType


### PR DESCRIPTION
The seller create-post AI valuation step whitelisted only APARTMENT, HOUSE, ROOM and STUDIO, silently disabling the feature for OFFICE and STORE even though the backing prediction API accepts any property type.