### PR TITLE
perf(following): defer feed query until the scoped user is known

### DIFF
--- a/src/components/templates/followingPageTemplate/index.tsx
+++ b/src/components/templates/followingPageTemplate/index.tsx
@@ -90,10 +90,19 @@ const FollowingPageTemplate: React.FC = () => {
   const [feedUserId, setFeedUserId] = React.useState<string>('')
 
   const peopleQuery = useFollowingPeople(peoplePage, PEOPLE_PAGE_SIZE)
+  // The feed always scopes to a single followed person, defaulting to the first
+  // one — but that id is only known after the people list resolves. Hold the
+  // feed request until either a person is selected, or the follow list has
+  // resolved to empty (so the empty state can still render). This avoids firing
+  // a wasted whole-follow-set request that would be discarded a render later.
+  const feedEnabled =
+    Boolean(feedUserId) ||
+    (peopleQuery.isSuccess && (peopleQuery.data?.content?.length ?? 0) === 0)
   const feedQuery = useFollowingFeed(
     feedPage,
     FEED_PAGE_SIZE,
     feedUserId || undefined,
+    { enabled: feedEnabled },
   )
 
   const people = peopleQuery.data?.content ?? []

--- a/src/hooks/useUserFollow/useFollowingFeed.ts
+++ b/src/hooks/useUserFollow/useFollowingFeed.ts
@@ -11,8 +11,19 @@ import { mapBackendToFrontendResponse } from '@/utils/property/mapListingRespons
  * "show only this person's posts" filter on the /following page. The server
  * silently returns an empty page if the viewer is not actually following the
  * given userId, so this can't be used to read arbitrary users' feeds.
+ *
+ * Pass {@code enabled: false} to hold the query until the caller knows which
+ * user to scope to. The /following page defaults the feed to its first followed
+ * person, but that id is only known after the people list resolves — firing the
+ * request before then would query the whole follow set and immediately discard
+ * the result, an extra (and more expensive, IN-list) round-trip on every visit.
  */
-export const useFollowingFeed = (page = 1, size = 12, userId?: string) => {
+export const useFollowingFeed = (
+  page = 1,
+  size = 12,
+  userId?: string,
+  options?: { enabled?: boolean },
+) => {
   const { isAuthenticated } = useAuth()
 
   return useQuery({
@@ -36,7 +47,7 @@ export const useFollowingFeed = (page = 1, size = 12, userId?: string) => {
       }
       return mapBackendToFrontendResponse(response.data)
     },
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && (options?.enabled ?? true),
     staleTime: 60 * 1000,
     gcTime: 5 * 60 * 1000,
   })


### PR DESCRIPTION
## What
The `/following` feed always scopes to a single followed person, defaulting to the first one **once the people list resolves**. But `useFollowingFeed` fired immediately on mount — before that id was known — so it queried the **whole follow set** and threw the result away a render later when the default person was applied. That's an extra, and more expensive (server-side `IN`-list) round-trip on every visit to the page.

## Change
- `useFollowingFeed` gains an optional `{ enabled }` option (backward-compatible — defaults to `true`).
- `FollowingPageTemplate` holds the feed request until either a person is selected **or** the follow list has resolved to empty (so the empty state still renders).

## Verify (local, worktree off `origin/main`)
- `npm run typecheck` — OK
- `npm run lint` — 0 warnings on touched files
- `npm run i18n:check` — OK (no new strings)

## Notes
These were **uncommitted local changes** sitting on an unrelated branch; packaged here as a clean PR off `main`. FE-only, backward-compatible hook signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
