### PR TITLE
refactor(property-card): drop the price-per-m² pill on compact cards

### DIFF
--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -556,16 +556,6 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
           >
             {formatByLocale(price, priceUnit)}
           </Typography>
-          {/* Area as secondary price info */}
-          {area && isCompact && (
-            <Typography
-              variant='small'
-              className='text-muted-foreground font-medium bg-muted/60 px-2 py-0.5 rounded-full'
-            >
-              {formatByLocale(Math.round(price / area), 'VND')}
-              /m²
-            </Typography>
-          )}
         </div>
 
         {/* Property Stats - Pill Style */}


### PR DESCRIPTION
## What
Removes the secondary **price/m²** chip rendered next to the price on **compact** property cards (`{area && isCompact}` block in `propertyCard`). Declutters the compact card price row.

This affects compact cards **site-wide** (search results, following feed, etc.), not a single page.

## Origin
This was an uncommitted local change sitting on an unrelated branch. The working-tree diff no longer applied to `main` (the component moved), so the same removal was re-created cleanly against current `origin/main`.

## Verify (local, worktree off `origin/main`)
- `npm run typecheck` — OK (no now-unused vars: `area` / `isCompact` still used elsewhere)
- `npm run lint` — 0 warnings on the touched file
- `npm run i18n:check` — OK