### PR TITLE
fix(create-post): apply the benefit's tier media limits, not the pay-…

### DIFF
--- a/src/api/types/membership.type.ts
+++ b/src/api/types/membership.type.ts
@@ -91,6 +91,12 @@ export interface UserBenefit {
   readonly quantityUsed: number
   readonly quantityRemaining: number
   readonly status: BenefitStatus
+  // The VIP tier a listing created with this benefit runs under, plus that
+  // tier's media caps. BE sends these on UserMembershipBenefitResponse; they
+  // are null for non-post benefits (e.g. PUSH).
+  readonly vipTierCode?: string | null
+  readonly maxImages?: number | null
+  readonly maxVideos?: number | null
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslations } from 'next-intl'
 import { useCreatePost } from '@/contexts/createPost'
@@ -27,6 +27,7 @@ import {
   X,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { resolveBenefitVipType } from '@/utils/createPost/benefitTier'
 import { SelectBenefitDialog } from '@/components/molecules/createPostSections/SelectPromotionDialog'
 
 interface PackageConfigSectionProps {
@@ -121,6 +122,10 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
   const membership = myMembership?.current ?? null
 
   const [benefitDialogOpen, setBenefitDialogOpen] = useState(false)
+
+  // The tier the user had picked before a benefit overrode it, so clearing the
+  // benefit doesn't leave them buying whatever tier the benefit posted under.
+  const purchasedVipTypeRef = useRef<VipType | undefined>(undefined)
 
   const hasBenefits =
     !!propertyInfo?.benefitIds && propertyInfo.benefitIds.length > 0
@@ -330,6 +335,7 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
   const handleApplyBenefits = useCallback(
     (benefits: UserBenefit[]) => {
       const benefitIds = benefits.map((b) => b.userBenefitId)
+      const hasSelection = benefitIds.length > 0
 
       // Calculate expiry date with 30 days duration when applying benefits
       const startDateObj = new Date(startDate)
@@ -338,20 +344,38 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
       )
       const expiryDate = expiryDateObj.toISOString()
 
+      // A benefit posts under its own VIP tier, so it — not the tier the user
+      // last clicked — decides the media limits. Keep `vipType` in sync or the
+      // uploader keeps enforcing the pay-now tier's min/max.
+      const benefitVipType = resolveBenefitVipType(benefits[0])
+      if (hasSelection && !hasBenefits) {
+        purchasedVipTypeRef.current = propertyInfo.vipType
+      }
+      const restoredVipType = purchasedVipTypeRef.current
+      const nextVipType = hasSelection ? benefitVipType : restoredVipType
+      const shouldSyncVipType =
+        !!nextVipType && nextVipType !== propertyInfo.vipType
+      if (!hasSelection) purchasedVipTypeRef.current = undefined
+
       // Selecting benefits implicitly enables quota-like behavior
       updatePropertyInfo({
         benefitIds,
-        useMembershipQuota: benefitIds.length > 0,
-        durationDays:
-          benefitIds.length > 0 ? 30 : (propertyInfo.durationDays ?? 10),
-        expiryDate:
-          benefitIds.length > 0 ? expiryDateObj : propertyInfo.expiryDate,
+        useMembershipQuota: hasSelection,
+        durationDays: hasSelection ? 30 : (propertyInfo.durationDays ?? 10),
+        expiryDate: hasSelection ? expiryDateObj : propertyInfo.expiryDate,
+        ...(shouldSyncVipType ? { vipType: nextVipType } : {}),
       })
       setValue('benefitIds', benefitIds, { shouldDirty: true })
-      setValue('useMembershipQuota', benefitIds.length > 0, {
+      setValue('useMembershipQuota', hasSelection, {
         shouldDirty: true,
       })
-      if (benefitIds.length > 0) {
+      if (shouldSyncVipType) {
+        setValue('vipType', nextVipType, {
+          shouldValidate: true,
+          shouldDirty: true,
+        })
+      }
+      if (hasSelection) {
         setValue('durationDays', 30, {
           shouldValidate: true,
           shouldDirty: true,
@@ -365,6 +389,8 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
     [
       updatePropertyInfo,
       setValue,
+      hasBenefits,
+      propertyInfo.vipType,
       propertyInfo.durationDays,
       propertyInfo.expiryDate,
       startDate,

--- a/src/utils/createPost/benefitTier.test.ts
+++ b/src/utils/createPost/benefitTier.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBenefitVipType } from './benefitTier'
+import {
+  BenefitStatus,
+  BenefitType,
+  type UserBenefit,
+} from '@/api/types/membership.type'
+
+const makeBenefit = (overrides: Partial<UserBenefit> = {}): UserBenefit => ({
+  userBenefitId: 1,
+  benefitType: BenefitType.POST_GOLD,
+  benefitNameDisplay: 'Gold posts',
+  grantedAt: '2026-01-01T00:00:00',
+  expiresAt: '2026-12-31T00:00:00',
+  totalQuantity: 5,
+  quantityUsed: 0,
+  quantityRemaining: 5,
+  status: BenefitStatus.ACTIVE,
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  ...overrides,
+})
+
+describe('resolveBenefitVipType', () => {
+  it('prefers the tier code resolved by the backend', () => {
+    const benefit = makeBenefit({
+      benefitType: BenefitType.POST_GOLD,
+      vipTierCode: 'DIAMOND',
+    })
+    expect(resolveBenefitVipType(benefit)).toBe('DIAMOND')
+  })
+
+  it.each([
+    [BenefitType.POST_SILVER, 'SILVER'],
+    [BenefitType.POST_GOLD, 'GOLD'],
+    [BenefitType.POST_DIAMOND, 'DIAMOND'],
+    [BenefitType.POST_NORMAL, 'NORMAL'],
+    [BenefitType.POST_STANDARD, 'NORMAL'],
+  ])('falls back to the benefit type: %s -> %s', (benefitType, expected) => {
+    const benefit = makeBenefit({ benefitType, vipTierCode: null })
+    expect(resolveBenefitVipType(benefit)).toBe(expected)
+  })
+
+  it('ignores a tier code the app does not know', () => {
+    const benefit = makeBenefit({
+      benefitType: BenefitType.POST_SILVER,
+      vipTierCode: 'PLATINUM',
+    })
+    expect(resolveBenefitVipType(benefit)).toBe('SILVER')
+  })
+
+  it('returns undefined for benefits that do not create a listing', () => {
+    const benefit = makeBenefit({
+      benefitType: BenefitType.PUSH,
+      vipTierCode: null,
+    })
+    expect(resolveBenefitVipType(benefit)).toBeUndefined()
+  })
+
+  it('returns undefined when no benefit is selected', () => {
+    expect(resolveBenefitVipType(undefined)).toBeUndefined()
+  })
+})

--- a/src/utils/createPost/benefitTier.ts
+++ b/src/utils/createPost/benefitTier.ts
@@ -1,0 +1,32 @@
+import { BenefitType, type UserBenefit } from '@/api/types/membership.type'
+import type { VipType } from '@/api/types/property.type'
+
+const BENEFIT_TYPE_TO_VIP_TYPE: Partial<Record<BenefitType, VipType>> = {
+  [BenefitType.POST_NORMAL]: 'NORMAL',
+  [BenefitType.POST_STANDARD]: 'NORMAL',
+  [BenefitType.POST_SILVER]: 'SILVER',
+  [BenefitType.POST_GOLD]: 'GOLD',
+  [BenefitType.POST_DIAMOND]: 'DIAMOND',
+}
+
+const isVipType = (value: string): value is VipType =>
+  value === 'NORMAL' ||
+  value === 'SILVER' ||
+  value === 'GOLD' ||
+  value === 'DIAMOND'
+
+/**
+ * The VIP tier a listing created with this benefit runs under — it decides the
+ * media limits, exactly as BE's MembershipServiceImpl#resolveTierCode does.
+ * Prefers the tier BE resolved; falls back to the benefit type so the flow
+ * still works if `vipTierCode` is absent. Undefined for non-post benefits.
+ */
+export const resolveBenefitVipType = (
+  benefit?: UserBenefit,
+): VipType | undefined => {
+  if (!benefit) return undefined
+  if (benefit.vipTierCode && isVipType(benefit.vipTierCode)) {
+    return benefit.vipTierCode
+  }
+  return BENEFIT_TYPE_TO_VIP_TYPE[benefit.benefitType]
+}


### PR DESCRIPTION
…now tier's

Picking a membership benefit left the image min/max at whatever VIP tier the user had last clicked (or the lowest tier by default), because useMediaLimits resolves limits from propertyInfo.vipType and handleApplyBenefits only wrote benefitIds / useMembershipQuota / duration / expiry.

A benefit posts under its own tier, and BE validates the media count against that tier (21001/21002), so the uploader could accept images the API then rejects. Sync vipType to the benefit's tier on apply, and restore the tier the user had picked when the benefit is cleared so they don't silently end up buying the benefit's tier.

UserBenefit now declares vipTierCode / maxImages / maxVideos, which BE already returns on UserMembershipBenefitResponse but the FE type never exposed.