### PR TITLE
fix(compare): show full listing detail in the compare table

### DIFF
--- a/src/components/organisms/compareTable/index.tsx
+++ b/src/components/organisms/compareTable/index.tsx
@@ -246,17 +246,20 @@ const CompareTable: React.FC<CompareTableProps> = ({ listings, className }) => {
     DIAMOND: 'apartmentDetail.property.vipTypes.DIAMOND',
   } as const
 
-  // Get primary image for each listing
+  // Get cover image for each listing: prefer the primary photo, but fall back to
+  // the first real image — not every listing has isPrimary set, and requiring it
+  // left cards with no image at all (matches the detail gallery, which shows any).
   const listingImages = useMemo(() => {
     return listings.map((listing) => {
-      const coverImage = listing.media?.find(
-        (m) =>
-          m.mediaType === 'IMAGE' &&
-          m.isPrimary &&
-          m.sourceType !== 'YOUTUBE' &&
-          !m.url?.includes('youtube.com') &&
-          !m.url?.includes('youtu.be'),
-      )
+      const imageMedia =
+        listing.media?.filter(
+          (m) =>
+            m.mediaType === 'IMAGE' &&
+            m.sourceType !== 'YOUTUBE' &&
+            !m.url?.includes('youtube.com') &&
+            !m.url?.includes('youtu.be'),
+        ) ?? []
+      const coverImage = imageMedia.find((m) => m.isPrimary) ?? imageMedia[0]
       return coverImage?.url || '/images/default-image.jpg'
     })
   }, [listings])

--- a/src/components/templates/compareTemplate/index.tsx
+++ b/src/components/templates/compareTemplate/index.tsx
@@ -20,6 +20,7 @@ import CompareTable from '@/components/organisms/compareTable'
 import EmptyCompareState from '@/components/organisms/emptyCompareState'
 import { useCompareStore } from '@/store/compare/useCompareStore'
 import { ListingService } from '@/api/services/listing.service'
+import { ListingApi } from '@/api/types/property.type'
 
 /**
  * CompareTemplate
@@ -31,50 +32,72 @@ const CompareTemplate: React.FC = () => {
   const { compareList, clearCompare, removeFromCompare } = useCompareStore()
   const [isMounted, setIsMounted] = useState(false)
   const [unavailableTitles, setUnavailableTitles] = useState<string[]>([])
-  const hasCheckedAvailability = useRef(false)
+  // Full listing detail fetched per id, keyed by listingId. sessionStorage only
+  // holds whatever partial shape the entry point (card, AI mini, detail header)
+  // happened to store, so the table must render from this, not from compareList.
+  const [detailsById, setDetailsById] = useState<Record<number, ListingApi>>({})
+  const fetchedIdsRef = useRef<Set<number>>(new Set())
 
   // Handle hydration: Wait for Zustand store to hydrate from localStorage
   useEffect(() => {
     setIsMounted(true)
   }, [])
 
-  // Re-validate compare list against the live listing endpoint once, after hydration.
-  // The compare table renders from sessionStorage, which goes stale once a listing
-  // expires, gets rejected/suspended, or is deleted — the API 404s all of those
-  // identically (see ListingController), so "no data back" is the single signal
-  // that a listing is no longer comparable.
+  // Hydrate each compared listing from the live detail endpoint (the same
+  // GET /listings/{id} the detail page uses), then render from that — the
+  // sessionStorage entry is only a partial snapshot and also goes stale once a
+  // listing's price/status changes. The endpoint 404s expired/rejected/deleted
+  // listings identically, so "no data back" doubles as the availability signal:
+  // those get pulled from the compare list and surfaced in the dialog.
   useEffect(() => {
-    if (
-      !isMounted ||
-      hasCheckedAvailability.current ||
-      compareList.length === 0
-    ) {
+    if (!isMounted || compareList.length === 0) {
       return
     }
-    hasCheckedAvailability.current = true
 
-    const checkListingsAvailability = async () => {
+    const pending = compareList.filter(
+      (listing) => !fetchedIdsRef.current.has(listing.listingId),
+    )
+    if (pending.length === 0) {
+      return
+    }
+    pending.forEach((listing) => fetchedIdsRef.current.add(listing.listingId))
+
+    let cancelled = false
+
+    const hydrateAndValidate = async () => {
       const responses = await Promise.all(
-        compareList.map((listing) => ListingService.getById(listing.listingId)),
+        pending.map((listing) => ListingService.getById(listing.listingId)),
       )
+      if (cancelled) {
+        return
+      }
 
+      const nextDetails: Record<number, ListingApi> = {}
       const unavailable: string[] = []
-      responses.forEach((response, index) => {
-        const listing = compareList[index]
-        const isUnavailable = !response.success || !response.data
 
-        if (isUnavailable) {
+      responses.forEach((response, index) => {
+        const listing = pending[index]
+        if (response.success && response.data) {
+          nextDetails[listing.listingId] = response.data
+        } else {
           unavailable.push(listing.title)
           removeFromCompare(listing.listingId)
         }
       })
 
+      if (Object.keys(nextDetails).length > 0) {
+        setDetailsById((prev) => ({ ...prev, ...nextDetails }))
+      }
       if (unavailable.length > 0) {
-        setUnavailableTitles(unavailable)
+        setUnavailableTitles((prev) => [...prev, ...unavailable])
       }
     }
 
-    checkListingsAvailability()
+    hydrateAndValidate()
+
+    return () => {
+      cancelled = true
+    }
   }, [isMounted, compareList, removeFromCompare])
 
   // Don't render until mounted to avoid hydration mismatch
@@ -90,6 +113,11 @@ const CompareTemplate: React.FC = () => {
   }
 
   const hasItems = compareList.length > 0
+  // Prefer the full detail; fall back to the stored partial while it loads so
+  // the table still paints immediately instead of flashing empty columns.
+  const displayListings = compareList.map(
+    (listing) => detailsById[listing.listingId] ?? listing,
+  )
 
   return (
     <PageContainer width='grid' className='py-6 sm:py-8'>
@@ -122,7 +150,7 @@ const CompareTemplate: React.FC = () => {
       </div>
 
       {hasItems ? (
-        <CompareTable listings={compareList} />
+        <CompareTable listings={displayListings} />
       ) : (
         <EmptyCompareState />
       )}


### PR DESCRIPTION
## Problem
Khi mở trang **So sánh** (kể cả lúc chưa đăng nhập), rất nhiều dòng hiển thị "Chưa cập nhật" và ảnh bìa bị mất — dù vào trang chi tiết của cùng tin đó thì thông tin đầy đủ.

## Root cause (frontend only — backend fine)
`getById` trả về đầy đủ `ListingDetail` cho cả khách chưa đăng nhập (trang chi tiết dùng chính nó qua SSR). Nhưng tính năng so sánh:
- Lưu vào sessionStorage đúng object **rút gọn** mà mỗi entry point truyền vào. Trên trang chi tiết, `PropertyHeader.listingForCompare` bỏ qua `listingType`, `waterPrice`/`electricityPrice`/`internetPrice`/`serviceFee`, `contactAvailable`, `ownerContactPhoneVerified` — đúng loạt dòng "Chưa cập nhật".
- `compareTemplate` render thẳng từ object rút gọn đó. Nó **có** gọi `getById` (full detail) nhưng chỉ dùng để check tin còn sống, rồi **bỏ luôn** phần data.
- Ảnh bìa của compare bắt buộc `isPrimary === true` (khắt khe hơn trang chi tiết), cộng với `media` rút gọn → không có ảnh.

## Fix
- **compareTemplate**: hydrate mỗi tin từ `getById` và render từ full `ListingDetail`; object rút gọn chỉ còn là fallback trong lúc đang tải. Việc phát hiện tin hết hạn/bị xóa vẫn giữ nguyên (dùng "không có data" làm tín hiệu). Một chỗ này bao trọn mọi lối vào (card, AI mini, trang chi tiết).
- **compareTable**: chọn ảnh đầu tiên khi không có ảnh nào gắn `isPrimary` (khớp gallery trang chi tiết) để ảnh bìa không biến mất.

## Testing
- `tsc --noEmit` → 0
- `eslint` (touched files) → 0
- `i18n:check` → 0 (không thêm string mới)