### PR TITLE
fix(create-post): require login before opening the post form

### DIFF
--- a/src/pages/seller/create-post/index.tsx
+++ b/src/pages/seller/create-post/index.tsx
@@ -19,9 +19,12 @@ import {
   DialogTitle,
 } from '@/components/atoms/dialog'
 import { Button } from '@/components/atoms/button'
-import { SELLERNET_ROUTES } from '@/constants/route'
+import { SELLER_ROUTES, SELLERNET_ROUTES } from '@/constants/route'
 import { AlertTriangle, FileEdit } from 'lucide-react'
 import React from 'react'
+import { useAuthDialog } from '@/contexts/authDialog'
+import LoginRequiredNotice from '@/components/molecules/loginRequiredNotice'
+import { cookieManager } from '@/utils/cookies'
 
 const CreatePostPage: NextPageWithLayout = () => {
   const router = useRouter()
@@ -35,9 +38,31 @@ const CreatePostPage: NextPageWithLayout = () => {
   const t = useTranslations('createPost.profilePhoneRequiredDialog')
   const tBlocked = useTranslations('createPost.blockedFromPostingDialog')
   const { user, isAuthenticated } = useAuth()
+  const { openAuth } = useAuthDialog()
   const [openPhoneRequiredDialog, setOpenPhoneRequiredDialog] =
     React.useState(false)
   const [openBlockedDialog, setOpenBlockedDialog] = React.useState(false)
+  const [isMounted, setIsMounted] = React.useState(false)
+  const hasPromptedLogin = React.useRef(false)
+
+  React.useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  // Client-side auth guard. middleware.ts guards /seller/* on a full document
+  // load, but Pages-Router client navigation to a page without getServerSideProps
+  // (this one) never reaches middleware — so a logged-out user could open the post
+  // form via the in-app "Đăng tin" link. Gate on the same access_token cookie the
+  // middleware reads and send guests to the login dialog instead of the form.
+  const isGuestVisitor =
+    isMounted && !isAuthenticated && !cookieManager.getAccessToken()
+
+  React.useEffect(() => {
+    if (isGuestVisitor && !hasPromptedLogin.current) {
+      hasPromptedLogin.current = true
+      openAuth('login', SELLER_ROUTES.CREATE)
+    }
+  }, [isGuestVisitor, openAuth])
 
   const { data: profileResponse, isLoading: isCheckingProfile } = useQuery({
     queryKey: ['create-post-profile-phone-check', user?.userId],
@@ -93,6 +118,26 @@ const CreatePostPage: NextPageWithLayout = () => {
     if (!nextOpen) {
       handleRedirectToProfile()
     }
+  }
+
+  // Before the client auth check resolves, render only the head — avoids an
+  // SSR/CSR mismatch and never flashes the form to a logged-out visitor.
+  if (!isMounted) {
+    return <SeoHead title='Đăng tin – Seller' noindex />
+  }
+
+  // Logged-out visitor: show the login-required screen instead of the post form.
+  // The login dialog is also opened automatically above; once they log in the
+  // guard falls through and the form renders in place.
+  if (isGuestVisitor) {
+    return (
+      <>
+        <SeoHead title='Đăng tin – Seller' noindex />
+        <LoginRequiredNotice
+          onLoginClick={() => openAuth('login', SELLER_ROUTES.CREATE)}
+        />
+      </>
+    )
   }
 
   return (


### PR DESCRIPTION
## Problem
Khi **chưa đăng nhập**, bấm "Đăng tin" vẫn vào được trang đăng tin và thấy/thao tác được form. Mong muốn: khách chưa đăng nhập bấm Đăng tin thì được đưa tới màn hình đăng nhập.

## Root cause
`/seller/create-post` không có `getServerSideProps`. Trong Next.js Pages Router, điều hướng client-side bằng `<Link>` tới một page không có server data **không đi qua `middleware.ts`** — guard `access_token` của middleware chỉ chạy khi load full document / mở URL trực tiếp / refresh cứng. Vì vậy khách bấm link "Đăng tin" ở header vào thẳng form; chỉ khi refresh cứng URL đó mới bị redirect sang `?auth=login`. Đó là lý do hành vi không nhất quán.

## Fix
Thêm **auth guard phía client** ngay trong trang create-post, kiểm tra đúng cookie `access_token` mà middleware dùng (đáng tin trên mọi kiểu điều hướng). Khách chưa đăng nhập giờ được tự động mở dialog đăng nhập kèm màn hình `LoginRequiredNotice` (component sẵn có, đã i18n) thay vì form; sau khi đăng nhập, guard đi qua và form hiện ra tại chỗ. Bao mọi lối vào (link header, mobile nav, gõ URL trực tiếp).

Ghi chú: app không có trang login riêng — đăng nhập là dialog; guard tái dùng đúng flow đăng nhập hiện có.

## Testing
- `tsc --noEmit` → 0
- `eslint` (touched file) → 0
- `i18n:check` → 0 (không thêm string mới; tái dùng key `auth.loginRequired.*`)