### PR TITLE
fix(chat): preserve guest chat history when a guest logs in

### DIFF
--- a/src/hooks/useAuth/index.tsx
+++ b/src/hooks/useAuth/index.tsx
@@ -62,11 +62,17 @@ export const useLogin = () => {
         }
 
         const user = await resolveAuthenticatedUser(tokens, queryClient)
+        // Snapshot BEFORE login() flips the store. A guest -> login is the same
+        // physical person, so the chat widget adopts their in-progress
+        // conversation; only a switch from one real account to another wipes it.
+        const wasAuthenticated = useAuthStore.getState().isAuthenticated
         login(user, tokens)
 
-        // Clear AI chat session so the new account never inherits the previous
-        // (or guest) conversation.
-        clearChatSessionStorage()
+        if (wasAuthenticated) {
+          // Switching between real accounts: never let the new account inherit
+          // the previous conversation.
+          clearChatSessionStorage()
+        }
 
         return result
       } catch (error) {
@@ -109,11 +115,17 @@ export const useAdminLogin = () => {
         }
 
         const user = await resolveAuthenticatedUser(tokens, queryClient)
+        // Snapshot BEFORE login() flips the store. A guest -> login is the same
+        // physical person, so the chat widget adopts their in-progress
+        // conversation; only a switch from one real account to another wipes it.
+        const wasAuthenticated = useAuthStore.getState().isAuthenticated
         login(user, tokens)
 
-        // Clear AI chat session so the new account never inherits the previous
-        // (or guest) conversation.
-        clearChatSessionStorage()
+        if (wasAuthenticated) {
+          // Switching between real accounts: never let the new account inherit
+          // the previous conversation.
+          clearChatSessionStorage()
+        }
 
         return result
       } catch (error) {
@@ -391,11 +403,17 @@ export const useVerifyMagicLink = () => {
             }
           : { accessToken: payload.accessToken }
         const user = await resolveAuthenticatedUser(tokens, queryClient)
+        // Snapshot BEFORE login() flips the store. A guest -> login is the same
+        // physical person, so the chat widget adopts their in-progress
+        // conversation; only a switch from one real account to another wipes it.
+        const wasAuthenticated = useAuthStore.getState().isAuthenticated
         login(user, tokens)
 
-        // Clear AI chat session so the new account never inherits the previous
-        // (or guest) conversation.
-        clearChatSessionStorage()
+        if (wasAuthenticated) {
+          // Switching between real accounts: never let the new account inherit
+          // the previous conversation.
+          clearChatSessionStorage()
+        }
 
         return result
       } catch (error) {

--- a/src/hooks/useChatAi/useChatSession.test.ts
+++ b/src/hooks/useChatAi/useChatSession.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 })
 
 describe('useChatSession identity reset', () => {
-  it('clears guest history when a guest logs in', () => {
+  it('carries guest history over when a guest logs in (same person)', () => {
     const { result, rerender } = render({ isAuthenticated: false })
 
     act(() => {
@@ -41,8 +41,33 @@ describe('useChatSession identity reset', () => {
     })
     expect(result.current.messages).toHaveLength(2)
 
-    // Guest logs in -> guest "please login" history must be wiped
+    // Guest logs in -> the in-progress conversation belongs to the same
+    // physical person and must carry over into their authenticated session.
     rerender({ auth: { isAuthenticated: true, userId: 'u1' } })
+
+    expect(result.current.messages).toHaveLength(2)
+    expect(result.current.messages[1].id).toBe('guest-1')
+    // Ownership is re-stamped to the now-authenticated user, and the adopted
+    // conversation is persisted under that owner so a reload keeps it.
+    expect(sessionStorage.getItem(CHAT_OWNER_KEY)).toBe('u1')
+    const stored = JSON.parse(
+      sessionStorage.getItem(CHAT_SESSION_KEY) as string,
+    ) as TChatMessage[]
+    expect(stored).toHaveLength(2)
+  })
+
+  it('wipes an adopted guest chat when that user later switches accounts', () => {
+    // Guest chats, then logs in as u1 (adopt), then a different real account
+    // u2 takes over the tab -> genuine identity switch, must wipe.
+    const { result, rerender } = render({ isAuthenticated: false })
+
+    act(() => {
+      result.current.addMessage(userMsg('guest-1'))
+    })
+    rerender({ auth: { isAuthenticated: true, userId: 'u1' } })
+    expect(result.current.messages).toHaveLength(2)
+
+    rerender({ auth: { isAuthenticated: true, userId: 'u2' } })
 
     expect(result.current.messages).toHaveLength(1)
     expect(result.current.messages[0].id).toBe('welcome-msg-initial')

--- a/src/hooks/useChatAi/useChatSession.ts
+++ b/src/hooks/useChatAi/useChatSession.ts
@@ -142,17 +142,39 @@ export const useChatSession = (
     [initialMessage],
   )
 
-  // Wipe the conversation whenever the effective identity changes
-  // (login / logout / account switch). The chat only serves authenticated
-  // users, so a guest's "please login" history is cleared on login too.
+  // Re-stamp ownership WITHOUT discarding the conversation. Used when an
+  // unauthenticated visitor logs in: the guest chat belongs to the same
+  // physical person, so it carries over into their authenticated session
+  // instead of being wiped. The current messages are re-persisted under the
+  // new owner so a subsequent reload restores them for that user.
+  const adoptForOwner = useCallback((owner: string) => {
+    try {
+      sessionStorage.setItem(CHAT_OWNER_KEY, owner)
+      sessionStorage.setItem(
+        CHAT_SESSION_KEY,
+        JSON.stringify(messagesRef.current),
+      )
+    } catch {
+      // Silent fail
+    }
+    ownerRef.current = owner
+  }, [])
+
+  // React to identity changes (login / logout / account switch).
+  //
+  // A guest logging in is the SAME physical person continuing their session —
+  // often they were just nudged to log in by the guest message gate — so their
+  // in-progress conversation is adopted into the authenticated session, not
+  // wiped. Every other identity change (switching between two real accounts, or
+  // logging out) still wipes, to avoid one user seeing another's chat.
   //
   // The tricky part is a same-tab reload: the auth store boots as
   // unauthenticated and only re-resolves the logged-in user asynchronously
   // (false -> true edge). We must NOT treat that as a fresh login, or every
   // refresh would wipe the restored history. Two guards handle it:
   //   - When authenticated, compare the (reliable) userId against the stored
-  //     owner: a reload resolves to the same owner (no reset); a real login /
-  //     switch resolves to a different owner (reset).
+  //     owner: a reload resolves to the same owner (no-op); a login from guest
+  //     adopts; a switch between real accounts resets.
   //   - When unauthenticated, only reset on an actual authenticated -> guest
   //     edge (explicit logout). The initial `false` may just be the hydration
   //     window of a logged-in user, so it must not wipe anything.
@@ -168,7 +190,16 @@ export const useChatSession = (
       const identity =
         userId !== null && userId !== undefined ? String(userId) : GUEST_OWNER
       if (ownerRef.current !== identity) {
-        resetForOwner(identity)
+        // Owner was the guest sentinel (or never stamped) -> the messages are
+        // the same person's guest conversation, safe to carry over. Owner was
+        // another real account -> genuine switch, wipe.
+        const cameFromGuest =
+          ownerRef.current === null || ownerRef.current === GUEST_OWNER
+        if (cameFromGuest) {
+          adoptForOwner(identity)
+        } else {
+          resetForOwner(identity)
+        }
       }
       return
     }
@@ -177,7 +208,7 @@ export const useChatSession = (
     if (wasAuthenticated && ownerRef.current !== GUEST_OWNER) {
       resetForOwner(GUEST_OWNER)
     }
-  }, [isAuthenticated, userId, resetForOwner])
+  }, [isAuthenticated, userId, resetForOwner, adoptForOwner])
 
   const clearSession = useCallback(() => {
     try {


### PR DESCRIPTION
## Vấn đề
Khi khách **chưa đăng nhập** chat với chatbot rồi **đăng nhập**, toàn bộ lịch sử chat bị mất về màn hình welcome.

## Nguyên nhân
Chat của guest bị xoá bởi **2 cơ chế** khi đăng nhập, vì `guest → login` bị coi như đổi tài khoản:
1. **Chính:** 3 handler login (`useLogin` / `useAdminLogin` / `useVerifyMagicLink`) gọi `clearChatSessionStorage()` với comment *"never inherit the previous (or guest) conversation"*.
2. **Phụ:** effect đổi-identity trong `useChatSession` gọi `resetForOwner()` khi `isAuthenticated` từ `false→true`.

Logic wipe vốn để chống rò chat giữa 2 người dùng thật (PR #397), nhưng không tách riêng ca `guest → login` — vốn là **cùng một người** đang tiếp tục phiên (thường vừa bị gate 5 tin nhắn ép đăng nhập).

## Cách sửa
Chỉ **adopt** (nhận) chat của guest sang tài khoản vừa đăng nhập; vẫn **wipe** khi đổi tài khoản thật (A→B) và khi logout.

- `useChatSession`: thêm `adoptForOwner()` — re-stamp owner + lưu lại messages, **không xoá**. Effect chọn adopt khi owner cũ là `guest`/`null`, chỉ `resetForOwner()` khi owner cũ là một tài khoản thật khác.
- `useAuth`: 3 handler login chỉ gọi `clearChatSessionStorage()` khi `wasAuthenticated` (chụp trước `login()`) — tức chỉ khi đổi tài khoản thật.

## An toàn
Chỉ messages thuộc owner `guest`/`null` mới được adopt — loại này chỉ sinh ra từ phiên chưa đăng nhập của **chính người đó**, nên chat của user thật không bao giờ rò sang user khác. Reload của user đã đăng nhập, đổi tài khoản A→B, và logout giữ nguyên hành vi cũ.

## Verify
- `useChatSession.test.ts`: cập nhật test cũ (vốn assert hành vi xoá) + thêm 2 test mới (adopt + switch-sau-adopt) → **5/5 pass**; cả folder `useChatAi` **14/14 pass**.
- `tsc --noEmit` exit 0; `eslint` 2 file đã sửa exit 0. Không thêm string i18n mới.