### PR TITLE
fix(chat): drop stale guest login CTA after the guest logs in

### DIFF
--- a/src/hooks/useChatAi/useChatLogic.guestQuota.test.ts
+++ b/src/hooks/useChatAi/useChatLogic.guestQuota.test.ts
@@ -126,4 +126,29 @@ describe('useChatLogic guest quota gating', () => {
 
     expect(AiService.chat).toHaveBeenCalledTimes(1)
   })
+
+  it('drops the stale login CTA from the transcript once the guest logs in', async () => {
+    // Guest at the limit: the one-shot login CTA is in the transcript.
+    setAuth(false)
+    sessionStorage.setItem(COUNT_KEY, '5')
+
+    const { result, rerender } = renderHook(() => useChatLogic())
+
+    expect(
+      result.current.messages.some((m) => m.id === 'guest-limit-cta'),
+    ).toBe(true)
+
+    // The guest logs in (typically by clicking that very CTA). The rest of the
+    // conversation is adopted into the authenticated session, but the now-dead
+    // login prompt must not linger.
+    act(() => {
+      setAuth(true, 'u1')
+      rerender()
+    })
+
+    expect(result.current.guestLimitReached).toBe(false)
+    expect(
+      result.current.messages.some((m) => m.id === 'guest-limit-cta'),
+    ).toBe(false)
+  })
 })

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -115,10 +115,11 @@ export const useChatLogic = () => {
   // Use session storage for message persistence. Passing the auth identity in
   // lets the session wipe itself on login / logout / account switch instead of
   // leaking one account's chat into the next.
-  const { messages, addMessage, updateMessage, clearSession } = useChatSession(
-    initialMessage,
-    { isAuthenticated, userId: user?.userId ?? null },
-  )
+  const { messages, addMessage, updateMessage, removeMessage, clearSession } =
+    useChatSession(initialMessage, {
+      isAuthenticated,
+      userId: user?.userId ?? null,
+    })
 
   //Init state hook
   const [isLoading, setIsLoading] = useState(false)
@@ -162,6 +163,15 @@ export const useChatLogic = () => {
     })
     scrollToMessage(GUEST_LIMIT_CTA_ID)
   }, [guestLimitReached, isLoading, addMessage, t, scrollToMessage])
+
+  // Once the guest logs in (usually by tapping the CTA itself), the one-shot
+  // login prompt is stale — its button just reopens an auth dialog for an
+  // already-authenticated user. useChatSession adopts the rest of the guest
+  // conversation into the authenticated session, so drop only this dead prompt.
+  useEffect(() => {
+    if (!isAuthenticated) return
+    removeMessage(GUEST_LIMIT_CTA_ID)
+  }, [isAuthenticated, removeMessage])
 
   const generateMessageId = useCallback(() => {
     const timestamp = Date.now()

--- a/src/hooks/useChatAi/useChatSession.ts
+++ b/src/hooks/useChatAi/useChatSession.ts
@@ -238,6 +238,10 @@ export const useChatSession = (
     [],
   )
 
+  const removeMessage = useCallback((id: string) => {
+    setSessionMessages((prev) => prev.filter((m) => m.id !== id))
+  }, [])
+
   const setMessages = useCallback((messages: TChatMessage[]) => {
     setSessionMessages(messages)
   }, [])
@@ -246,6 +250,7 @@ export const useChatSession = (
     messages: sessionMessages,
     addMessage,
     updateMessage,
+    removeMessage,
     setMessages,
     clearSession,
   }


### PR DESCRIPTION
## Vấn đề
Khi guest dùng hết 5 lượt hỏi miễn phí, một bong bóng CTA `guest-limit-cta` (`action: 'login'`) được thêm vào transcript. Sau khi user bấm **Đăng nhập để tiếp tục** và login thành công:

- Input un-gate ngay (`guestLimitReached = !isAuthenticated && …`) ✅
- Nhưng theo #449, cuộc trò chuyện guest được **adopt** sang session đã đăng nhập (không wipe) — nên bong bóng CTA **vẫn nằm lại**, và nút giờ chỉ mở lại dialog login cho người... đã đăng nhập rồi.

## Cách sửa
Xóa **đúng mỗi message CTA** khỏi transcript ngay khi `isAuthenticated` = true, giữ nguyên phần chat thật vừa được adopt.

- `useChatSession`: thêm `removeMessage(id)` (filter theo id) + export.
- `useChatLogic`: effect mới — khi đã login thì `removeMessage(GUEST_LIMIT_CTA_ID)`. Effect add-CTA không re-add vì `guestLimitReached` đã false → không loop.
- Bản persist debounce ghi đè list đã lọc nên reload sau đó cũng không thấy lại CTA.

## Test
- Thêm case: guest hết lượt → CTA hiện → login → CTA biến mất.
- `vitest` (chat hooks): 15/15 pass · `tsc --noEmit`: 0 · `eslint` (3 file): 0 · pre-commit pass.