### PR TITLE
fix(listing-cards): remove verified badge from property list/grid cards

### DIFF
--- a/src/components/molecules/CardListingAIMini/index.tsx
+++ b/src/components/molecules/CardListingAIMini/index.tsx
@@ -35,17 +35,8 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
   const tSaved = useTranslations('savedListings')
   const { language } = useLanguage()
 
-  const {
-    listingId,
-    title,
-    price,
-    area,
-    bedrooms,
-    address,
-    media,
-    vipType,
-    verified,
-  } = listing
+  const { listingId, title, price, area, bedrooms, address, media, vipType } =
+    listing
 
   const primaryImage =
     media?.find((m) => m.isPrimary)?.url || media?.[0]?.url || DEFAULT_IMAGE
@@ -111,13 +102,6 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
               <div className='absolute top-2 left-2'>
                 <Badge className='rounded-full shadow-md font-medium backdrop-blur-sm bg-gradient-to-r from-primary to-primary/80 text-primary-foreground text-xs px-2.5 py-1'>
                   {tHome('priorityBadge')}
-                </Badge>
-              </div>
-            )}
-            {verified && (
-              <div className='absolute top-2 right-2'>
-                <Badge variant='secondary' className='text-xs'>
-                  ✓
                 </Badge>
               </div>
             )}

--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -14,7 +14,6 @@ import {
   Square,
   Users,
   Camera,
-  Check,
   Sparkles,
   MapPin,
 } from 'lucide-react'
@@ -75,7 +74,6 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
     area,
     bedrooms,
     bathrooms,
-    verified,
     user,
     address,
     vipType,
@@ -136,19 +134,6 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
               compact ? 'top-1.5 left-1.5 gap-1' : 'top-2 left-2 gap-1.5',
             )}
           >
-            {verified && (
-              <Badge
-                className={classNames(
-                  'bg-emerald-500/90 text-white text-[11px] rounded-full shadow-md flex items-center backdrop-blur-sm',
-                  compact ? 'px-1.5 py-0.5 gap-0.5' : 'px-2.5 py-1 gap-1',
-                )}
-              >
-                <Check className={compact ? 'w-2.5 h-2.5' : 'w-3 h-3'} />
-                <span className='font-medium'>
-                  {t('homePage.property.verified')}
-                </span>
-              </Badge>
-            )}
             {isPriority && (
               <Badge
                 className={classNames(

--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -13,7 +13,6 @@ import {
   Bath,
   Square,
   Camera,
-  Check,
   Home,
   Building2,
   Users,
@@ -73,7 +72,6 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
     area,
     bedrooms,
     bathrooms,
-    verified,
     user,
     address,
     productType,
@@ -278,14 +276,6 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
 
             {/* Badges - Top Left */}
             <div className='absolute top-2 left-2 flex flex-col gap-1.5 z-10'>
-              {verified && (
-                <Badge className='bg-emerald-500/90 text-white text-xs px-2.5 py-1 rounded-full shadow-md flex items-center gap-1 backdrop-blur-sm'>
-                  <Check className='w-3 h-3' />
-                  <span className='font-medium text-2xs'>
-                    {t('homePage.property.verified')}
-                  </span>
-                </Badge>
-              )}
               {vipBadgeConfig &&
                 (() => {
                   const VipIcon = vipBadgeConfig.icon
@@ -422,17 +412,6 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
               : 'top-2 left-2 sm:top-3 sm:left-3 gap-1 sm:gap-2',
           )}
         >
-          {verified && (
-            <Badge
-              className={classNames(
-                'bg-emerald-500/90 text-white rounded-full shadow-md flex items-center gap-0.5 backdrop-blur-sm',
-                isCompact ? 'text-2xs px-1.5 py-0.5' : 'text-xs px-2.5 py-1',
-              )}
-            >
-              <Check className={isCompact ? 'w-2.5 h-2.5' : 'w-3 h-3'} />
-              {!isCompact && t('homePage.property.verified')}
-            </Badge>
-          )}
           {vipBadgeConfig &&
             (() => {
               const VipIcon = vipBadgeConfig.icon

--- a/src/components/organisms/listing-card/index.tsx
+++ b/src/components/organisms/listing-card/index.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { RankDisplay } from '@/components/atoms/rank-display'
-import { VerificationBadge } from '@/components/atoms/verification-badge'
 import { Badge } from '@/components/atoms/badge'
 import { Typography } from '@/components/atoms/typography'
 import { ListingCardActions } from '@/components/molecules/listingCardActions'
@@ -249,9 +248,6 @@ export const ListingCard: React.FC<ListingCardProps> = ({
                   <Badge variant='secondary' className='font-medium'>
                     {tNot(getProductTypeTranslationKey(productType))}
                   </Badge>
-                )}
-                {verified && (
-                  <VerificationBadge verified={verified} type='verified' />
                 )}
                 {isPubliclyVisible && (
                   <TooltipProvider delayDuration={300}>


### PR DESCRIPTION
The green "Đã xác minh" checkmark badge on listing cards duplicated the active/status badge already shown on the same card.