### PR TITLE
feat(policies): trang quy định + fix nhỏ UI listing/compare

### DIFF
--- a/src/components/molecules/sellerPublicProfileCard/index.tsx
+++ b/src/components/molecules/sellerPublicProfileCard/index.tsx
@@ -50,7 +50,7 @@ const maskEmail = (value: string): string => {
 }
 
 const CONTACT_PILL_CLASSNAME =
-  'flex items-center gap-2.5 text-sm rounded-lg border border-primary/25 p-2.5 bg-background/85 transition-colors hover:border-primary/45 flex-1 min-w-[160px]'
+  'flex items-center gap-2.5 text-sm rounded-lg border border-primary/25 p-2.5 bg-background/85 transition-colors hover:border-primary/45 w-full'
 
 const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
   seller,
@@ -73,14 +73,14 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
             </div>
           </div>
 
-          <div className='flex flex-wrap gap-2'>
-            <div className='flex items-center gap-2 rounded-lg border border-primary/25 p-2.5 bg-background/85 flex-1 min-w-[160px]'>
+          <div className='flex flex-col gap-2'>
+            <div className='flex items-center gap-2 rounded-lg border border-primary/25 p-2.5 bg-background/85 w-full'>
               <Skeleton className='h-8 w-8 rounded-full shrink-0' />
               <Skeleton className='h-8 max-w-full flex-1' />
               <Skeleton className='h-8 w-8 rounded-md shrink-0' />
             </div>
 
-            <div className='flex items-center gap-2 rounded-lg border border-primary/25 p-2.5 bg-background/85 flex-1 min-w-[160px]'>
+            <div className='flex items-center gap-2 rounded-lg border border-primary/25 p-2.5 bg-background/85 w-full'>
               <Skeleton className='h-8 w-8 rounded-full shrink-0' />
               <Skeleton className='h-8 max-w-full flex-1' />
               <Skeleton className='h-8 w-8 rounded-md shrink-0' />
@@ -189,7 +189,7 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
           </Typography>
 
           {contactItems.length > 0 ? (
-            <div className='flex flex-wrap gap-2'>
+            <div className='flex flex-col gap-2'>
               {contactItems.map((item) => (
                 <div key={item.key} className={CONTACT_PILL_CLASSNAME}>
                   <div className='h-8 w-8 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0'>

--- a/src/components/organisms/compareTable/index.tsx
+++ b/src/components/organisms/compareTable/index.tsx
@@ -57,27 +57,25 @@ const PriceDisplay: React.FC<PriceDisplayProps> = ({
   unitKey,
   lowestLabel,
 }) => (
-  <div className='flex flex-col gap-1'>
-    <div className='flex items-center gap-2 flex-wrap'>
-      <span
-        className={cn(
-          'font-semibold text-primary tabular-nums',
-          isLowest ? 'text-base md:text-lg' : 'text-sm md:text-base',
-        )}
-      >
-        {formattedPrice}
-      </span>
-      {isLowest && (
-        <Badge
-          variant='secondary'
-          className='bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30 text-2xs font-semibold px-1.5 py-0 h-5'
-        >
-          {lowestLabel}
-        </Badge>
+  <div className='flex items-center gap-x-1.5 gap-y-1 flex-wrap'>
+    <span
+      className={cn(
+        'font-semibold text-primary tabular-nums',
+        isLowest ? 'text-base md:text-lg' : 'text-sm md:text-base',
       )}
-    </div>
+    >
+      {formattedPrice}
+    </span>
     {unitKey && (
       <span className='text-xs text-muted-foreground'>/{unitKey}</span>
+    )}
+    {isLowest && (
+      <Badge
+        variant='secondary'
+        className='bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30 text-2xs font-semibold px-1.5 py-0 h-5'
+      >
+        {lowestLabel}
+      </Badge>
     )}
   </div>
 )

--- a/src/components/organisms/footer/index.tsx
+++ b/src/components/organisms/footer/index.tsx
@@ -6,7 +6,7 @@ import { Mail, Phone, GraduationCap } from 'lucide-react'
 
 import Logo from '@/components/atoms/logo'
 import { Button } from '@/components/atoms/button'
-import { SELLERNET_ROUTES, SELLER_ROUTES } from '@/constants'
+import { SELLERNET_ROUTES, SELLER_ROUTES, PUBLIC_ROUTES } from '@/constants'
 
 const SOCIAL_ICONS = [
   { src: '/svg/facebook.svg', alt: 'Facebook', label: 'Facebook' },
@@ -55,6 +55,13 @@ const SUPPORT_LINKS = [
   ['usageGuide', SELLERNET_ROUTES.USAGE_GUIDE],
 ] as const
 
+const LEGAL_LINKS = [
+  ['listingRules', PUBLIC_ROUTES.POLICY_LISTING_RULES],
+  ['termsAgreement', PUBLIC_ROUTES.POLICY_TERMS],
+  ['privacyPolicy', PUBLIC_ROUTES.POLICY_PRIVACY],
+  ['complaints', PUBLIC_ROUTES.POLICY_COMPLAINTS],
+] as const
+
 const Footer: React.FC = () => {
   const t = useTranslations('footer')
 
@@ -91,7 +98,7 @@ const Footer: React.FC = () => {
         </div>
 
         {/* ── Main grid ── */}
-        <div className='grid grid-cols-2 lg:grid-cols-4 gap-8 py-8 border-t border-border'>
+        <div className='grid grid-cols-2 lg:grid-cols-5 gap-8 py-8 border-t border-border'>
           {/* Col 1 — Brand */}
           <div className='col-span-2 lg:col-span-1 space-y-4'>
             <Logo size='large' clickable={false} />
@@ -121,7 +128,10 @@ const Footer: React.FC = () => {
           {/* Col 3 — Hỗ trợ */}
           <FooterNavColumn heading={t('support')} links={SUPPORT_LINKS} t={t} />
 
-          {/* Col 4 — Liên hệ */}
+          {/* Col 4 — Quy định */}
+          <FooterNavColumn heading={t('legal')} links={LEGAL_LINKS} t={t} />
+
+          {/* Col 5 — Liên hệ */}
           <div className='space-y-4'>
             <p className='text-2xs font-semibold tracking-widest text-muted-foreground uppercase'>
               {t('contactInfo')}

--- a/src/components/templates/policyTemplate/index.tsx
+++ b/src/components/templates/policyTemplate/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { GraduationCap } from 'lucide-react'
+import { Badge } from '@/components/atoms/badge'
+import { Card } from '@/components/atoms/card'
+import { Typography } from '@/components/atoms/typography'
+import { GuideCard, BulletList } from '@/components/templates/guide/shared'
+
+export type PolicyKey = 'listingRules' | 'terms' | 'privacy' | 'complaints'
+
+// Section order per policy. Content lives in messages/*.json under
+// `policies.<policyKey>.sections.<section>`; the template only owns ordering.
+const POLICY_SECTIONS: Record<PolicyKey, readonly string[]> = {
+  listingRules: ['eligibility', 'content', 'prohibited', 'media', 'moderation'],
+  terms: ['acceptance', 'accounts', 'usage', 'content', 'disclaimer', 'changes'],
+  privacy: ['collection', 'use', 'sharing', 'cookies', 'security', 'rights'],
+  complaints: ['scope', 'channels', 'process', 'time'],
+}
+
+const CONTACT_EMAIL = 'smartrent.tools@gmail.com'
+const BODY_TEXT_CLASS = 'text-sm leading-6 text-muted-foreground'
+
+interface PolicyTemplateProps {
+  policyKey: PolicyKey
+}
+
+const PolicyTemplate: React.FC<PolicyTemplateProps> = ({ policyKey }) => {
+  const t = useTranslations('policies')
+  const sections = POLICY_SECTIONS[policyKey]
+
+  return (
+    <div className='mx-auto w-full max-w-3xl space-y-6 px-4 py-8 sm:space-y-7 sm:py-10'>
+      <Card className='overflow-hidden border-border/60 bg-card/90 shadow-sm'>
+        <div className='space-y-3 px-5 py-6 sm:px-7 sm:py-7'>
+          <Badge
+            variant='outline'
+            className='w-fit gap-1.5 rounded-full border-primary/25 bg-primary/10 px-2.5 py-0.5 text-2xs font-medium text-primary'
+          >
+            <GraduationCap className='h-3.5 w-3.5' />
+            {t('meta.academicBadge')}
+          </Badge>
+          <Typography variant='pageTitle' className='leading-tight'>
+            {t(`${policyKey}.title`)}
+          </Typography>
+          <Typography variant='p' className={`max-w-2xl ${BODY_TEXT_CLASS}`}>
+            {t(`${policyKey}.intro`)}
+          </Typography>
+          <Typography variant='small' className='text-muted-foreground'>
+            {t('meta.updatedLabel')}: {t('meta.updatedDate')}
+          </Typography>
+        </div>
+      </Card>
+
+      {sections.map((section) => {
+        const base = `${policyKey}.sections.${section}`
+        const body = t.raw(`${base}.body`) as string[]
+        const hasBullets = t.has(`${base}.bullets`)
+        const bullets = hasBullets ? (t.raw(`${base}.bullets`) as string[]) : []
+
+        return (
+          <GuideCard key={section} title={t(`${base}.heading`)}>
+            <div className='space-y-3'>
+              {body.map((paragraph, i) => (
+                <Typography
+                  key={`${section}-p-${i}`}
+                  variant='p'
+                  className={BODY_TEXT_CLASS}
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+              {hasBullets && <BulletList items={bullets} />}
+            </div>
+          </GuideCard>
+        )
+      })}
+
+      <Card className='border-primary/20 bg-primary/[0.04] px-5 py-5 sm:px-7'>
+        <Typography variant='small' className='leading-6 text-muted-foreground'>
+          {t('meta.academicNote')}
+        </Typography>
+        <Typography
+          variant='small'
+          className='mt-3 leading-6 text-muted-foreground'
+        >
+          {t('meta.contactPrompt')}{' '}
+          <a
+            href={`mailto:${CONTACT_EMAIL}`}
+            className='text-primary hover:underline'
+          >
+            {CONTACT_EMAIL}
+          </a>
+        </Typography>
+      </Card>
+    </div>
+  )
+}
+
+export default PolicyTemplate

--- a/src/constants/route/index.ts
+++ b/src/constants/route/index.ts
@@ -55,6 +55,10 @@ export const PUBLIC_ROUTES = {
   COMPARE: '/compare',
   NEWS: '/news',
   NEWS_DETAIL: '/news/:slug',
+  POLICY_LISTING_RULES: '/policies/listing-rules',
+  POLICY_TERMS: '/policies/terms',
+  POLICY_PRIVACY: '/policies/privacy',
+  POLICY_COMPLAINTS: '/policies/complaints',
 } as const
 
 export type PublicRouteKey = keyof typeof PUBLIC_ROUTES

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2120,6 +2120,10 @@
     "pricing": "Pricing",
     "paymentGuide": "Payment guide",
     "usageGuide": "Usage guide",
+    "legal": "Policies",
+    "listingRules": "Listing Rules",
+    "termsAgreement": "Terms of Agreement",
+    "complaints": "Complaint Resolution",
     "contactInfo": "Contact",
     "phone": "+84 123 456 789",
     "email": "smartrent.tools@gmail.com",
@@ -2138,6 +2142,249 @@
       "badge": "Academic Project",
       "description": "Capstone thesis at VNU-HCM University of Science. Data is used for research purposes.",
       "requestRemoval": "Request Removal"
+    }
+  },
+  "policies": {
+    "meta": {
+      "academicBadge": "Academic platform",
+      "updatedLabel": "Last updated",
+      "updatedDate": "July 2026",
+      "academicNote": "SmartRent is a demo product built as a capstone thesis at VNU-HCM University of Science and is non-commercial. Some listing data is generated or simulated for demonstration and research purposes.",
+      "contactPrompt": "For any questions about these policies, please contact:"
+    },
+    "listingRules": {
+      "title": "Listing Rules",
+      "seoDescription": "Rules for posting rental property listings on the SmartRent platform.",
+      "intro": "To keep listing quality high and the rental search experience transparent, every listing on SmartRent must follow the rules below.",
+      "sections": {
+        "eligibility": {
+          "heading": "Eligibility to post",
+          "body": [
+            "The person posting must have a valid account on the platform and is responsible for the content they publish.",
+            "The property must be real, actually available for rent, and the poster must have the right or valid authorization to rent it out."
+          ],
+          "bullets": [
+            "Provide accurate contact information (phone number, email).",
+            "Verify your account when requested to increase trust.",
+            "Post only one listing per property to avoid duplicates."
+          ]
+        },
+        "content": {
+          "heading": "Listing content",
+          "body": [
+            "Listing information must be accurate and up to date: rent, area, address, amenities, and related costs such as electricity, water, and services."
+          ],
+          "bullets": [
+            "The title and description must reflect the property truthfully and not be misleading.",
+            "The listed price must be the actual rental price.",
+            "Update or remove the listing once the property has been rented."
+          ]
+        },
+        "prohibited": {
+          "heading": "Prohibited content",
+          "body": [
+            "Violating listings will be hidden or removed; repeat offenders may have their posting rights restricted."
+          ],
+          "bullets": [
+            "Fake or ghost listings, or false information used to lure contact.",
+            "Duplicate content, spam, or reposting the same property multiple times.",
+            "Offensive, discriminatory language or content that violates Vietnamese law.",
+            "Advertising services or products unrelated to property rental."
+          ]
+        },
+        "media": {
+          "heading": "Images and media",
+          "body": [
+            "Images help renters picture the property, so they must be truthful and clear."
+          ],
+          "bullets": [
+            "Use real photos of the property being rented.",
+            "Do not overlay phone numbers, promotional watermarks, or third-party logos on images.",
+            "Do not use images that misrepresent the actual quality or size."
+          ]
+        },
+        "moderation": {
+          "heading": "Moderation and enforcement",
+          "body": [
+            "Listings may be moderated automatically by AI and/or manually, before or after they are displayed.",
+            "Users can report violating listings; the platform will review and act based on severity."
+          ],
+          "bullets": [
+            "A reminder or edit request for minor violations.",
+            "Hiding or removing violating listings.",
+            "Restricting or suspending posting rights for repeat offenders."
+          ]
+        }
+      }
+    },
+    "terms": {
+      "title": "Terms of Agreement",
+      "seoDescription": "Terms of service for using the SmartRent platform.",
+      "intro": "By accessing and using SmartRent, you agree to the terms below. Please read them carefully before using the service.",
+      "sections": {
+        "acceptance": {
+          "heading": "Acceptance of terms",
+          "body": [
+            "Creating an account, posting a listing, or using any feature of the platform means you accept these terms.",
+            "If you do not agree, please stop using the service."
+          ]
+        },
+        "accounts": {
+          "heading": "User accounts",
+          "body": [
+            "You are responsible for keeping your login credentials secure and for all activity that occurs under your account."
+          ],
+          "bullets": [
+            "Provide accurate registration information and keep it current.",
+            "Do not share your account or impersonate others.",
+            "Notify us if you detect unauthorized access."
+          ]
+        },
+        "usage": {
+          "heading": "Rights and obligations of use",
+          "body": [
+            "The platform lets you search, post, and manage rental property listings in accordance with the rules."
+          ],
+          "bullets": [
+            "Do not use the service for unlawful purposes.",
+            "Do not collect other users' data with automated tools without permission.",
+            "Respect the listing rules and other users."
+          ]
+        },
+        "content": {
+          "heading": "User-posted content",
+          "body": [
+            "You retain the rights to the content you post, while granting the platform permission to display, store, and process it to provide the service.",
+            "You are responsible for the legality and accuracy of the content you provide."
+          ]
+        },
+        "disclaimer": {
+          "heading": "Disclaimer",
+          "body": [
+            "SmartRent acts as an intermediary platform connecting landlords and renters; we are not a party to any rental transaction.",
+            "The platform does not guarantee that every listing is fully accurate and is not responsible for agreements or transactions between parties.",
+            "This is a non-commercial capstone thesis product; some data is illustrative."
+          ]
+        },
+        "changes": {
+          "heading": "Changes to the terms",
+          "body": [
+            "We may update these terms over time. The new version takes effect once it is published on this page."
+          ]
+        }
+      }
+    },
+    "privacy": {
+      "title": "Privacy Policy",
+      "seoDescription": "Privacy policy and how SmartRent collects and uses your data.",
+      "intro": "This policy describes how we collect, use, and protect your information when you use SmartRent.",
+      "sections": {
+        "collection": {
+          "heading": "Information we collect",
+          "body": [
+            "We collect information to provide and improve the service."
+          ],
+          "bullets": [
+            "Account information: name, email, phone number, avatar.",
+            "Content you post: rental listings, images, descriptions.",
+            "Usage data: views, searches, and actions on the platform.",
+            "Technical data: device type, browser, and cookies."
+          ]
+        },
+        "use": {
+          "heading": "How we use it",
+          "body": [
+            "Your information is used to operate the platform and deliver a more relevant experience."
+          ],
+          "bullets": [
+            "Display and manage listings, connecting renters with landlords.",
+            "Personalize suggestions and support AI-powered search.",
+            "Send notifications related to your account and listings.",
+            "Analysis and research for the capstone thesis."
+          ]
+        },
+        "sharing": {
+          "heading": "Sharing information",
+          "body": [
+            "We do not sell your personal information.",
+            "Information is shared only to the extent necessary."
+          ],
+          "bullets": [
+            "Contact details you provide are shown publicly on your listings.",
+            "Infrastructure and service providers that support platform operations.",
+            "When there is a lawful request from authorities."
+          ]
+        },
+        "cookies": {
+          "heading": "Cookies and tracking technologies",
+          "body": [
+            "We use cookies and browser storage to keep you signed in, remember preferences, and improve performance. You can manage cookies through your browser settings."
+          ]
+        },
+        "security": {
+          "heading": "Data security",
+          "body": [
+            "We apply reasonable measures to protect your data. However, no system is perfectly secure, and because this is an academic environment you should avoid providing genuinely sensitive data."
+          ]
+        },
+        "rights": {
+          "heading": "Your rights",
+          "body": [
+            "You have the right to control your personal data."
+          ],
+          "bullets": [
+            "Access and edit your account information.",
+            "Request deletion of your account and related data.",
+            "Contact us for support regarding your personal data."
+          ]
+        }
+      }
+    },
+    "complaints": {
+      "title": "Complaint Resolution",
+      "seoDescription": "The process for receiving and resolving complaints on the SmartRent platform.",
+      "intro": "We aim to handle every report transparently and promptly. Below is how to submit a complaint and how it is resolved.",
+      "sections": {
+        "scope": {
+          "heading": "Scope of complaints",
+          "body": [
+            "You can submit complaints related to the following issues."
+          ],
+          "bullets": [
+            "Listings that are false, fraudulent, or violate the rules.",
+            "Inappropriate behavior by other users.",
+            "Technical issues or errors during use."
+          ]
+        },
+        "channels": {
+          "heading": "How to reach us",
+          "body": [
+            "There are two main ways to send a report to us."
+          ],
+          "bullets": [
+            "Use the Report button directly on the violating listing.",
+            "Email smartrent.tools@gmail.com with detailed information."
+          ]
+        },
+        "process": {
+          "heading": "Resolution process",
+          "body": [
+            "Once received, a complaint is handled through the following steps."
+          ],
+          "bullets": [
+            "Step 1: Receive and record the complaint.",
+            "Step 2: Verify the information and the related listing.",
+            "Step 3: Decide on an action such as a reminder, hiding/removing the listing, or restricting the account.",
+            "Step 4: Respond with the outcome to the complainant."
+          ]
+        },
+        "time": {
+          "heading": "Response time",
+          "body": [
+            "We aim to respond within 3 to 5 business days of receiving a complaint with complete information. Complex cases may take longer and will be communicated accordingly."
+          ]
+        }
+      }
     }
   },
   "navigation": {
@@ -4013,7 +4260,7 @@
     "floatingBar": {
       "items": "{count} item",
       "items_plural": "{count} items",
-      "compareNow": "Compare Now"
+      "compareNow": "View Comparison"
     },
     "unavailableDialog": {
       "title": "Some listings are no longer available",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1894,6 +1894,10 @@
     "pricing": "Báo giá",
     "paymentGuide": "Hướng dẫn thanh toán",
     "usageGuide": "Hướng dẫn sử dụng",
+    "legal": "Quy định",
+    "listingRules": "Quy định đăng tin",
+    "termsAgreement": "Điều khoản thỏa thuận",
+    "complaints": "Giải quyết khiếu nại",
     "contactInfo": "Liên hệ",
     "phone": "+84 123 456 789",
     "email": "smartrent.tools@gmail.com",
@@ -1912,6 +1916,249 @@
       "badge": "Dự án học thuật",
       "description": "Đồ án tốt nghiệp tại VNU-HCM University of Science. Dữ liệu phục vụ mục đích nghiên cứu.",
       "requestRemoval": "Yêu cầu gỡ"
+    }
+  },
+  "policies": {
+    "meta": {
+      "academicBadge": "Nền tảng học thuật",
+      "updatedLabel": "Cập nhật lần cuối",
+      "updatedDate": "Tháng 7, 2026",
+      "academicNote": "Thuê Nhà Trọ là sản phẩm demo trong khuôn khổ đồ án tốt nghiệp tại VNU-HCM University of Science, phi thương mại. Một phần dữ liệu tin đăng được tạo hoặc mô phỏng nhằm phục vụ trình diễn và nghiên cứu.",
+      "contactPrompt": "Mọi thắc mắc về các quy định này, vui lòng liên hệ:"
+    },
+    "listingRules": {
+      "title": "Quy định đăng tin",
+      "seoDescription": "Quy định về việc đăng tin cho thuê bất động sản trên nền tảng Thuê Nhà Trọ.",
+      "intro": "Để giữ chất lượng tin đăng và trải nghiệm tìm trọ minh bạch, mọi tin đăng trên Thuê Nhà Trọ cần tuân thủ các quy định dưới đây.",
+      "sections": {
+        "eligibility": {
+          "heading": "Điều kiện đăng tin",
+          "body": [
+            "Người đăng tin phải có tài khoản hợp lệ trên nền tảng và chịu trách nhiệm về nội dung mình đăng.",
+            "Bất động sản được đăng phải có thật, đang trong tình trạng cho thuê và người đăng có quyền cho thuê hoặc được uỷ quyền hợp lệ."
+          ],
+          "bullets": [
+            "Cung cấp thông tin liên hệ chính xác (số điện thoại, email).",
+            "Xác thực tài khoản khi hệ thống yêu cầu để tăng độ tin cậy.",
+            "Mỗi bất động sản chỉ nên đăng một tin để tránh trùng lặp."
+          ]
+        },
+        "content": {
+          "heading": "Nội dung tin đăng",
+          "body": [
+            "Thông tin trong tin đăng phải chính xác và cập nhật: giá thuê, diện tích, địa chỉ, tiện ích và các chi phí đi kèm như điện, nước, dịch vụ."
+          ],
+          "bullets": [
+            "Tiêu đề và mô tả phản ánh đúng bất động sản, không gây hiểu nhầm.",
+            "Giá niêm yết là giá thực tế đang cho thuê.",
+            "Cập nhật hoặc gỡ tin khi bất động sản đã được thuê."
+          ]
+        },
+        "prohibited": {
+          "heading": "Nội dung bị cấm",
+          "body": [
+            "Các tin đăng vi phạm sẽ bị ẩn hoặc gỡ bỏ; tài khoản tái phạm có thể bị hạn chế quyền đăng tin."
+          ],
+          "bullets": [
+            "Tin giả, tin ảo hoặc thông tin sai lệch nhằm câu kéo liên hệ.",
+            "Nội dung trùng lặp, spam hoặc đăng lại nhiều lần cùng một bất động sản.",
+            "Ngôn từ phản cảm, phân biệt đối xử hoặc vi phạm pháp luật Việt Nam.",
+            "Rao bán dịch vụ, sản phẩm không liên quan đến cho thuê bất động sản."
+          ]
+        },
+        "media": {
+          "heading": "Hình ảnh và phương tiện",
+          "body": [
+            "Hình ảnh giúp người thuê hình dung bất động sản, vì vậy cần trung thực và rõ ràng."
+          ],
+          "bullets": [
+            "Sử dụng ảnh thật của bất động sản đang cho thuê.",
+            "Không chèn số điện thoại, watermark quảng cáo hay logo bên thứ ba lên ảnh.",
+            "Không dùng ảnh gây hiểu nhầm về chất lượng hoặc quy mô thực tế."
+          ]
+        },
+        "moderation": {
+          "heading": "Kiểm duyệt và xử lý vi phạm",
+          "body": [
+            "Tin đăng có thể được kiểm duyệt tự động bằng AI và/hoặc thủ công trước hoặc sau khi hiển thị.",
+            "Người dùng có thể báo cáo tin vi phạm; nền tảng sẽ xem xét và xử lý theo mức độ."
+          ],
+          "bullets": [
+            "Nhắc nhở hoặc yêu cầu chỉnh sửa với vi phạm nhẹ.",
+            "Ẩn hoặc gỡ tin đăng vi phạm.",
+            "Hạn chế hoặc khoá quyền đăng tin với tài khoản tái phạm."
+          ]
+        }
+      }
+    },
+    "terms": {
+      "title": "Điều khoản thỏa thuận",
+      "seoDescription": "Điều khoản sử dụng dịch vụ của nền tảng Thuê Nhà Trọ.",
+      "intro": "Khi truy cập và sử dụng Thuê Nhà Trọ, bạn đồng ý với các điều khoản dưới đây. Vui lòng đọc kỹ trước khi sử dụng.",
+      "sections": {
+        "acceptance": {
+          "heading": "Chấp nhận điều khoản",
+          "body": [
+            "Việc bạn tạo tài khoản, đăng tin hoặc sử dụng bất kỳ tính năng nào của nền tảng đồng nghĩa với việc bạn chấp nhận các điều khoản này.",
+            "Nếu không đồng ý, vui lòng ngừng sử dụng dịch vụ."
+          ]
+        },
+        "accounts": {
+          "heading": "Tài khoản người dùng",
+          "body": [
+            "Bạn chịu trách nhiệm bảo mật thông tin đăng nhập và mọi hoạt động diễn ra dưới tài khoản của mình."
+          ],
+          "bullets": [
+            "Cung cấp thông tin đăng ký chính xác và cập nhật khi có thay đổi.",
+            "Không chia sẻ tài khoản hoặc mạo danh người khác.",
+            "Thông báo cho chúng tôi nếu phát hiện truy cập trái phép."
+          ]
+        },
+        "usage": {
+          "heading": "Quyền và nghĩa vụ khi sử dụng",
+          "body": [
+            "Nền tảng cho phép bạn tìm kiếm, đăng và quản lý tin cho thuê bất động sản theo đúng quy định."
+          ],
+          "bullets": [
+            "Không sử dụng dịch vụ cho mục đích trái pháp luật.",
+            "Không thu thập dữ liệu người dùng khác bằng công cụ tự động khi chưa được phép.",
+            "Tôn trọng quy định đăng tin và các người dùng khác."
+          ]
+        },
+        "content": {
+          "heading": "Nội dung do người dùng đăng",
+          "body": [
+            "Bạn giữ quyền đối với nội dung mình đăng, đồng thời cho phép nền tảng hiển thị, lưu trữ và xử lý nội dung đó nhằm cung cấp dịch vụ.",
+            "Bạn chịu trách nhiệm về tính hợp pháp và chính xác của nội dung mình cung cấp."
+          ]
+        },
+        "disclaimer": {
+          "heading": "Miễn trừ trách nhiệm",
+          "body": [
+            "Thuê Nhà Trọ đóng vai trò nền tảng trung gian kết nối người cho thuê và người thuê; chúng tôi không phải một bên trong giao dịch thuê nhà.",
+            "Nền tảng không bảo đảm mọi tin đăng đều chính xác tuyệt đối và không chịu trách nhiệm cho các thỏa thuận, giao dịch giữa các bên.",
+            "Đây là sản phẩm đồ án tốt nghiệp, phi thương mại; một số dữ liệu mang tính minh hoạ."
+          ]
+        },
+        "changes": {
+          "heading": "Thay đổi điều khoản",
+          "body": [
+            "Chúng tôi có thể cập nhật các điều khoản này theo thời gian. Phiên bản mới có hiệu lực kể từ khi được đăng tải trên trang này."
+          ]
+        }
+      }
+    },
+    "privacy": {
+      "title": "Chính sách bảo mật",
+      "seoDescription": "Chính sách bảo mật và cách Thuê Nhà Trọ thu thập, sử dụng dữ liệu của bạn.",
+      "intro": "Chính sách này mô tả cách chúng tôi thu thập, sử dụng và bảo vệ thông tin của bạn khi sử dụng Thuê Nhà Trọ.",
+      "sections": {
+        "collection": {
+          "heading": "Thông tin chúng tôi thu thập",
+          "body": [
+            "Chúng tôi thu thập thông tin để cung cấp và cải thiện dịch vụ."
+          ],
+          "bullets": [
+            "Thông tin tài khoản: họ tên, email, số điện thoại, ảnh đại diện.",
+            "Nội dung bạn đăng: tin cho thuê, hình ảnh, mô tả.",
+            "Dữ liệu sử dụng: lượt xem, tìm kiếm, thao tác trên nền tảng.",
+            "Dữ liệu kỹ thuật: loại thiết bị, trình duyệt và cookie."
+          ]
+        },
+        "use": {
+          "heading": "Mục đích sử dụng",
+          "body": [
+            "Thông tin của bạn được dùng để vận hành nền tảng và mang lại trải nghiệm phù hợp hơn."
+          ],
+          "bullets": [
+            "Hiển thị và quản lý tin đăng, kết nối người thuê với người cho thuê.",
+            "Cá nhân hoá gợi ý và hỗ trợ tìm kiếm bằng AI.",
+            "Gửi thông báo liên quan đến tài khoản và tin đăng.",
+            "Phân tích và nghiên cứu phục vụ đồ án tốt nghiệp."
+          ]
+        },
+        "sharing": {
+          "heading": "Chia sẻ thông tin",
+          "body": [
+            "Chúng tôi không bán thông tin cá nhân của bạn.",
+            "Thông tin chỉ được chia sẻ trong phạm vi cần thiết."
+          ],
+          "bullets": [
+            "Thông tin liên hệ hiển thị công khai trên tin đăng do chính bạn cung cấp.",
+            "Nhà cung cấp hạ tầng và dịch vụ hỗ trợ vận hành nền tảng.",
+            "Khi có yêu cầu hợp pháp từ cơ quan chức năng."
+          ]
+        },
+        "cookies": {
+          "heading": "Cookie và công nghệ theo dõi",
+          "body": [
+            "Chúng tôi sử dụng cookie và bộ nhớ trình duyệt để duy trì đăng nhập, ghi nhớ tuỳ chọn và cải thiện hiệu năng. Bạn có thể quản lý cookie qua cài đặt trình duyệt."
+          ]
+        },
+        "security": {
+          "heading": "Bảo mật dữ liệu",
+          "body": [
+            "Chúng tôi áp dụng các biện pháp hợp lý để bảo vệ dữ liệu. Tuy nhiên, không hệ thống nào an toàn tuyệt đối, và đây là môi trường học thuật nên bạn nên hạn chế cung cấp dữ liệu nhạy cảm thật."
+          ]
+        },
+        "rights": {
+          "heading": "Quyền của bạn",
+          "body": [
+            "Bạn có quyền kiểm soát dữ liệu cá nhân của mình."
+          ],
+          "bullets": [
+            "Truy cập và chỉnh sửa thông tin tài khoản.",
+            "Yêu cầu xoá tài khoản và dữ liệu liên quan.",
+            "Liên hệ để được hỗ trợ về dữ liệu cá nhân."
+          ]
+        }
+      }
+    },
+    "complaints": {
+      "title": "Giải quyết khiếu nại",
+      "seoDescription": "Quy trình tiếp nhận và giải quyết khiếu nại trên nền tảng Thuê Nhà Trọ.",
+      "intro": "Chúng tôi mong muốn xử lý mọi phản ánh một cách minh bạch và kịp thời. Dưới đây là cách gửi và quy trình giải quyết khiếu nại.",
+      "sections": {
+        "scope": {
+          "heading": "Phạm vi khiếu nại",
+          "body": [
+            "Bạn có thể gửi khiếu nại liên quan đến các vấn đề sau."
+          ],
+          "bullets": [
+            "Tin đăng sai sự thật, lừa đảo hoặc vi phạm quy định.",
+            "Hành vi không phù hợp của người dùng khác.",
+            "Sự cố kỹ thuật hoặc lỗi trong quá trình sử dụng."
+          ]
+        },
+        "channels": {
+          "heading": "Kênh tiếp nhận",
+          "body": [
+            "Có hai cách chính để gửi phản ánh tới chúng tôi."
+          ],
+          "bullets": [
+            "Sử dụng nút Báo cáo ngay trên tin đăng vi phạm.",
+            "Gửi email tới smartrent.tools@gmail.com kèm thông tin chi tiết."
+          ]
+        },
+        "process": {
+          "heading": "Quy trình xử lý",
+          "body": [
+            "Sau khi tiếp nhận, khiếu nại sẽ được xử lý theo các bước sau."
+          ],
+          "bullets": [
+            "Bước 1: Tiếp nhận và ghi nhận nội dung khiếu nại.",
+            "Bước 2: Xác minh thông tin và tin đăng liên quan.",
+            "Bước 3: Đưa ra hướng xử lý như nhắc nhở, ẩn/gỡ tin, hạn chế tài khoản.",
+            "Bước 4: Phản hồi kết quả tới người khiếu nại."
+          ]
+        },
+        "time": {
+          "heading": "Thời gian phản hồi",
+          "body": [
+            "Chúng tôi cố gắng phản hồi trong vòng 3 đến 5 ngày làm việc kể từ khi nhận được khiếu nại đầy đủ thông tin. Với các trường hợp phức tạp, thời gian có thể kéo dài hơn và sẽ được thông báo lại."
+          ]
+        }
+      }
     }
   },
   "navigation": {
@@ -4013,7 +4260,7 @@
     "floatingBar": {
       "items": "{count} tin",
       "items_plural": "{count} tin",
-      "compareNow": "So sánh ngay"
+      "compareNow": "Xem So sánh"
     },
     "unavailableDialog": {
       "title": "Một số tin không còn khả dụng",

--- a/src/pages/policies/complaints/index.tsx
+++ b/src/pages/policies/complaints/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import type { NextPageWithLayout } from '@/types/next-page'
+import MainLayout from '@/components/layouts/homePageLayout'
+import SeoHead from '@/components/atoms/seo/SeoHead'
+import { useTranslations } from 'next-intl'
+import PolicyTemplate from '@/components/templates/policyTemplate'
+
+const ComplaintsPage: NextPageWithLayout = () => {
+  const t = useTranslations('policies')
+
+  return (
+    <>
+      <SeoHead
+        title={t('complaints.title')}
+        description={t('complaints.seoDescription')}
+      />
+      <PolicyTemplate policyKey='complaints' />
+    </>
+  )
+}
+
+ComplaintsPage.getLayout = (page: React.ReactNode) => (
+  <MainLayout>{page}</MainLayout>
+)
+
+export default ComplaintsPage

--- a/src/pages/policies/listing-rules/index.tsx
+++ b/src/pages/policies/listing-rules/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import type { NextPageWithLayout } from '@/types/next-page'
+import MainLayout from '@/components/layouts/homePageLayout'
+import SeoHead from '@/components/atoms/seo/SeoHead'
+import { useTranslations } from 'next-intl'
+import PolicyTemplate from '@/components/templates/policyTemplate'
+
+const ListingRulesPage: NextPageWithLayout = () => {
+  const t = useTranslations('policies')
+
+  return (
+    <>
+      <SeoHead
+        title={t('listingRules.title')}
+        description={t('listingRules.seoDescription')}
+      />
+      <PolicyTemplate policyKey='listingRules' />
+    </>
+  )
+}
+
+ListingRulesPage.getLayout = (page: React.ReactNode) => (
+  <MainLayout>{page}</MainLayout>
+)
+
+export default ListingRulesPage

--- a/src/pages/policies/privacy/index.tsx
+++ b/src/pages/policies/privacy/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import type { NextPageWithLayout } from '@/types/next-page'
+import MainLayout from '@/components/layouts/homePageLayout'
+import SeoHead from '@/components/atoms/seo/SeoHead'
+import { useTranslations } from 'next-intl'
+import PolicyTemplate from '@/components/templates/policyTemplate'
+
+const PrivacyPage: NextPageWithLayout = () => {
+  const t = useTranslations('policies')
+
+  return (
+    <>
+      <SeoHead
+        title={t('privacy.title')}
+        description={t('privacy.seoDescription')}
+      />
+      <PolicyTemplate policyKey='privacy' />
+    </>
+  )
+}
+
+PrivacyPage.getLayout = (page: React.ReactNode) => (
+  <MainLayout>{page}</MainLayout>
+)
+
+export default PrivacyPage

--- a/src/pages/policies/terms/index.tsx
+++ b/src/pages/policies/terms/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import type { NextPageWithLayout } from '@/types/next-page'
+import MainLayout from '@/components/layouts/homePageLayout'
+import SeoHead from '@/components/atoms/seo/SeoHead'
+import { useTranslations } from 'next-intl'
+import PolicyTemplate from '@/components/templates/policyTemplate'
+
+const TermsPage: NextPageWithLayout = () => {
+  const t = useTranslations('policies')
+
+  return (
+    <>
+      <SeoHead
+        title={t('terms.title')}
+        description={t('terms.seoDescription')}
+      />
+      <PolicyTemplate policyKey='terms' />
+    </>
+  )
+}
+
+TermsPage.getLayout = (page: React.ReactNode) => <MainLayout>{page}</MainLayout>
+
+export default TermsPage


### PR DESCRIPTION
## Tóm tắt
Thêm 4 trang **Quy định** (public) cho SmartRent và một vài fix UI nhỏ. Nội dung viết mới, **adapt cho scope đồ án** (phi thương mại), song ngữ vi/en.

## Thay đổi
### Trang quy định (mới)
- 4 route public dưới `/policies/*`:
  - `/policies/listing-rules` — Quy định đăng tin
  - `/policies/terms` — Điều khoản thỏa thuận
  - `/policies/privacy` — Chính sách bảo mật
  - `/policies/complaints` — Giải quyết khiếu nại
- 1 `PolicyTemplate` chung render cả 4 trang (dùng lại `GuideCard`/`BulletList`), nội dung nằm trong i18n (`policies.*`), body/bullets là mảng chuỗi.
- Thêm cột **"Quy định"** vào Footer (grid 4 → 5 cột) link tới 4 trang.

### Fix UI nhỏ (đi kèm)
- **Seller profile card**: ô liên hệ (SĐT/Email) trước bị bóp hẹp, label wrap + giá trị bị cắt "0..."/"m.." → cho xếp dọc full-width.
- **Bảng so sánh**: giá + `/tháng` trước tách 2 dòng → gộp về **1 hàng**.
- **CTA thanh so sánh nổi**: đổi "So sánh ngay" → **"Xem So sánh"** (en: "View Comparison").

## Kiểm tra
- `npm run typecheck` → sạch
- `npm run i18n:check` → ✅ 3170 key khớp vi/en
- `eslint` các file đã đụng → 0 lỗi/warning

> Chưa render live trên browser (mới verify tĩnh). Nội dung quy định súc tích, đúng scope đồ án — có thể tinh chỉnh thêm nếu cần.