### PR TITLE
fix(saved-listings): hide expired listings and cap saves at 50

### DIFF
--- a/src/api/types/saved-listing.type.ts
+++ b/src/api/types/saved-listing.type.ts
@@ -74,6 +74,11 @@ export type SavesAnalyticsSearchRequest = {
   size?: number
 }
 
+// ============= LIMITS =============
+
+/** Max number of listings a user may keep in their saved list at once. */
+export const MAX_SAVED_LISTINGS = 50
+
 // ============= QUERY KEYS =============
 
 export const SAVED_LISTING_QUERY_KEYS = {

--- a/src/components/organisms/savedListings/SavedListingsGrid.tsx
+++ b/src/components/organisms/savedListings/SavedListingsGrid.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropertyCard from '@/components/molecules/propertyCard'
 import { SavedListing } from '@/api/types'
+import { isListingPubliclyVisible } from '@/utils/property'
 
 export interface SavedListingsGridProps {
   savedListings: SavedListing[]
@@ -20,7 +21,7 @@ export const SavedListingsGrid: React.FC<SavedListingsGridProps> = ({
     <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8'>
       {savedListings.map((savedListing) => {
         const listing = savedListing.listing
-        if (!listing) return null
+        if (!listing || !isListingPubliclyVisible(listing)) return null
 
         return (
           <PropertyCard

--- a/src/components/templates/savedListingsTemplate/index.tsx
+++ b/src/components/templates/savedListingsTemplate/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { SavedListing } from '@/api/types'
+import { SavedListingService } from '@/api/services'
 import { PUBLIC_ROUTES } from '@/constants/route'
+import { isListingPubliclyVisible } from '@/utils/property'
 import {
   SavedListingsEmptyState,
   SavedListingsHeader,
@@ -20,7 +22,31 @@ import { PageContainer } from '@/components/atoms/pageContainer'
  */
 const SavedListingsContent: React.FC = () => {
   const router = useRouter()
-  const { items, isLoading, pagination } = useListContext<SavedListing>()
+  const { items, isLoading, pagination, removeItem } =
+    useListContext<SavedListing>()
+
+  // Listings that expired/were unpublished after being saved still come back
+  // from the API with full data (the endpoint has no visibility filter), so
+  // silently unsave them once detected — they're filtered from the grid
+  // below regardless, this just stops them from reappearing on next visit.
+  const cleanedUpIdsRef = useRef<Set<number>>(new Set())
+  useEffect(() => {
+    const staleItems = items.filter(
+      (item) =>
+        item.listing &&
+        !isListingPubliclyVisible(item.listing) &&
+        !cleanedUpIdsRef.current.has(item.listingId),
+    )
+
+    staleItems.forEach((item) => {
+      cleanedUpIdsRef.current.add(item.listingId)
+      SavedListingService.unsave(item.listingId)
+        .then(() => removeItem(item.listingId))
+        .catch(() => {
+          cleanedUpIdsRef.current.delete(item.listingId)
+        })
+    })
+  }, [items, removeItem])
   // List context starts with isLoading=false and only flips to true inside a
   // useEffect, so first paint would briefly render the empty state. Track when
   // the first fetch attempt has actually completed and gate the empty state on

--- a/src/hooks/useSavedListings/useSaveListing.ts
+++ b/src/hooks/useSavedListings/useSaveListing.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { SavedListingService } from '@/api/services'
-import { SAVED_LISTING_QUERY_KEYS } from '@/api/types'
+import { MAX_SAVED_LISTINGS, SAVED_LISTING_QUERY_KEYS } from '@/api/types'
 import { toast } from 'sonner'
 import { isAxiosError } from 'axios'
 import { useTranslations } from 'next-intl'
 import { useAuth } from '@/hooks/useAuth'
+
+const SAVED_LISTINGS_LIMIT_REACHED = 'Saved listings limit reached'
 
 /**
  * Hook to save a listing to favorites
@@ -22,6 +24,20 @@ export const useSaveListing = () => {
         toast.error(t('loginRequired'))
         throw new Error('Authentication required')
       }
+
+      // Fetch (or reuse a fresh cached) count so the cap is enforced even
+      // when nothing else on the page has mounted the count query yet.
+      const countResponse = await queryClient.fetchQuery({
+        queryKey: SAVED_LISTING_QUERY_KEYS.count(),
+        queryFn: () => SavedListingService.getCount(),
+        staleTime: 60000,
+      })
+      const currentCount = countResponse?.data ?? 0
+      if (currentCount >= MAX_SAVED_LISTINGS) {
+        toast.warning(t('limitReached', { max: MAX_SAVED_LISTINGS }))
+        throw new Error(SAVED_LISTINGS_LIMIT_REACHED)
+      }
+
       return SavedListingService.save({ listingId })
     },
     onSuccess: (response) => {
@@ -60,10 +76,11 @@ export const useSaveListing = () => {
       })
     },
     onError: (error: unknown) => {
-      // Skip error toast if authentication error (already shown)
+      // Skip error toast if authentication or limit error (already shown)
       if (
         error instanceof Error &&
-        error.message === 'Authentication required'
+        (error.message === 'Authentication required' ||
+          error.message === SAVED_LISTINGS_LIMIT_REACHED)
       ) {
         return
       }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2329,9 +2329,7 @@
         },
         "rights": {
           "heading": "Your rights",
-          "body": [
-            "You have the right to control your personal data."
-          ],
+          "body": ["You have the right to control your personal data."],
           "bullets": [
             "Access and edit your account information.",
             "Request deletion of your account and related data.",
@@ -2358,9 +2356,7 @@
         },
         "channels": {
           "heading": "How to reach us",
-          "body": [
-            "There are two main ways to send a report to us."
-          ],
+          "body": ["There are two main ways to send a report to us."],
           "bullets": [
             "Use the Report button directly on the violating listing.",
             "Email smartrent.tools@gmail.com with detailed information."
@@ -4189,7 +4185,8 @@
       "unsaveFailed": "Failed to remove listing",
       "loginRequired": "Please login to save listings",
       "alreadySaved": "Listing already saved",
-      "notFound": "Listing not found"
+      "notFound": "Listing not found",
+      "limitReached": "You can only save up to {max} listings. Remove one to save another."
     },
     "tooltip": {
       "save": "Save this listing",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2103,9 +2103,7 @@
         },
         "rights": {
           "heading": "Quyền của bạn",
-          "body": [
-            "Bạn có quyền kiểm soát dữ liệu cá nhân của mình."
-          ],
+          "body": ["Bạn có quyền kiểm soát dữ liệu cá nhân của mình."],
           "bullets": [
             "Truy cập và chỉnh sửa thông tin tài khoản.",
             "Yêu cầu xoá tài khoản và dữ liệu liên quan.",
@@ -2121,9 +2119,7 @@
       "sections": {
         "scope": {
           "heading": "Phạm vi khiếu nại",
-          "body": [
-            "Bạn có thể gửi khiếu nại liên quan đến các vấn đề sau."
-          ],
+          "body": ["Bạn có thể gửi khiếu nại liên quan đến các vấn đề sau."],
           "bullets": [
             "Tin đăng sai sự thật, lừa đảo hoặc vi phạm quy định.",
             "Hành vi không phù hợp của người dùng khác.",
@@ -2132,9 +2128,7 @@
         },
         "channels": {
           "heading": "Kênh tiếp nhận",
-          "body": [
-            "Có hai cách chính để gửi phản ánh tới chúng tôi."
-          ],
+          "body": ["Có hai cách chính để gửi phản ánh tới chúng tôi."],
           "bullets": [
             "Sử dụng nút Báo cáo ngay trên tin đăng vi phạm.",
             "Gửi email tới smartrent.tools@gmail.com kèm thông tin chi tiết."
@@ -4189,7 +4183,8 @@
       "unsaveFailed": "Không thể bỏ lưu tin",
       "loginRequired": "Vui lòng đăng nhập để lưu tin",
       "alreadySaved": "Tin đã được lưu trước đó",
-      "notFound": "Không tìm thấy tin đăng"
+      "notFound": "Không tìm thấy tin đăng",
+      "limitReached": "Bạn chỉ có thể lưu tối đa {max} tin. Hãy bỏ lưu một tin để lưu tin khác."
     },
     "tooltip": {
       "save": "Lưu tin này",

--- a/src/pages/listing-detail/[...slug].tsx
+++ b/src/pages/listing-detail/[...slug].tsx
@@ -6,15 +6,9 @@ import DetailPostTemplate from '@/components/templates/detailPostTemplate'
 import SeoHead from '@/components/atoms/seo/SeoHead'
 import { ListingNotFound } from '@/components/molecules/listingNotFound'
 import type { ListingDetail } from '@/api/types'
-import { POST_STATUS } from '@/api/types'
 import { ListingService } from '@/api/services'
 import { PUBLIC_ROUTES } from '@/constants'
-
-const PUBLICLY_VISIBLE_STATUSES = new Set([
-  POST_STATUS.DISPLAYING,
-  POST_STATUS.EXPIRING_SOON,
-  POST_STATUS.VERIFIED,
-])
+import { isListingPubliclyVisible } from '@/utils/property'
 
 interface ListingDetailProps {
   listing?: ListingDetail
@@ -122,12 +116,7 @@ export async function getServerSideProps(context: {
     return { props: { listingNotFound: true } }
   }
 
-  const isVisible =
-    !listing.expired &&
-    (!listing.listingStatus ||
-      PUBLICLY_VISIBLE_STATUSES.has(listing.listingStatus))
-
-  if (!isVisible) {
+  if (!isListingPubliclyVisible(listing)) {
     return { props: { listingNotFound: true } }
   }
 

--- a/src/utils/property/index.ts
+++ b/src/utils/property/index.ts
@@ -14,3 +14,8 @@ export {
   getFurnishingTranslationKey,
   FURNISHING_TRANSLATION_KEYS,
 } from './furnishing'
+export {
+  isListingPubliclyVisible,
+  PUBLICLY_VISIBLE_STATUSES,
+} from './listingVisibility'
+export type { ListingVisibilityFields } from './listingVisibility'

--- a/src/utils/property/listingVisibility.ts
+++ b/src/utils/property/listingVisibility.ts
@@ -1,0 +1,28 @@
+import { POST_STATUS, PostStatus } from '@/api/types'
+
+export const PUBLICLY_VISIBLE_STATUSES = new Set<PostStatus>([
+  POST_STATUS.DISPLAYING,
+  POST_STATUS.EXPIRING_SOON,
+  POST_STATUS.VERIFIED,
+])
+
+export interface ListingVisibilityFields {
+  expired?: boolean
+  listingStatus?: PostStatus
+}
+
+/**
+ * Mirrors the visibility gate the listing-detail page applies server-side
+ * (getListingById in the backend), so lists built from data that skips that
+ * gate (e.g. saved listings) can filter out expired/unpublished listings too.
+ */
+export const isListingPubliclyVisible = (
+  listing?: ListingVisibilityFields | null,
+): boolean => {
+  if (!listing) return false
+  if (listing.expired) return false
+  return (
+    !listing.listingStatus ||
+    PUBLICLY_VISIBLE_STATUSES.has(listing.listingStatus)
+  )
+}


### PR DESCRIPTION
Saved listings never checked the listing's status, so an expired/ unpublished listing kept showing full details in "Tin đã lưu" even though opening it landed on "Bài đăng không tồn tại". Filter the grid using the same visibility rule the detail page enforces, and silently unsave any stale entries found so they don't keep reappearing. Also cap saving at 50 listings per user, matching the compare list's existing limit pattern.