### PR TITLE
feat(contact): route phone buttons to Zalo chat links

### DIFF
--- a/src/components/molecules/CardListingAIDetail/index.tsx
+++ b/src/components/molecules/CardListingAIDetail/index.tsx
@@ -396,11 +396,20 @@ export const CardListingAIDetail: React.FC<CardListingAIDetailProps> = ({
             variant='outline'
             size='icon'
             className='h-9 w-9 flex-shrink-0 rounded-lg'
-            aria-label={t('call')}
+            aria-label={t('chatZalo')}
           >
-            <a href={`tel:${cleanPhone}`} onClick={(e) => e.stopPropagation()}>
-              <Phone
-                className='w-4 h-4 text-muted-foreground'
+            <a
+              href={`https://zalo.me/${cleanPhone.replace(/\D/g, '')}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Image
+                src='/svg/zalo.svg'
+                alt='Zalo'
+                width={16}
+                height={16}
+                className='w-4 h-4'
                 aria-hidden='true'
               />
             </a>

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -40,13 +40,16 @@ const processListingIds = (text: string): string => {
   )
 }
 
-// Convert phone numbers to tel: links
+// Convert phone numbers to Zalo chat links
 const processPhoneNumbers = (text: string): string => {
   return text.replace(
     /(?:SĐT|Điện thoại|Phone|Tel)[:\s]*(\+?[\d\s.-]{9,15})/gi,
     (match, phone) => {
-      const cleanPhone = phone.replace(/[\s.-]/g, '').trim()
-      return match.replace(phone, `[${phone.trim()}](tel:${cleanPhone})`)
+      const zaloPhone = phone.replace(/\D/g, '')
+      return match.replace(
+        phone,
+        `[${phone.trim()}](https://zalo.me/${zaloPhone})`,
+      )
     },
   )
 }
@@ -69,10 +72,12 @@ const renderLink = (
   children: React.ReactNode,
   props: Record<string, unknown>,
 ) => {
-  if (href?.startsWith('tel:')) {
+  if (href?.startsWith('https://zalo.me/')) {
     return (
       <a
         href={href}
+        target='_blank'
+        rel='noopener noreferrer'
         className='text-primary font-medium hover:underline'
         onClick={(e) => e.stopPropagation()}
         {...props}

--- a/src/components/molecules/aiChatContactCard/index.tsx
+++ b/src/components/molecules/aiChatContactCard/index.tsx
@@ -80,7 +80,9 @@ const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
       <div className='p-2 space-y-0.5'>
         {phone && (
           <a
-            href={`tel:${phone.replace(/[\s.-]/g, '')}`}
+            href={`https://zalo.me/${phone.replace(/\D/g, '')}`}
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent transition-colors'
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/components/molecules/sellerPublicProfileCard/index.tsx
+++ b/src/components/molecules/sellerPublicProfileCard/index.tsx
@@ -100,7 +100,6 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
     seller?.contactPhoneNumber ||
     `${seller?.phoneCode || ''} ${seller?.phoneNumber || ''}`.trim()
 
-  const dialPhone = phone.replace(/\s+/g, '')
   const zaloPhone =
     `${seller?.phoneCode || ''}${seller?.phoneNumber || ''}`.replace(/\D/g, '')
 
@@ -118,9 +117,9 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
       masked: maskPhoneNumber(phone),
       copyText: phone,
       copySuccess: t('profile.copiedPhone'),
-      actionHref: `tel:${dialPhone}`,
+      actionHref: `https://zalo.me/${phone.replace(/\D/g, '')}`,
       actionIcon: <Phone className='h-4 w-4' />,
-      actionLabel: t('profile.actions.call'),
+      actionLabel: t('profile.actions.chatZalo'),
     })
   }
   if (hasEmail && seller?.email) {
@@ -216,7 +215,12 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
                       variant='ghost'
                       className='h-8 w-8 text-primary hover:bg-primary/10'
                     >
-                      <a href={item.actionHref} aria-label={item.actionLabel}>
+                      <a
+                        href={item.actionHref}
+                        target='_blank'
+                        rel='noreferrer'
+                        aria-label={item.actionLabel}
+                      >
                         {item.actionIcon}
                       </a>
                     </Button>

--- a/src/components/organisms/footer/index.tsx
+++ b/src/components/organisms/footer/index.tsx
@@ -140,7 +140,9 @@ const Footer: React.FC = () => {
               <div className='flex items-center gap-2.5'>
                 <Phone className='w-4 h-4 flex-shrink-0 text-muted-foreground' />
                 <a
-                  href={`tel:${t('phone').replaceAll(' ', '')}`}
+                  href={`https://zalo.me/${t('phone').replace(/\D/g, '')}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
                   className='text-sm text-muted-foreground hover:text-foreground transition-colors tabular-nums'
                 >
                   {t('phone')}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -81,6 +81,7 @@
       "year": "year",
       "available": "Available",
       "call": "Call",
+      "chatZalo": "Chat via Zalo",
       "noPhone": "No phone number",
       "prevImage": "Previous image",
       "nextImage": "Next image",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -81,6 +81,7 @@
       "year": "năm",
       "available": "Trống",
       "call": "Gọi điện",
+      "chatZalo": "Nhắn Zalo",
       "noPhone": "Không có số điện thoại",
       "prevImage": "Ảnh trước",
       "nextImage": "Ảnh sau",


### PR DESCRIPTION
## What
All contact **phone buttons** that opened a `tel:` dialer now open a **Zalo chat** instead — `https://zalo.me/<digits>`, in a new tab. This matches the Zalo convention already used across the app (e.g. `SellerContact`, the existing Zalo rows) and shipped by the backend (`ownerZaloLink`, support `zaloLink`).

## Changes
| File | Change |
|---|---|
| `aiChatContactCard` | Phone row → Zalo (number stays visible, opens Zalo) |
| `sellerPublicProfileCard` | Contact-item action → Zalo; label → `chatZalo`; dropped now-unused `dialPhone` |
| `CardListingAIDetail` | Call icon button → Zalo action (Zalo logo + `chatZalo` aria-label) |
| `aiChatBubble` | Phone numbers linkified in AI chat text now produce Zalo links |
| `footer` | Support hotline → Zalo |
| `messages/en.json`, `vi.json` | Added `chat.listing.chatZalo` |

## Deliberately unchanged
- The listing-detail `SellerContact` **"Hiện số / Gọi điện"** button (reveals the number; not a `tel:` link, and a Zalo button already sits beside it).
- `createPostDraftGuard`'s `tel:` whitelist (guard logic; Zalo `https://` links are already whitelisted).

## Verification
- `npm run i18n:check` ✅ · `npm run typecheck` ✅ · `eslint` on touched files ✅ (0/0)
- Pre-commit hooks (typecheck + i18n + lint-staged) passed.