### PR TITLE
feat: search and filter my listings by exact ID

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -573,6 +573,8 @@ export interface ListingFilterRequest {
   amenityIds?: number[]
 
   keyword?: string
+  /** Exact match on listing ID. */
+  id?: number
 
   page?: number
   size?: number
@@ -637,6 +639,8 @@ export interface ListingSearchApiRequest {
   amenityIds?: number[]
 
   keyword?: string
+  /** Exact match on listing ID (PK lookup). */
+  id?: number
 
   // Backend uses these for pagination
   page?: number

--- a/src/components/molecules/mobileFilter/mainView.tsx
+++ b/src/components/molecules/mobileFilter/mainView.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import RadioRow from '@/components/atoms/mobileFilter/radioRow'
 import ToggleChip from '@/components/atoms/mobileFilter/toggleChip'
+import { Input } from '@/components/atoms/input'
 // Location filter retired — the "Vị trí của bạn" toggle is hidden from the
 // dialog. Import/handler kept commented so it can be re-enabled in one change.
 // import LocationToggleChip from '@/components/atoms/mobileFilter/locationToggleChip'
@@ -24,6 +25,7 @@ import {
   Receipt,
   MapIcon,
   Tag,
+  Hash,
 } from 'lucide-react'
 import { ListingFilterRequest } from '@/api/types'
 import { LISTING_TYPE } from '@/api/types/property.type'
@@ -36,6 +38,10 @@ interface MobileFilterMainViewProps {
   hideVerifiedFilter?: boolean
   hideBrokerFilter?: boolean
   hideViewMapButton?: boolean
+  // Only meaningful for the owner's "My Listings" management view — the
+  // public marketplace filter (homepage/residentialProperties) shares this
+  // component and must not surface an internal listing-ID field to visitors.
+  showListingIdFilter?: boolean
 }
 
 const MobileFilterMainView: React.FC<MobileFilterMainViewProps> = ({
@@ -45,6 +51,7 @@ const MobileFilterMainView: React.FC<MobileFilterMainViewProps> = ({
   hideVerifiedFilter = false,
   hideBrokerFilter = false,
   hideViewMapButton = false,
+  showListingIdFilter = false,
 }) => {
   const t = useTranslations('residentialFilter')
 
@@ -79,6 +86,28 @@ const MobileFilterMainView: React.FC<MobileFilterMainViewProps> = ({
               <MapIcon className='h-4 w-4 mr-2' /> {t('actions.viewMap')}
             </Button>
           </Link>
+        </div>
+      )}
+
+      {/* Exact listing ID — owner "My Listings" only, see showListingIdFilter */}
+      {showListingIdFilter && (
+        <div className='p-4 pb-2'>
+          <ToggleSection
+            icon={<Hash className='h-4 w-4 text-muted-foreground' />}
+            title={t('fields.listingId')}
+          >
+            <Input
+              type='text'
+              inputMode='numeric'
+              placeholder={t('fields.listingIdPlaceholder')}
+              value={filters.id ?? ''}
+              onChange={(e) => {
+                const digits = e.target.value.replace(/[^0-9]/g, '')
+                onUpdate({ id: digits ? Number(digits) : undefined })
+              }}
+              className='h-9'
+            />
+          </ToggleSection>
         </div>
       )}
 

--- a/src/components/molecules/residentialFilterDialog/index.tsx
+++ b/src/components/molecules/residentialFilterDialog/index.tsx
@@ -33,6 +33,7 @@ interface ResidentialFilterDialogProps {
   hideVerifiedFilter?: boolean
   hideBrokerFilter?: boolean
   hideViewMapButton?: boolean
+  showListingIdFilter?: boolean
 }
 
 type ViewKey =
@@ -57,6 +58,7 @@ const ResidentialFilterDialog: React.FC<ResidentialFilterDialogProps> = ({
   hideVerifiedFilter = false,
   hideBrokerFilter = false,
   hideViewMapButton = false,
+  showListingIdFilter = false,
 }) => {
   const t = useTranslations('residentialFilter')
   const router = useRouter()
@@ -243,6 +245,7 @@ const ResidentialFilterDialog: React.FC<ResidentialFilterDialogProps> = ({
             hideVerifiedFilter={hideVerifiedFilter}
             hideBrokerFilter={hideBrokerFilter}
             hideViewMapButton={hideViewMapButton}
+            showListingIdFilter={showListingIdFilter}
           />
         )
     }

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -532,6 +532,7 @@ const FilterDialogWrapper: React.FC<{
       hideVerifiedFilter
       hideBrokerFilter
       hideViewMapButton
+      showListingIdFilter
     />
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2469,6 +2469,10 @@
       "video": "Has video",
       "has360": "Has 3D/360°"
     },
+    "fields": {
+      "listingId": "Listing ID",
+      "listingIdPlaceholder": "Enter listing ID"
+    },
     "dropdowns": {
       "propertyType": "Property Type",
       "priceRange": "Price Range",
@@ -2888,7 +2892,7 @@
         "reasonLabel": "Reason for restriction"
       },
       "toolbar": {
-        "searchPlaceholder": "Search listings...",
+        "searchPlaceholder": "Search by title or listing ID...",
         "filter": "Filter",
         "type": "Type",
         "listingType": "Listing Type",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2241,6 +2241,10 @@
       "video": "Có video",
       "has360": "Có 3D/360°"
     },
+    "fields": {
+      "listingId": "ID tin đăng",
+      "listingIdPlaceholder": "Nhập ID tin đăng"
+    },
     "dropdowns": {
       "propertyType": "Loại nhà đất",
       "priceRange": "Khoảng giá",
@@ -2886,7 +2890,7 @@
         "reasonLabel": "Lý do bị chặn"
       },
       "toolbar": {
-        "searchPlaceholder": "Tìm kiếm tin...",
+        "searchPlaceholder": "Tìm theo tiêu đề hoặc ID tin đăng...",
         "filter": "Lọc",
         "type": "Loại",
         "listingType": "Nhu cầu",

--- a/src/pages/seller/listings/index.tsx
+++ b/src/pages/seller/listings/index.tsx
@@ -107,6 +107,7 @@ const ListingsPage: NextPageWithLayout = () => {
           categoryId: filters.categoryId ?? null,
           productType: filters.productType ?? null,
           keyword: filters.keyword || null,
+          id: filters.id ?? null,
           minPrice: filters.minPrice ?? null,
           maxPrice: filters.maxPrice ?? null,
           minArea: filters.minArea ?? null,

--- a/src/utils/property/mapListingResponse.ts
+++ b/src/utils/property/mapListingResponse.ts
@@ -110,6 +110,7 @@ export function mapFrontendToBackendRequest(
     serviceFee: frontendFilter?.serviceFee,
     amenityIds: frontendFilter?.amenityIds,
     keyword: frontendFilter?.keyword,
+    id: frontendFilter?.id,
     // Public browse (no userId) must exclude expired listings so the
     // listing-page total matches the homepage category/location counts,
     // which always exclude expired. For owner "my listings" (userId set)

--- a/src/utils/queryParams/index.ts
+++ b/src/utils/queryParams/index.ts
@@ -126,6 +126,9 @@ export function getFiltersFromQuery(
     filters.keyword = keywordParam
   }
 
+  // Exact listing ID
+  filters.id = parseNumberParam(query, 'id')
+
   // Price range
   filters.minPrice = parseNumberParam(query, 'minPrice')
   filters.maxPrice = parseNumberParam(query, 'maxPrice')


### PR DESCRIPTION
Mirrors the admin panel's listing-ID search on the seller's "My Listings" page: the quick-search box now also matches by exact listing ID (numeric keyword, handled server-side), the URL/query-param round-trip carries `id`, and the advanced filter dialog gets a dedicated ID field — gated behind a new showListingIdFilter prop so it stays off the shared public marketplace filter (homepage/residentialProperties), which reuses the same dialog component.