### PR TITLE
fix(recently-viewed): refresh UI after initial server fetch

### DIFF
--- a/src/hooks/useRecentlyViewed/index.ts
+++ b/src/hooks/useRecentlyViewed/index.ts
@@ -41,6 +41,15 @@ export const useRecentlyViewed = () => {
     gcTime: 5 * 60 * 1000, // 5 minutes
   })
 
+  // queryFn already wrote the server-filtered list into localStorage;
+  // bump updateTrigger so the localStorage-backed memo below re-reads it
+  // instead of continuing to show whatever was cached before this resolved.
+  useEffect(() => {
+    if (apiData !== undefined) {
+      setUpdateTrigger((prev) => prev + 1)
+    }
+  }, [apiData])
+
   // Sync mutation - sync localStorage with server
   const syncMutation = useMutation({
     mutationFn: async (localData: RecentlyViewedListing[]) => {


### PR DESCRIPTION
The GET query already wrote the server-filtered list into localStorage, but nothing bumped updateTrigger on that resolution, so the UI kept rendering whatever was cached before the fetch completed - including listings deleted/unpublished since the last visit. Only navigating to a second listing (which explicitly calls refresh()) picked it up.