### PR TITLE
fix: route notification clicks to the correct page per type

### DIFF
--- a/src/api/types/notification.type.ts
+++ b/src/api/types/notification.type.ts
@@ -12,6 +12,7 @@ export type NotificationType =
   | 'REPORT_RESOLVED'
   | 'REPORT_REJECTED'
   | 'REPORT_ACTION_REQUIRED'
+  | 'REPORT_LISTING_REMOVED'
   // Moderation flow
   | 'LISTING_APPROVED'
   | 'LISTING_REJECTED'
@@ -20,16 +21,21 @@ export type NotificationType =
   | 'LISTING_RESUBMITTED'
   // Listing lifecycle — daily aggregate sent by the expiring-listing scheduler
   | 'LISTING_EXPIRING'
+  // A followed seller published a new listing
+  | 'NEW_LISTING_FROM_FOLLOWED_USER'
+  // Membership lifecycle — daily aggregate sent by the membership-expiry scheduler
+  | 'MEMBERSHIP_EXPIRING'
 
 /**
- * Reference type for navigation. `LISTING_DAILY_SUMMARY` is the aggregate-summary
- * marker used by the expiring-listing scheduler — it has no specific listing id
- * and should route the user to their listings management page.
+ * Reference type for navigation. `LISTING_DAILY_SUMMARY` and
+ * `MEMBERSHIP_DAILY_SUMMARY` are aggregate-summary markers used by their
+ * respective schedulers — they have no specific listing/membership id.
  */
 export type NotificationReferenceType =
   | 'LISTING'
   | 'REPORT'
   | 'LISTING_DAILY_SUMMARY'
+  | 'MEMBERSHIP_DAILY_SUMMARY'
 
 /**
  * Notification entity from API / WebSocket

--- a/src/components/molecules/notificationPanel/NotificationIcon.tsx
+++ b/src/components/molecules/notificationPanel/NotificationIcon.tsx
@@ -10,6 +10,9 @@ import {
   Ban,
   RotateCcw,
   Clock,
+  Trash2,
+  UserPlus,
+  CreditCard,
 } from 'lucide-react'
 
 /**
@@ -66,6 +69,21 @@ export function getNotificationIcon(type: NotificationType) {
       return {
         icon: AlertTriangle,
         className: 'text-orange-600',
+      }
+    case 'REPORT_LISTING_REMOVED':
+      return {
+        icon: Trash2,
+        className: 'text-red-600',
+      }
+    case 'NEW_LISTING_FROM_FOLLOWED_USER':
+      return {
+        icon: UserPlus,
+        className: 'text-blue-500',
+      }
+    case 'MEMBERSHIP_EXPIRING':
+      return {
+        icon: CreditCard,
+        className: 'text-amber-500',
       }
     default:
       return {

--- a/src/components/molecules/notificationPanel/index.tsx
+++ b/src/components/molecules/notificationPanel/index.tsx
@@ -22,7 +22,11 @@ import { useIsMobile } from '@/hooks/useIsMobile'
 import { useNotifications } from '@/hooks/useNotifications'
 import type { NotificationItem } from '@/api/types/notification.type'
 import { NotificationItemCard } from './NotificationItemCard'
-import { buildSellerListingsRoute } from '@/constants/route'
+import {
+  buildApartmentDetailRoute,
+  buildSellerListingsRoute,
+  SELLERNET_ROUTES,
+} from '@/constants/route'
 
 const NotificationPanel: React.FC = () => {
   const t = useTranslations('notification')
@@ -61,11 +65,31 @@ const NotificationPanel: React.FC = () => {
       if (!notification.isRead) {
         markAsRead(notification.id)
       }
-      // Both the daily expiring-listing summary and moderation notifications
-      // (approved/rejected/revision required/suspended/resubmitted) concern
-      // the seller's own listing, which may not be publicly viewable (e.g.
-      // rejected/suspended) — route to the seller's listings management page
-      // rather than the public listing-detail page.
+
+      // A new listing from a followed seller belongs to someone else — send
+      // the user to the public listing-detail page, not their own seller
+      // listings management page.
+      if (
+        notification.type === 'NEW_LISTING_FROM_FOLLOWED_USER' &&
+        notification.referenceId
+      ) {
+        setOpen(false)
+        router.push(buildApartmentDetailRoute(String(notification.referenceId)))
+        return
+      }
+
+      if (notification.referenceType === 'MEMBERSHIP_DAILY_SUMMARY') {
+        setOpen(false)
+        router.push(SELLERNET_ROUTES.MEMBERSHIP_STATUS)
+        return
+      }
+
+      // The daily expiring-listing summary and moderation/report
+      // notifications about the seller's own listing (approved/rejected/
+      // revision required/suspended/resubmitted/reported/removed) concern a
+      // listing that may not be publicly viewable (e.g. rejected/suspended)
+      // — route to the seller's listings management page rather than the
+      // public listing-detail page.
       if (
         notification.referenceType === 'LISTING_DAILY_SUMMARY' ||
         notification.referenceType === 'LISTING'

--- a/src/constants/route/index.ts
+++ b/src/constants/route/index.ts
@@ -20,6 +20,7 @@ export const SELLERNET_ROUTES = {
   POST_DRAFTS: '/seller/drafts',
   POST_SPONSORED: '/sellernet/post/sponsored',
   CUSTOMERS: '/seller/customers', // Redirect to seller layout
+  MEMBERSHIP_STATUS: '/sellernet/membership',
   MEMBERSHIP_REGISTER: '/sellernet/membership/register',
   PUSH_DETAILS: '/sellernet/push',
   PRO_REGISTER: '/sellernet/pro/register',


### PR DESCRIPTION
handleNotificationClick only branched on referenceType, so any new notification type sharing referenceType: LISTING would silently be misrouted to the seller listings page. Switch the follow-listing and membership cases to branch on type first, and wire up two types that had no navigation at all:

- NEW_LISTING_FROM_FOLLOWED_USER -> public listing detail page (it's someone else's listing, not the seller's own)
- MEMBERSHIP_EXPIRING -> membership status page

Moderation and report-about-own-listing types keep routing to /seller/listings as before.