### PR TITLE
fix: remove VAT included line from package selection step

### DIFF
--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -671,11 +671,6 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
                 ? t('freePosting')
                 : `${totalPrice.toLocaleString('vi-VN')} đ`}
             </Typography>
-            {!useMembership && (
-              <Typography variant='muted' className='text-xs mt-1'>
-                {t('vatIncluded')}
-              </Typography>
-            )}
           </Card>
         </Card>
       </CardContent>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1177,7 +1177,6 @@
         "selectedPackage": "Package type",
         "duration": "Duration",
         "totalAmount": "Total",
-        "vatIncluded": "VAT included",
         "packagePrice": "Package price",
         "priceBreakdown": "Price Breakdown",
         "promotionApplied": "Benefit applied",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1177,7 +1177,6 @@
         "selectedPackage": "Loại tin",
         "duration": "Thời hạn",
         "totalAmount": "Tổng cộng",
-        "vatIncluded": "Đã bao gồm VAT",
         "packagePrice": "Giá gói",
         "priceBreakdown": "Chi tiết thanh toán",
         "promotionApplied": "Quyền lợi được áp dụng",


### PR DESCRIPTION
The "VAT included" note under the total price no longer applies to the package selection summary and was left over from an earlier layout.