### PR TITLE
Rename REMOVED moderation status label from "permanently removed" to …

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2918,7 +2918,7 @@
         "MOD_REJECTED": "Rejected",
         "MOD_REVISION_REQUIRED": "Revision Required",
         "MOD_SUSPENDED": "Temporarily Hidden",
-        "MOD_REMOVED": "Permanently Removed"
+        "MOD_REMOVED": "Suspended"
       },
       "propertyTypes": {
         "0": "All Types",
@@ -3165,7 +3165,7 @@
         "REVISION_REQUIRED": "Revision Required",
         "RESUBMITTED": "Resubmitted",
         "SUSPENDED": "Temporarily Hidden",
-        "REMOVED": "Permanently Removed"
+        "REMOVED": "Suspended"
       },
       "banner": {
         "rejectedTitle": "Listing Rejected",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2916,7 +2916,7 @@
         "MOD_REJECTED": "Đã từ chối",
         "MOD_REVISION_REQUIRED": "Cần chỉnh sửa",
         "MOD_SUSPENDED": "Đang ẩn tạm thời",
-        "MOD_REMOVED": "Đã gỡ vĩnh viễn"
+        "MOD_REMOVED": "Bị đình chỉ"
       },
       "propertyTypes": {
         "0": "Tất cả Loại",
@@ -3163,7 +3163,7 @@
         "REVISION_REQUIRED": "Cần chỉnh sửa",
         "RESUBMITTED": "Đã gửi lại",
         "SUSPENDED": "Đang ẩn tạm thời",
-        "REMOVED": "Đã gỡ vĩnh viễn"
+        "REMOVED": "Bị đình chỉ"
       },
       "banner": {
         "rejectedTitle": "Bài đăng bị từ chối",


### PR DESCRIPTION
…"suspended"

Seller listings page badge showed "Đã gỡ vĩnh viễn" / "Permanently Removed" for moderationStatus=REMOVED, which doesn't match how the status is actually used. Updated to "Bị đình chỉ" / "Suspended" in both the listing filter status map and the moderation status badge map.