### PR TITLE
Fix stale "permanently removed" wording in removed-listing banner

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3176,7 +3176,7 @@
         "hiddenMessage": "An admin has temporarily hidden this listing while a report is under review. It will reappear automatically once resolved — no action needed from you.",
         "cannotEditNote": "You can't edit or resubmit this listing.",
         "noReasonProvided": "This listing was rejected. The admin didn't provide a specific reason.",
-        "permanentlyRemovedTitle": "Listing Permanently Removed",
+        "permanentlyRemovedTitle": "Listing Suspended",
         "adminNoteLabel": "Note from admin",
         "editAndResubmit": "Edit & Resubmit",
         "resubmitDirectly": "Resubmit Now",
@@ -3204,7 +3204,7 @@
         "successTitle": "Resubmitted Successfully",
         "successDescription": "Your listing has been updated and resubmitted for review. It is now awaiting admin approval.",
         "error": "Failed to resubmit listing",
-        "notAllowed": "This listing has been permanently removed and cannot be resubmitted."
+        "notAllowed": "This listing has been suspended and cannot be resubmitted."
       }
     },
     "drafts": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3174,7 +3174,7 @@
         "hiddenMessage": "Quản trị viên đã tạm ẩn bài đăng này để xem xét báo cáo. Bài đăng sẽ tự động hiển thị lại sau khi xử lý xong, bạn không cần thao tác gì.",
         "cannotEditNote": "Bạn không thể chỉnh sửa hoặc gửi lại bài đăng này.",
         "noReasonProvided": "Bài đăng đã bị từ chối. Quản trị viên chưa cung cấp lý do cụ thể.",
-        "permanentlyRemovedTitle": "Bài đăng đã bị gỡ vĩnh viễn",
+        "permanentlyRemovedTitle": "Bài đăng đã bị đình chỉ",
         "adminNoteLabel": "Ghi chú từ quản trị viên",
         "editAndResubmit": "Chỉnh sửa và gửi lại",
         "resubmitDirectly": "Gửi lại ngay",
@@ -3202,7 +3202,7 @@
         "successTitle": "Đã gửi lại thành công",
         "successDescription": "Tin đăng của bạn đã được cập nhật và gửi lại để duyệt. Hiện đang chờ quản trị viên phê duyệt.",
         "error": "Không thể gửi lại bài đăng",
-        "notAllowed": "Tin đăng này đã bị gỡ vĩnh viễn và không thể gửi lại."
+        "notAllowed": "Tin đăng này đã bị đình chỉ và không thể gửi lại."
       }
     },
     "drafts": {


### PR DESCRIPTION
The banner and resubmit-blocked toast for moderationStatus=REMOVED still said "gỡ vĩnh viễn" / "permanently removed", left over from before REMOVED was redefined to mean suspended (see 28da1d1). Updated both to match the badge's "đình chỉ" / "Suspended" wording.