### PR TITLE
fix(create-post): publish through the draft so the server can clean it up

### DIFF
--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -15,8 +15,6 @@ import {
   CreateVipListingRequest,
   DraftListingRequest,
   DraftListingResponse,
-  PublishDraftRequest,
-  PublishDraftResponse,
   ListingDetail,
   ListingOwnerDetail,
   ListingSearchApiRequest,
@@ -157,10 +155,17 @@ export class ListingService {
     })
   }
 
+  /**
+   * Create a draft listing
+   * POST /v1/listings/draft
+   *
+   * Returns a DraftListingResponse — the id lives on `draftId`, NOT `listingId`.
+   * A draft is a row in `listing_drafts`, not a listing.
+   */
   static async createDraft(
     data: CreateListingRequest,
-  ): Promise<ApiResponse<{ listingId: number; status: string }>> {
-    return apiRequest<{ listingId: number; status: string }>({
+  ): Promise<ApiResponse<DraftListingResponse>> {
+    return apiRequest<DraftListingResponse>({
       method: 'POST',
       url: PATHS.LISTING.CREATE_DRAFT,
       data,
@@ -631,17 +636,23 @@ export class ListingService {
   /**
    * Publish a draft listing
    * POST /v1/listings/draft/:draftId/publish
+   *
+   * Same request/response shape as create() — the server merges the draft with
+   * this payload (payload wins) and then runs the normal creation flow. Prefer
+   * this over create() whenever a draft exists: the server owns the draft's
+   * lifecycle from here on and deletes it once the listing actually exists,
+   * including after a payment callback the browser never comes back for.
    */
   static async publishDraft(
     draftId: string | number,
-    data: PublishDraftRequest,
+    data: CreateListingRequest,
     instance?: AxiosInstance,
-  ): Promise<ApiResponse<PublishDraftResponse>> {
+  ): Promise<ApiResponse<CreateListingResponse>> {
     const url = PATHS.LISTING.PUBLISH_DRAFT.replace(
       ':draftId',
       draftId.toString(),
     )
-    return apiRequest<PublishDraftResponse>(
+    return apiRequest<CreateListingResponse>(
       {
         method: 'POST',
         url,

--- a/src/api/types/draft.type.ts
+++ b/src/api/types/draft.type.ts
@@ -14,7 +14,6 @@ import {
   listingType,
   PriceType,
 } from './property.type'
-import type { SePayGatewayData } from './payment.type'
 
 /**
  * Request DTO for creating/updating draft listings
@@ -152,39 +151,8 @@ export interface DraftListingResponse {
 }
 
 /**
- * Request DTO for publishing a draft
+ * Publishing a draft takes and returns exactly what creating a listing does —
+ * see CreateListingRequest / CreateListingResponse in property.type.ts. The
+ * server merges the draft with the payload and runs the same creation flow, so
+ * a separate pair of DTOs here only ever drifts out of sync with the backend.
  */
-export interface PublishDraftRequest extends Partial<DraftListingRequest> {
-  // Option 1: Use membership quota
-  useMembershipQuota?: boolean
-  benefitIds?: number[]
-
-  // Option 2: Direct payment
-  vipType?: 'SILVER' | 'GOLD' | 'DIAMOND'
-  durationDays?: number
-  paymentProvider?: 'SEPAY' | 'MOMO' | 'PAYPAL' | 'ZALOPAY'
-}
-
-/**
- * Response DTO for publishing a draft
- */
-export interface PublishDraftResponse {
-  // Success case (used quota or free listing)
-  listingId?: number
-  title?: string
-  vipType?: string
-  status?: 'ACTIVE' | 'PENDING'
-  createdAt?: string
-  expiryDate?: string
-
-  // Payment required case
-  transactionId?: string
-  paymentRequired?: boolean
-  paymentUrl?: string
-  amount?: number
-  message?: string
-  // SePay Payment Gateway: hosted-checkout form data ({ method, checkoutUrl, fields })
-  providerData?: SePayGatewayData
-  expiresAt?: string
-  provider?: string
-}

--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -104,6 +104,9 @@ export const LISTING_ERROR_CODES = {
   RESUBMIT_NOT_ALLOWED: '16003',
   // User has been blocked from posting by an admin (too many approved reports)
   USER_POSTING_BLOCKED: '23001',
+  // The media being attached already belongs to a listing — the draft being
+  // published was published once already, so it can never succeed again.
+  MEDIA_ALREADY_LINKED: '12004',
 } as const
 
 export type ListingErrorCode =

--- a/src/components/templates/createPostTemplate/components/NavigationButtons.tsx
+++ b/src/components/templates/createPostTemplate/components/NavigationButtons.tsx
@@ -27,6 +27,9 @@ interface NavigationButtonsProps {
   onSubmit: () => void
   onUpdateDraft?: () => void
   isUpdatingDraft?: boolean
+  // The publish request is in flight. Distinct from isUpdatingDraft, which only
+  // tracks the draft mutation and left the submit CTA clickable twice.
+  isSubmitting?: boolean
   // When the user is blocked from posting, the publish/payment CTA is replaced
   // by a "save draft" action so they can still keep their work.
   postingBlocked?: boolean
@@ -41,6 +44,7 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   onSubmit,
   onUpdateDraft,
   isUpdatingDraft = false,
+  isSubmitting = false,
   postingBlocked = false,
   onSaveDraft,
 }) => {
@@ -89,7 +93,7 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
     return (
       <Button
         onClick={handleSubmit}
-        disabled={isUpdatingDraft}
+        disabled={isUpdatingDraft || isSubmitting}
         className={PRIMARY_CTA_CLASSES}
       >
         <CreditCard className='size-4' aria-hidden='true' />

--- a/src/components/templates/createPostTemplate/index.tsx
+++ b/src/components/templates/createPostTemplate/index.tsx
@@ -86,6 +86,15 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   // Shown when the user has been blocked from posting by an admin
   const [blockedOpen, setBlockedOpen] = React.useState(false)
   const [blockedDesc, setBlockedDesc] = React.useState<string>('')
+  // Shown when this draft's media already belongs to a listing — the draft was
+  // published before and only discarding it makes sense.
+  const [alreadyPublishedOpen, setAlreadyPublishedOpen] = React.useState(false)
+  // Guards the publish request itself. isUpdatingDraft tracks the *draft* mutation
+  // and never blocked a double-click on submit.
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  // Draft created by ensureDraft() for a submission that has no draft of its own,
+  // kept so a retry after a failed publish reuses it rather than making another.
+  const createdDraftIdRef = React.useRef<string | number | null>(null)
 
   // Payment method dialog
   const {
@@ -116,9 +125,46 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
     await createListing()
   }
 
+  /**
+   * Make sure a draft row exists for this submission and return its id.
+   *
+   * Publishing through a draft is what lets the *server* delete it once the
+   * listing actually exists — including on the payment path, where the callback
+   * that materialises the listing may fire long after the browser is gone.
+   * Without it, cleanup depends on the user coming back to /payment/result, and
+   * every abandoned return leaves a draft whose media is already spoken for.
+   * Republishing that draft then dies on "Media X is already linked to listing Y".
+   *
+   * Returns null when the draft could not be saved — publishing still proceeds
+   * through the plain create endpoint, we just lose the server-side cleanup.
+   */
+  const ensureDraft = async (): Promise<string | number | null> => {
+    if (draftId) return draftId
+    // Reuse the draft from an earlier failed attempt instead of stacking up a
+    // new row every time the user fixes something and resubmits.
+    if (createdDraftIdRef.current) return createdDraftIdRef.current
+    try {
+      const draftResponse = await createDraftAsync({
+        ...propertyInfo,
+        isDraft: true,
+      })
+      if (draftResponse.success && draftResponse.data) {
+        createdDraftIdRef.current = draftResponse.data.draftId
+        return draftResponse.data.draftId
+      }
+      return null
+    } catch (draftError) {
+      // Non-fatal: publishing can still proceed, only cleanup/recovery is lost.
+      console.error('Failed to save draft before publishing:', draftError)
+      return null
+    }
+  }
+
   const createListing = async (
     selectedProvider?: MembershipPaymentProvider,
   ) => {
+    if (isSubmitting) return
+    setIsSubmitting(true)
     try {
       // Use unified /v1/listings endpoint for all listing types (NORMAL, SILVER, GOLD, DIAMOND)
       // Backend will determine if payment is required based on:
@@ -145,14 +191,26 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         ...(paymentProvider && { paymentProvider }),
       }
 
-      const { success, data, message, code } =
-        await ListingService.create(requestData)
+      // Publish through the draft when we have one, so the server owns the
+      // draft's lifecycle end to end. Falls back to a plain create only when the
+      // draft could not be saved at all.
+      const publishFromDraftId = await ensureDraft()
+      const { success, data, message, code } = publishFromDraftId
+        ? await ListingService.publishDraft(publishFromDraftId, requestData)
+        : await ListingService.create(requestData)
 
       if (!success || !data) {
         // User blocked from posting by an admin → show dedicated notice
         if (code === LISTING_ERROR_CODES.USER_POSTING_BLOCKED) {
           setBlockedDesc(message || t('blockedDescription'))
           setBlockedOpen(true)
+          return
+        }
+        // The draft's media already belongs to a listing, i.e. this draft was
+        // published before. Say so and offer to discard it — retrying can only
+        // ever fail the same way.
+        if (code === LISTING_ERROR_CODES.MEDIA_ALREADY_LINKED) {
+          setAlreadyPublishedOpen(true)
           return
         }
         setErrorTitle(t('errorTitle'))
@@ -169,39 +227,21 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
 
         // Redirecting to the payment gateway (SePay hosted checkout or e.g.
         // ZaloPay) is a full-page navigation that destroys the in-memory form
-        // state (CreatePostProvider). If the user abandons or fails the
-        // payment, the form would otherwise be lost. Persist the listing
-        // content as a DB draft first so it can be recovered via
-        // /seller/create-post?draftId=... on return. When already editing an
-        // existing draft, reuse it instead of creating a duplicate.
-        let recoverableDraftId: string | number | null = draftId || null
-        if (!recoverableDraftId) {
-          try {
-            const draftResponse = await createDraftAsync({
-              ...propertyInfo,
-              isDraft: true,
-            })
-            if (draftResponse.success && draftResponse.data) {
-              recoverableDraftId = draftResponse.data.listingId
-            }
-          } catch (draftError) {
-            // Non-fatal: payment can still proceed, only recovery is unavailable.
-            console.error(
-              'Failed to auto-save draft before payment redirect:',
-              draftError,
-            )
-          }
-        }
-
-        // Store listing info in session storage for tracking after payment
-        // callback (the draft is deleted on success by /payment/result).
+        // state (CreatePostProvider). The draft ensureDraft() saved above is
+        // what the user recovers from via /seller/create-post?draftId=... if
+        // they abandon or fail the payment.
+        //
+        // Store listing info in session storage for tracking after payment.
+        // Deleting the draft on success is the server's job now (it holds the
+        // draft id alongside the cached request); /payment/result still tries,
+        // as a belt-and-braces for the fallback create() path.
         const listingPaymentInfo = {
           title: propertyInfo?.title,
           vipType: propertyInfo?.vipType,
           durationDays: propertyInfo?.durationDays,
           transactionId: data.transactionId,
           transactionType: 'POST_FEE',
-          draftId: recoverableDraftId, // Used to recover on failure / delete on success
+          draftId: publishFromDraftId, // Used to recover on failure / delete on success
         }
         sessionStorage.setItem(
           'pendingListingCreation',
@@ -218,15 +258,19 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         return
       }
 
-      // Listing created successfully without payment (used quota or free NORMAL listing)
-      // If recreating from draft, delete the draft
-      if (draftId) {
+      // Listing created without payment (quota or free NORMAL listing). publishDraft
+      // already dropped the draft in the same transaction; this only cleans up after
+      // the fallback create() path, where no publish happened.
+      if (!publishFromDraftId && draftId) {
         try {
           await deleteDraft(draftId)
         } catch (error) {
           console.error('Failed to delete draft after listing creation:', error)
         }
       }
+      // Whatever draft backed this submission is gone now — don't hand a stale id
+      // to a later attempt.
+      createdDraftIdRef.current = null
 
       setIsSubmitSuccess(true)
       setSuccessTitle(t('successTitle'))
@@ -236,6 +280,8 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
       setErrorTitle(t('errorTitle'))
       setErrorDesc(err instanceof Error ? err.message : t('unexpectedError'))
       setErrorOpen(true)
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -321,6 +367,21 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
     router,
   ])
 
+  // The listing this draft describes already exists, so the draft is dead weight.
+  // Drop it and send the user to their listings, where the published one is.
+  const handleDiscardPublishedDraft = React.useCallback(async () => {
+    if (draftId) {
+      try {
+        await deleteDraft(draftId)
+      } catch (error) {
+        console.error('Failed to discard already-published draft:', error)
+      }
+    }
+    setIsSubmitSuccess(true)
+    resetPropertyInfo()
+    await router.push(SELLER_ROUTES.LISTINGS)
+  }, [draftId, deleteDraft, setIsSubmitSuccess, resetPropertyInfo, router])
+
   return (
     <PostTemplateBase
       className={className}
@@ -352,6 +413,7 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
           onSubmit={handleSubmit}
           onUpdateDraft={handleUpdateDraft}
           isUpdatingDraft={isUpdatingDraft}
+          isSubmitting={isSubmitting}
           postingBlocked={postingBlocked}
           onSaveDraft={handleSaveDraft}
         />
@@ -386,6 +448,16 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         description={blockedDesc}
         okText={t('ok')}
         onOpenChange={setBlockedOpen}
+      />
+
+      {/* Draft was already published — discarding it is the only way forward */}
+      <NotificationDialog
+        open={alreadyPublishedOpen}
+        title={t('alreadyPublishedTitle')}
+        description={t('alreadyPublishedDescription')}
+        okText={t('alreadyPublishedDiscard')}
+        onOpenChange={setAlreadyPublishedOpen}
+        onOk={handleDiscardPublishedDraft}
       />
 
       {/* Payment Method Dialog */}

--- a/src/hooks/useListings/usePublishDraft.ts
+++ b/src/hooks/useListings/usePublishDraft.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ListingService } from '@/api/services'
-import type { PublishDraftRequest } from '@/api/types'
+import type { CreateListingRequest } from '@/api/types'
 
 /**
  * Hook to publish a draft listing
@@ -15,7 +15,7 @@ export const usePublishDraft = () => {
       data,
     }: {
       draftId: string | number
-      data: PublishDraftRequest
+      data: CreateListingRequest
     }) => ListingService.publishDraft(draftId, data),
     onSuccess: () => {
       // Invalidate drafts list since the draft will be deleted after publishing

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1014,7 +1014,10 @@
       "createFailed": "Failed to create listing",
       "unexpectedError": "An unexpected error occurred",
       "blockedTitle": "Account blocked from posting",
-      "blockedDescription": "Your account has been blocked from posting because several of your listings were reported and confirmed as violations. Please contact an administrator for support."
+      "blockedDescription": "Your account has been blocked from posting because several of your listings were reported and confirmed as violations. Please contact an administrator for support.",
+      "alreadyPublishedTitle": "This draft has already been posted",
+      "alreadyPublishedDescription": "The photos in this draft already belong to a listing you posted earlier, so it cannot be posted again. Your listing is still in your listings — you can discard this leftover draft.",
+      "alreadyPublishedDiscard": "Discard draft"
     },
     "validation": {
       "categoryTypeRequired": "Category type is required",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1014,7 +1014,10 @@
       "createFailed": "Tạo tin đăng thất bại",
       "unexpectedError": "Đã xảy ra lỗi không mong muốn",
       "blockedTitle": "Tài khoản bị chặn đăng tin",
-      "blockedDescription": "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin đăng vi phạm bị báo cáo và đã được duyệt. Vui lòng liên hệ quản trị viên để được hỗ trợ."
+      "blockedDescription": "Tài khoản của bạn đã bị chặn đăng tin do có nhiều tin đăng vi phạm bị báo cáo và đã được duyệt. Vui lòng liên hệ quản trị viên để được hỗ trợ.",
+      "alreadyPublishedTitle": "Tin nháp này đã được đăng",
+      "alreadyPublishedDescription": "Ảnh trong tin nháp này đã thuộc về một tin đã đăng trước đó, nên không thể đăng lại. Tin của bạn vẫn nằm trong danh sách tin đăng — bạn có thể xoá bản nháp thừa này.",
+      "alreadyPublishedDiscard": "Xoá bản nháp"
     },
     "validation": {
       "imagesUploadInProgress": "Vui lòng đợi quá trình tải ảnh hoàn tất trước khi tiếp tục",


### PR DESCRIPTION
Đi kèm backend PR Vuhuydiet/smartrent-backend#452 (mã lỗi `12004` + script dọn dữ liệu).

## Vấn đề

Lỗi user gặp khi đăng lại một bản nháp:

```
Media 1521051 is already linked to listing 757849
```

Media chỉ thuộc đúng một listing, nên bản nháp đó **vĩnh viễn không đăng được** — và UI không cho lối thoát nào.

### Vì sao bản nháp còn sót lại

`usePublishDraft` chưa từng được gọi ở đâu — submit luôn POST `/v1/listings`. Toàn bộ việc xoá nháp dồn cho client, và client làm sai:

`createDraft()` khai báo trả `{ listingId }`, nhưng endpoint trả `DraftListingResponse` với id nằm ở **`draftId`**. Nên bản nháp cứu hộ tạo trước lúc redirect thanh toán vào `sessionStorage` với `draftId: undefined`. Thanh toán xong, callback tạo listing và gán media, còn `/payment/result` bỏ qua bước xoá vì id falsy.

Nháp sống sót, mang theo media giờ đã thuộc listing mới → mở lại đăng tiếp → lỗi trên.

## Thay đổi

- `createDraft()` trả `DraftListingResponse`. Đọc `.listingId` từ nó giờ là **compile error** — đúng thứ lẽ ra phải chặn bug này ngay từ đầu.
- `ensureDraft()` đảm bảo có nháp trước khi đăng (tái dùng nháp từ URL, hoặc từ lần submit lỗi trước), rồi submit qua `publishDraft()`. Server xoá nháp trong cùng transaction ở luồng quota, và mang `sourceDraftId` theo request cache trong Redis để callback thanh toán cũng xoá — **không còn phụ thuộc việc user quay lại `/payment/result`**. Vẫn giữ `create()` làm fallback khi không lưu được nháp.
- Bắt mã `12004 LISTING_MEDIA_ALREADY_LINKED`: hiện dialog "tin nháp này đã được đăng" kèm nút xoá nháp, thay vì đổ message nội bộ của backend ra màn hình.
- Chặn double-submit. `disabled={isUpdatingDraft}` trước đây theo dõi mutation *cập nhật nháp*, không phải lệnh đăng — bấm hai lần là ra hai tin.

`publishDraft()` nay dùng `CreateListingRequest` / `CreateListingResponse` — cùng một DTO backend với `create()`; cặp `PublishDraft*` riêng đã trôi lệch khỏi thực tế nên bỏ.

## Kiểm tra

Chạy sau chỉnh sửa cuối, trong worktree tách khỏi tree đang dirty:

| Lệnh | Kết quả |
| --- | --- |
| `npm run typecheck` | exit 0 |
| `npx eslint` (các file đụng tới) | 0 error, 0 warning |
| `npm run i18n:check` | 3178 keys, in sync |
| `npm run test -- --run` | 6 files, 39 tests passed |

Chưa chạy thử end-to-end trên app thật (cần cổng thanh toán) — luồng quota và luồng thanh toán mới chỉ được xác minh bằng đọc code + test phía backend.

## Ghi chú

`createVipListingFromCache` phía backend không gọi `deleteSourceDraftIfPresent`, nhưng FE không dùng endpoint `/v1/listings/vip` (đã deprecated) nên `publishDraft` không bao giờ đi vào đó. Là lỗ hổng tiềm ẩn, chưa vá trong PR này.