### PR TITLE
fix(create-post): close three holes found reviewing the draft flow

### DIFF
--- a/src/components/templates/createPostTemplate/index.tsx
+++ b/src/components/templates/createPostTemplate/index.tsx
@@ -165,6 +165,11 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   ) => {
     if (isSubmitting) return
     setIsSubmitting(true)
+    // Leaving for the payment gateway is a full-page navigation that takes a
+    // moment to tear the page down. Re-enabling the CTA in that window lets a
+    // second click start a second transaction, so the guard stays latched and
+    // the unmount takes it with us.
+    let leavingForGateway = false
     try {
       // Use unified /v1/listings endpoint for all listing types (NORMAL, SILVER, GOLD, DIAMOND)
       // Backend will determine if payment is required based on:
@@ -254,6 +259,7 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         window.dispatchEvent(
           new CustomEvent(CREATE_POST_BYPASS_DRAFT_GUARD_EVENT),
         )
+        leavingForGateway = true
         startGatewayCheckout(data)
         return
       }
@@ -281,7 +287,7 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
       setErrorDesc(err instanceof Error ? err.message : t('unexpectedError'))
       setErrorOpen(true)
     } finally {
-      setIsSubmitting(false)
+      if (!leavingForGateway) setIsSubmitting(false)
     }
   }
 
@@ -370,9 +376,14 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   // The listing this draft describes already exists, so the draft is dead weight.
   // Drop it and send the user to their listings, where the published one is.
   const handleDiscardPublishedDraft = React.useCallback(async () => {
-    if (draftId) {
+    // Not always the draft from the URL: a submission that started without one
+    // gets a draft from ensureDraft(), and that is the one left stranded when the
+    // publish comes back with "media already linked".
+    const staleDraftId = draftId ?? createdDraftIdRef.current
+    if (staleDraftId) {
       try {
-        await deleteDraft(draftId)
+        await deleteDraft(staleDraftId)
+        createdDraftIdRef.current = null
       } catch (error) {
         console.error('Failed to discard already-published draft:', error)
       }

--- a/src/hooks/useListings/useDeleteDraft.ts
+++ b/src/hooks/useListings/useDeleteDraft.ts
@@ -5,7 +5,10 @@ export const useDeleteDraft = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (draftId: string) => ListingService.deleteDraft(draftId),
+    // string | number, matching ListingService.deleteDraft — draft ids come from
+    // the router as strings but straight off the API as numbers.
+    mutationFn: (draftId: string | number) =>
+      ListingService.deleteDraft(draftId),
     onSuccess: () => {
       // Invalidate drafts query to refresh the list
       queryClient.invalidateQueries({ queryKey: ['my-drafts'] })

--- a/src/hooks/useListings/usePublishDraft.ts
+++ b/src/hooks/useListings/usePublishDraft.ts
@@ -18,8 +18,10 @@ export const usePublishDraft = () => {
       data: CreateListingRequest
     }) => ListingService.publishDraft(draftId, data),
     onSuccess: () => {
-      // Invalidate drafts list since the draft will be deleted after publishing
-      queryClient.invalidateQueries({ queryKey: ['drafts'] })
+      // Invalidate drafts list since the draft will be deleted after publishing.
+      // The list query is keyed ['my-drafts'] (useGetMyDrafts) — ['drafts'] is
+      // not a prefix of it and matched nothing.
+      queryClient.invalidateQueries({ queryKey: ['my-drafts'] })
       // Invalidate listings list since a new listing was created
       queryClient.invalidateQueries({ queryKey: ['listings'] })
     },

--- a/src/hooks/useListings/useUpdateDraft.ts
+++ b/src/hooks/useListings/useUpdateDraft.ts
@@ -25,7 +25,9 @@ export const useUpdateDraft = () => {
         response,
       })
       queryClient.invalidateQueries({ queryKey: ['draft', variables.draftId] })
-      queryClient.invalidateQueries({ queryKey: ['drafts'] })
+      // useGetMyDrafts is keyed ['my-drafts']; ['drafts'] matched no query, so
+      // the list kept serving a stale card for the 30s staleTime after an edit.
+      queryClient.invalidateQueries({ queryKey: ['my-drafts'] })
     },
     onError: (error, variables) => {
       console.error('❌ [UPDATE DRAFT] Error:', {


### PR DESCRIPTION
⚠️ **Đây là commit bị rớt khỏi #466.** PR đó được merge đúng lúc commit đầu tiên, commit thứ hai push sau nên không vào `main`. Nội dung y hệt, đã rebase lên `main` mới.

Nghĩa là **main hiện đang mang 2 lỗi ở mục 1 và 2 bên dưới** — do chính #466 đưa vào.

## 1. Chặn double-submit không bao luồng thanh toán

Nhánh payment `return` từ trong `try`, nên `finally` set `isSubmitting = false` **trong lúc** `startGatewayCheckout` đang tear down trang. Bấm lần hai trong khoảng đó → `createListing` chạy lại → **giao dịch thanh toán thứ hai**.

Đúng là trường hợp mà cái guard sinh ra để chặn. Giờ latch lại khi rời sang cổng, để việc unmount mang nó đi.

## 2. "Xoá bản nháp" không xoá gì

`handleDiscardPublishedDraft` chỉ nhìn `draftId` từ URL. Nhưng nháp bị kẹt lại là nháp do `ensureDraft()` tạo: submit khi chưa có draft → thanh toán → callback gán media → quay lại tab cũ bấm submit lần nữa → `12004`, dialog mời xoá nháp, và **không xoá gì cả**. Fallback sang `createdDraftIdRef`.

## 3. Invalidate key trỏ vào hư không

`useUpdateDraft` và `usePublishDraft` invalidate `['drafts']`. Không query nào dùng key đó — danh sách là `['my-drafts']` (`useGetMyDrafts`), và `['drafts']` không phải prefix của nó nên cả hai lệnh đều là no-op. Sửa nháp rồi quay lại `/seller/drafts` trong 30s `staleTime` vẫn thấy card cũ.

Kèm theo: `useDeleteDraft` khai `mutationFn: (draftId: string)` trong khi `ListingService.deleteDraft` nhận `string | number` — id về từ API là number, từ router là string. Nới cho khớp service.

## Kiểm tra

`typecheck` exit 0 · `eslint` (file đụng tới) exit 0 · `i18n:check` in sync · `vitest` 39 passed.