### PR TITLE
feat(ai-valuation): đánh giá giá chào bán so với khoảng AI đề xuất

### DIFF
--- a/docs/superpowers/plans/2026-07-20-asking-price-evaluation.md
+++ b/docs/superpowers/plans/2026-07-20-asking-price-evaluation.md
@@ -1,0 +1,607 @@
+# Asking-Price Evaluation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the user how their asking price compares to the AI-suggested range in the đăng bài valuation step.
+
+**Architecture:** One pure function (`evaluateAskingPrice`) in a new file computes a verdict from data already in context — no network calls, no AI/backend changes. The existing `aiValuationSection.tsx` renders its result below the evidence line added by #465. The function returns `null` for every unusable input, and the UI renders nothing in that case.
+
+**Tech Stack:** TypeScript, React, next-intl, vitest, Tailwind.
+
+## Global Constraints
+
+- **Repo:** smartrent-fe only. Do NOT modify smartrent-ai or smartrent-backend.
+- **Worktree:** `C:\Users\huynh\AppData\Local\Temp\claude\d--DEV-datn\b65821b0-9c47-47b0-b5ff-82e684a58a6a\scratchpad\fe-valuation`, branch `feat/asking-price-evaluation` (already created off `origin/main`). Use absolute paths for file tools — a `cd` in Bash shifts the cwd.
+- **Package manager:** `pnpm`. Tests: `pnpm test:run`. Lint: `pnpm lint <paths>`. i18n gate: `pnpm i18n:check`.
+- **Informational only.** Never block navigation, never disable the submit button, never gate a step.
+- **Strong-deviation threshold:** exactly `25` percent, exported as `STRONG_DEVIATION_PERCENT`.
+- **Range bounds are inclusive:** `p === min` and `p === max` are both `fair`.
+- **Severity is decided on the raw unrounded deviation;** only `differencePercent` is rounded (1 decimal).
+- **Hide the verdict only on positive evidence of unreliability** — `source === 'rule_based_fallback'` or `listings_found === 0`. When those fields are `undefined`, still evaluate.
+- **Commits:** do NOT add `Co-Authored-By` trailers. The pre-commit hook runs a full typecheck that fails on unmodified `origin/main` in a clean install (phantom deps `framer-motion`, `@radix-ui/react-visually-hidden` missing from `package.json`); commit with `--no-verify` and verify separately, as in #465.
+- **Do NOT commit `pnpm-lock.yaml`** — it is untracked in this repo.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/utils/ai/priceEvaluation.ts` (create) | Pure comparison logic. No React, no i18n, no formatting. |
+| `src/utils/ai/priceEvaluation.test.ts` (create) | vitest coverage of the function. |
+| `src/messages/vi.json`, `src/messages/en.json` (modify) | New keys under `createPost.sections.aiValuation.results.priceEvaluation`. |
+| `src/components/organisms/createPostSections/aiValuationSection.tsx` (modify) | Renders the verdict. Owns colours and copy; holds no comparison logic. |
+
+Kept out of `src/utils/ai/housingPredictor.ts` on purpose — that file already owns address resolution and request building.
+
+---
+
+### Task 1: Pure evaluation function
+
+**Files:**
+- Create: `src/utils/ai/priceEvaluation.ts`
+- Test: `src/utils/ai/priceEvaluation.test.ts`
+
+**Interfaces:**
+- Consumes: `HousingPredictorResponse` from `@/api/types/ai.type` (has `price_range: {min, max}`, and optional `source`, `listings_found`, `confidence`); `PriceUnit` from `@/api/types/property.type` (`'MONTH' | 'YEAR' | 'DAY'`).
+- Produces: `evaluateAskingPrice(price, priceUnit, prediction): PriceEvaluation | null`, plus exported types `PriceVerdict`, `PriceSeverity`, `PriceEvaluation` and the constant `STRONG_DEVIATION_PERCENT`. Task 2 imports all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/ai/priceEvaluation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import type { HousingPredictorResponse } from '@/api/types/ai.type'
+
+import { STRONG_DEVIATION_PERCENT, evaluateAskingPrice } from './priceEvaluation'
+
+const prediction = (
+  overrides: Partial<HousingPredictorResponse> = {},
+): HousingPredictorResponse => ({
+  price_range: { min: 5_000_000, max: 8_000_000 },
+  location: 'Thanh Xuân, Hà Nội',
+  property_type: 'APARTMENT',
+  currency: 'VND',
+  source: 'ai_comparables',
+  listings_found: 12,
+  confidence: 'medium',
+  ...overrides,
+})
+
+describe('evaluateAskingPrice', () => {
+  describe('inside the range', () => {
+    it('is fair with no deviation', () => {
+      const result = evaluateAskingPrice(6_500_000, 'MONTH', prediction())
+      expect(result).toEqual({
+        verdict: 'fair',
+        severity: null,
+        differencePercent: 0,
+        normalizedMonthlyPrice: 6_500_000,
+      })
+    })
+
+    it('treats the lower bound as fair', () => {
+      expect(evaluateAskingPrice(5_000_000, 'MONTH', prediction())?.verdict).toBe(
+        'fair',
+      )
+    })
+
+    it('treats the upper bound as fair', () => {
+      expect(evaluateAskingPrice(8_000_000, 'MONTH', prediction())?.verdict).toBe(
+        'fair',
+      )
+    })
+  })
+
+  describe('above the range', () => {
+    it('is mild at 10% over the max', () => {
+      const result = evaluateAskingPrice(8_800_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('above')
+      expect(result?.severity).toBe('mild')
+      expect(result?.differencePercent).toBe(10)
+    })
+
+    it('is strong at 50% over the max', () => {
+      const result = evaluateAskingPrice(12_000_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('above')
+      expect(result?.severity).toBe('strong')
+      expect(result?.differencePercent).toBe(50)
+    })
+
+    it('is still mild exactly at the threshold', () => {
+      const atThreshold = 8_000_000 * (1 + STRONG_DEVIATION_PERCENT / 100)
+      expect(evaluateAskingPrice(atThreshold, 'MONTH', prediction())?.severity).toBe(
+        'mild',
+      )
+    })
+
+    it('decides severity on the raw value, not the rounded one', () => {
+      // 25.04% over the max rounds to 25.0 but must still count as strong.
+      const justOver = 8_000_000 * 1.2504
+      const result = evaluateAskingPrice(justOver, 'MONTH', prediction())
+      expect(result?.differencePercent).toBe(25)
+      expect(result?.severity).toBe('strong')
+    })
+  })
+
+  describe('below the range', () => {
+    it('is mild at 10% under the min', () => {
+      const result = evaluateAskingPrice(4_500_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('below')
+      expect(result?.severity).toBe('mild')
+      expect(result?.differencePercent).toBe(10)
+    })
+
+    it('is strong at 50% under the min', () => {
+      const result = evaluateAskingPrice(2_500_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('below')
+      expect(result?.severity).toBe('strong')
+      expect(result?.differencePercent).toBe(50)
+    })
+  })
+
+  describe('unit conversion', () => {
+    it('converts a yearly price to monthly before comparing', () => {
+      // 78M/year = 6.5M/month, inside the range.
+      const result = evaluateAskingPrice(78_000_000, 'YEAR', prediction())
+      expect(result?.verdict).toBe('fair')
+      expect(result?.normalizedMonthlyPrice).toBe(6_500_000)
+    })
+
+    it('does not compare a yearly price as if it were monthly', () => {
+      // Without conversion this would read as wildly above the range.
+      expect(evaluateAskingPrice(78_000_000, 'YEAR', prediction())?.verdict).not.toBe(
+        'above',
+      )
+    })
+
+    it('refuses units it cannot convert', () => {
+      expect(evaluateAskingPrice(200_000, 'DAY', prediction())).toBeNull()
+      expect(evaluateAskingPrice(6_500_000, undefined, prediction())).toBeNull()
+    })
+  })
+
+  describe('unusable input', () => {
+    it.each([undefined, 0, -1, NaN])('returns null for price %s', (price) => {
+      expect(evaluateAskingPrice(price as number, 'MONTH', prediction())).toBeNull()
+    })
+
+    it('returns null without a prediction', () => {
+      expect(evaluateAskingPrice(6_500_000, 'MONTH', null)).toBeNull()
+    })
+
+    it('returns null for an invalid range', () => {
+      expect(
+        evaluateAskingPrice(
+          6_500_000,
+          'MONTH',
+          prediction({ price_range: { min: 0, max: 8_000_000 } }),
+        ),
+      ).toBeNull()
+      expect(
+        evaluateAskingPrice(
+          6_500_000,
+          'MONTH',
+          prediction({ price_range: { min: 9_000_000, max: 8_000_000 } }),
+        ),
+      ).toBeNull()
+    })
+  })
+
+  describe('evidence gating', () => {
+    it('stays silent on a rule-based fallback range', () => {
+      expect(
+        evaluateAskingPrice(
+          12_000_000,
+          'MONTH',
+          prediction({ source: 'rule_based_fallback' }),
+        ),
+      ).toBeNull()
+    })
+
+    it('stays silent when no comparable listings backed the range', () => {
+      expect(
+        evaluateAskingPrice(12_000_000, 'MONTH', prediction({ listings_found: 0 })),
+      ).toBeNull()
+    })
+
+    it('still evaluates when the evidence fields are absent', () => {
+      // Missing information is not evidence of a fallback; refusing here would
+      // make the feature vanish silently whenever a field is omitted.
+      const result = evaluateAskingPrice(
+        6_500_000,
+        'MONTH',
+        prediction({ source: undefined, listings_found: undefined }),
+      )
+      expect(result?.verdict).toBe('fair')
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:run src/utils/ai/priceEvaluation.test.ts`
+Expected: FAIL — `Failed to resolve import "./priceEvaluation"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/utils/ai/priceEvaluation.ts`:
+
+```ts
+import type { HousingPredictorResponse } from '@/api/types/ai.type'
+import type { PriceUnit } from '@/api/types/property.type'
+
+export type PriceVerdict = 'below' | 'fair' | 'above'
+export type PriceSeverity = 'mild' | 'strong'
+
+export interface PriceEvaluation {
+  verdict: PriceVerdict
+  /** null when the verdict is 'fair' */
+  severity: PriceSeverity | null
+  /** Percent away from the nearest bound, rounded to 1 decimal. 0 when inside. */
+  differencePercent: number
+  /** The monthly VND figure actually compared against the range. */
+  normalizedMonthlyPrice: number
+}
+
+/** Deviation beyond a range bound, in percent, past which the gap is reported
+ *  as significant rather than moderate. A guess pending real feedback — named
+ *  so it is cheap to retune. */
+export const STRONG_DEVIATION_PERCENT = 25
+
+const MONTHS_PER_YEAR = 12
+
+const isPositiveFinite = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+/** The AI always quotes a monthly rent, so a yearly asking price has to be
+ *  brought onto the same footing before any comparison means anything. */
+const toMonthly = (price: number, unit: PriceUnit | undefined): number | null => {
+  if (unit === 'MONTH') return price
+  if (unit === 'YEAR') return price / MONTHS_PER_YEAR
+  // 'DAY' exists on the type but the create-post validation schema rejects it.
+  // Refuse rather than invent a conversion factor and be wrong by ~30x.
+  return null
+}
+
+export const evaluateAskingPrice = (
+  price: number | undefined,
+  priceUnit: PriceUnit | undefined,
+  prediction: HousingPredictorResponse | null,
+): PriceEvaluation | null => {
+  if (!isPositiveFinite(price)) return null
+  if (!prediction) return null
+
+  // Say nothing when the range itself is not backed by market data. Claiming
+  // "your price is 40% above market" off a hardcoded table would be worse than
+  // staying quiet. Only positive evidence of unreliability suppresses the
+  // verdict — absent fields do not.
+  if (prediction.source === 'rule_based_fallback') return null
+  if (prediction.listings_found === 0) return null
+
+  const min = prediction.price_range?.min
+  const max = prediction.price_range?.max
+  if (!isPositiveFinite(min) || !isPositiveFinite(max) || min > max) return null
+
+  const monthly = toMonthly(price, priceUnit)
+  if (monthly === null || !isPositiveFinite(monthly)) return null
+
+  if (monthly >= min && monthly <= max) {
+    return {
+      verdict: 'fair',
+      severity: null,
+      differencePercent: 0,
+      normalizedMonthlyPrice: monthly,
+    }
+  }
+
+  const isBelow = monthly < min
+  // Unrounded on purpose: rounding first would misfile 25.04% as mild.
+  const rawDeviation = isBelow
+    ? ((min - monthly) / min) * 100
+    : ((monthly - max) / max) * 100
+
+  return {
+    verdict: isBelow ? 'below' : 'above',
+    severity: rawDeviation > STRONG_DEVIATION_PERCENT ? 'strong' : 'mild',
+    differencePercent: Math.round(rawDeviation * 10) / 10,
+    normalizedMonthlyPrice: monthly,
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:run src/utils/ai/priceEvaluation.test.ts`
+Expected: PASS, 20 tests.
+
+- [ ] **Step 5: Lint the new files**
+
+Run: `pnpm lint src/utils/ai/priceEvaluation.ts src/utils/ai/priceEvaluation.test.ts`
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/ai/priceEvaluation.ts src/utils/ai/priceEvaluation.test.ts
+git commit --no-verify -m "feat(ai-valuation): compare the asking price against the suggested range
+
+Pure function, no network. Returns null for every unusable input so the
+caller only has to check for null.
+
+Two decisions worth noting:
+- A yearly asking price is converted to monthly before comparison; the AI
+  always quotes a monthly rent, so comparing raw would be wrong by 12x.
+- The verdict is suppressed when the range came from the rule-based
+  fallback or had no comparable listings behind it. Absent evidence fields
+  do not suppress it - missing information is not evidence of a fallback."
+```
+
+---
+
+### Task 2: Render the verdict
+
+**Files:**
+- Modify: `src/messages/vi.json`, `src/messages/en.json` — add `createPost.sections.aiValuation.results.priceEvaluation`
+- Modify: `src/components/organisms/createPostSections/aiValuationSection.tsx`
+
+**Interfaces:**
+- Consumes: `evaluateAskingPrice` and `PriceEvaluation` from Task 1; `propertyInfo.price` / `propertyInfo.priceUnit` from `useCreatePost()`; the existing local `formatPrice(price: number)` helper (line 137) and `prediction` state.
+- Produces: no new exports. This is the last code task.
+
+- [ ] **Step 1: Add the Vietnamese keys**
+
+In `src/messages/vi.json`, inside `createPost.sections.aiValuation.results`, add a `priceEvaluation` object alongside the existing `fallbackNotice` / `basedOnListings` / `confidenceLabel` keys:
+
+```json
+"priceEvaluation": {
+  "yourPrice": "Giá bạn đang đặt",
+  "perMonth": "/tháng",
+  "perYear": "/năm",
+  "fair": "Hợp lý",
+  "above": "Cao hơn thị trường",
+  "aboveStrong": "Cao hơn thị trường đáng kể",
+  "below": "Thấp hơn thị trường",
+  "belowStrong": "Thấp hơn thị trường đáng kể",
+  "inRange": "Nằm trong khoảng AI đề xuất",
+  "deviationAbove": "Cao hơn khoảng đề xuất {percent}%",
+  "deviationBelow": "Thấp hơn khoảng đề xuất {percent}%"
+}
+```
+
+- [ ] **Step 2: Add the English keys**
+
+In `src/messages/en.json`, same location:
+
+```json
+"priceEvaluation": {
+  "yourPrice": "Your asking price",
+  "perMonth": "/month",
+  "perYear": "/year",
+  "fair": "Reasonable",
+  "above": "Above market",
+  "aboveStrong": "Well above market",
+  "below": "Below market",
+  "belowStrong": "Well below market",
+  "inRange": "Within the AI-suggested range",
+  "deviationAbove": "{percent}% above the suggested range",
+  "deviationBelow": "{percent}% below the suggested range"
+}
+```
+
+- [ ] **Step 3: Verify the translation files stay in sync**
+
+Run: `pnpm i18n:check`
+Expected: `✅ All checks passed! Translation files are in sync.` — the `{percent}` placeholder must match across both files.
+
+- [ ] **Step 4: Import the function in the section**
+
+In `src/components/organisms/createPostSections/aiValuationSection.tsx`, add below the existing `@/utils/ai/housingPredictor` import block (currently lines 25-30):
+
+```tsx
+import { evaluateAskingPrice } from '@/utils/ai/priceEvaluation'
+```
+
+- [ ] **Step 5: Derive the evaluation and its presentation**
+
+In the same file, immediately after the `confidenceDotClass` declaration (currently ends around line 180, just before `const canPredict = !!predictionRequest`), insert:
+
+```tsx
+  const priceEvaluation = useMemo(
+    () =>
+      evaluateAskingPrice(
+        propertyInfo.price,
+        propertyInfo.priceUnit,
+        prediction,
+      ),
+    [propertyInfo.price, propertyInfo.priceUnit, prediction],
+  )
+
+  const priceUnitSuffix =
+    propertyInfo.priceUnit === 'YEAR'
+      ? t('results.priceEvaluation.perYear')
+      : t('results.priceEvaluation.perMonth')
+
+  // Colour and wording for the verdict. Green reads as "no action needed",
+  // amber as "worth a second look", red as "probably a mistake".
+  const evaluationTone = useMemo(() => {
+    if (!priceEvaluation) return null
+
+    if (priceEvaluation.verdict === 'fair') {
+      return {
+        box: 'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950/40',
+        text: 'text-green-700 dark:text-green-400',
+        label: t('results.priceEvaluation.fair'),
+      }
+    }
+
+    const isStrong = priceEvaluation.severity === 'strong'
+    const isAbove = priceEvaluation.verdict === 'above'
+
+    return {
+      box: isStrong
+        ? 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/40'
+        : 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40',
+      text: isStrong
+        ? 'text-red-700 dark:text-red-400'
+        : 'text-amber-700 dark:text-amber-400',
+      label: isAbove
+        ? t(
+            isStrong
+              ? 'results.priceEvaluation.aboveStrong'
+              : 'results.priceEvaluation.above',
+          )
+        : t(
+            isStrong
+              ? 'results.priceEvaluation.belowStrong'
+              : 'results.priceEvaluation.below',
+          ),
+    }
+  }, [priceEvaluation, t])
+```
+
+- [ ] **Step 6: Render the block**
+
+In the same file, find the `</div>` that closes the suggested-price wrapper (the one immediately followed by the `{/* Price Details */}` comment, currently line 284). Insert this block between that `</div>` and the `{/* Price Details */}` comment:
+
+```tsx
+                {/* How the user's own price sits against the range. Rendered
+                    only when the range is backed by comparable listings -
+                    evaluateAskingPrice returns null otherwise. */}
+                {priceEvaluation && evaluationTone && (
+                  <div className={`rounded-xl border p-4 ${evaluationTone.box}`}>
+                    <div className='flex items-center justify-between gap-3 mb-1'>
+                      <span className='text-sm text-muted-foreground'>
+                        {t('results.priceEvaluation.yourPrice')}
+                      </span>
+                      <span className='text-sm font-semibold text-foreground'>
+                        {formatPrice(propertyInfo.price as number)}
+                        {priceUnitSuffix}
+                      </span>
+                    </div>
+                    <div className='flex flex-wrap items-center gap-x-2 gap-y-1'>
+                      <span
+                        className={`text-sm font-semibold ${evaluationTone.text}`}
+                      >
+                        {evaluationTone.label}
+                      </span>
+                      <span className='text-xs text-muted-foreground'>
+                        {priceEvaluation.verdict === 'fair'
+                          ? t('results.priceEvaluation.inRange')
+                          : priceEvaluation.verdict === 'above'
+                            ? t('results.priceEvaluation.deviationAbove', {
+                                percent: priceEvaluation.differencePercent,
+                              })
+                            : t('results.priceEvaluation.deviationBelow', {
+                                percent: priceEvaluation.differencePercent,
+                              })}
+                      </span>
+                    </div>
+                  </div>
+                )}
+```
+
+- [ ] **Step 7: Lint and typecheck the section**
+
+Run: `pnpm lint src/components/organisms/createPostSections/aiValuationSection.tsx`
+Expected: no output.
+
+Run: `pnpm typecheck 2>&1 | grep -E "aiValuationSection|priceEvaluation"`
+Expected: no output — no errors in the touched files. (The repo has pre-existing typecheck errors in other files; see Task 3.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/messages/vi.json src/messages/en.json src/components/organisms/createPostSections/aiValuationSection.tsx
+git commit --no-verify -m "feat(ai-valuation): show how the asking price compares to the range
+
+Renders below the evidence line: the price the user entered, a verdict,
+and how far outside the suggested range it falls. Green when inside,
+amber when moderately outside, red past 25% beyond a bound.
+
+Nothing renders when evaluateAskingPrice returns null, which includes the
+case where the range came from the rule-based fallback - a verdict drawn
+from a hardcoded table would undo the point of surfacing the fallback in
+the first place."
+```
+
+---
+
+### Task 3: Verify and open the PR
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: the working tree from Tasks 1-2.
+- Produces: a pushed branch and an open PR.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test:run`
+Expected: all files pass. Before this change the suite was 39 tests across 6 files; expect 59 across 7.
+
+- [ ] **Step 2: Confirm no new typecheck errors**
+
+Run: `pnpm typecheck 2>&1 | grep -c "error TS"`
+Expected: `24` — the same pre-existing count measured on unmodified `origin/main`. Any higher number means this change introduced errors; investigate before continuing.
+
+To re-measure the baseline if the number differs:
+
+```bash
+git stash -u && pnpm typecheck 2>&1 | grep -c "error TS"; git stash pop
+```
+
+- [ ] **Step 3: Confirm the i18n gate**
+
+Run: `pnpm i18n:check`
+Expected: `✅ All checks passed! Translation files are in sync.`
+
+- [ ] **Step 4: Confirm the lockfile was not staged**
+
+Run: `git status --porcelain`
+Expected: `pnpm-lock.yaml` still shows as untracked (`??`), never staged or committed.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/asking-price-evaluation
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+gh pr create --base main --title "feat(ai-valuation): đánh giá giá chào bán so với khoảng AI đề xuất"
+```
+
+Body must cover: what the step showed before versus now; the four design decisions (FE-only, informational, range-based thresholds, hidden when evidence is weak); the yearly-price conversion; the verification numbers from Steps 1-3; and a note that the commits used `--no-verify` because the pre-commit typecheck fails on unmodified `origin/main` in a clean install due to the two phantom dependencies.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Pure function, file location, signature | 1 |
+| Six null conditions | 1 (Steps 1, 3) |
+| Undefined evidence fields still evaluate | 1 (test `still evaluates when the evidence fields are absent`) |
+| MONTH/YEAR conversion, DAY refused | 1 (`toMonthly`, `refuses units it cannot convert`) |
+| Threshold table, inclusive bounds | 1 (`inside the range` + `above`/`below` describes) |
+| Rounding vs severity on raw value | 1 (`decides severity on the raw value`) |
+| `STRONG_DEVIATION_PERCENT` named constant | 1 |
+| UI placement below the evidence line | 2 (Step 6) |
+| Colour mapping green/amber/red | 2 (Step 5, `evaluationTone`) |
+| Display in the user's chosen unit | 2 (`priceUnitSuffix`) |
+| Render nothing when null | 2 (Step 6 guard) |
+| i18n keys with `{percent}` | 2 (Steps 1-3) |
+| Every listed test case | 1 (Step 1) |
+| No blocking, no AI call, no inline price editing | Global Constraints |
+| Update-post flow inherits the change | No task needed — shared component, verified during design |
+
+**Placeholder scan:** none — every code step carries complete code, every command carries expected output.
+
+**Type consistency:** `PriceEvaluation` fields (`verdict`, `severity`, `differencePercent`, `normalizedMonthlyPrice`) are named identically in Task 1's interface, Task 1's tests, and Task 2's JSX. `evaluateAskingPrice` takes `(price, priceUnit, prediction)` in that order in both tasks. `STRONG_DEVIATION_PERCENT` is exported in Task 1 and consumed by Task 1's threshold test only.
+
+**One gap found and closed:** the spec lists "price_range có giá trị không hợp lệ" without saying whether `min > max` counts. Task 1 rejects it explicitly and tests it — an inverted range cannot produce a meaningful verdict.

--- a/docs/superpowers/specs/2026-07-20-asking-price-evaluation-design.md
+++ b/docs/superpowers/specs/2026-07-20-asking-price-evaluation-design.md
@@ -1,0 +1,226 @@
+# Đánh giá giá chào bán trong bước AI valuation
+
+**Ngày:** 2026-07-20
+**Repo ảnh hưởng:** smartrent-fe (duy nhất)
+
+## Bối cảnh
+
+Bước "Đánh giá giá AI" (step 1 của wizard đăng bài) hiện chỉ hiển thị khoảng giá
+AI đề xuất — min / trung bình / max — kèm bằng chứng (`listings_found`,
+`confidence`, cảnh báo fallback) vừa được thêm ở smartrent-fe#465.
+
+Nhưng nó chưa bao giờ **đánh giá giá mà user đang đặt**. Bước này tên là "đánh
+giá giá" trong khi thực tế chỉ gợi ý khoảng giá; user phải tự nhẩm xem giá mình
+nhập có nằm trong khoảng đó không.
+
+`propertyInfo.price` được nhập ở **step 0**, trước bước định giá, nên dữ liệu đã
+có sẵn trong context khi `AIValuationSection` mount. Không cần plumbing mới.
+
+Logic so sánh giá-với-thị trường có tồn tại trong smartrent-ai
+(`evaluate_price_vs_market`) nhưng nằm trong file XGBoost không reachable từ
+luồng đăng bài, và đã có quyết định không nối XGBoost vào.
+
+## Mục tiêu
+
+Cho user biết giá họ đang đặt nằm ở đâu so với khoảng AI đề xuất, và lệch bao
+nhiêu phần trăm.
+
+## Phi mục tiêu
+
+- **Không chặn** việc đăng bài hay chuyển step. Chỉ thông báo.
+- **Không gọi AI.** Không gửi `askingPrice` lên, không sửa smartrent-ai hay
+  smartrent-backend.
+- **Không thêm ô sửa giá tại chỗ.** Ô giá ở bước này vẫn là read-only echo từ
+  step 0 như hiện tại.
+- Không nối XGBoost.
+
+## Quyết định thiết kế
+
+| Quyết định | Chọn | Lý do |
+|---|---|---|
+| Tính ở đâu | FE thuần | Một repo, tức thì, deterministic nên test được đầy đủ, không tốn token LLM |
+| Mức độ | Chỉ thông báo | Khoảng giá AI vẫn có lúc yếu; chặn user dựa trên số liệu yếu gây ức chế |
+| Ngưỡng | Dựa trên khoảng min–max | Độ rộng khoảng đã phản ánh độ không chắc chắn — khoảng rộng thì tự động khoan dung hơn |
+| Khi dữ liệu yếu | Ẩn đánh giá | Nói "giá bạn cao hơn 40%" dựa trên bảng hardcode là sai, đi ngược lại chính #89/#465 |
+
+## Kiến trúc
+
+### Hàm thuần `evaluateAskingPrice`
+
+File mới: `src/utils/ai/priceEvaluation.ts`
+
+Tách riêng khỏi `housingPredictor.ts` — file đó đã lo phân giải địa chỉ và dựng
+request; thêm logic đánh giá vào sẽ làm nó gánh hai việc không liên quan.
+
+```ts
+export type PriceVerdict = 'below' | 'fair' | 'above'
+export type PriceSeverity = 'mild' | 'strong'
+
+export interface PriceEvaluation {
+  verdict: PriceVerdict
+  /** null khi verdict === 'fair' */
+  severity: PriceSeverity | null
+  /** % lệch so với biên gần nhất; 0 khi nằm trong khoảng */
+  differencePercent: number
+  /** giá theo tháng (VND) thực sự được đem so sánh */
+  normalizedMonthlyPrice: number
+}
+
+export const evaluateAskingPrice = (
+  price: number | undefined,
+  priceUnit: PriceUnit | undefined,
+  prediction: HousingPredictorResponse | null,
+): PriceEvaluation | null
+```
+
+### Điều kiện trả `null`
+
+Trả `null` (UI không render gì) khi bất kỳ điều nào đúng:
+
+1. `price` không phải số hữu hạn, hoặc `<= 0`
+2. `prediction` là `null`
+3. `prediction.price_range.min`/`max` không phải số hữu hạn dương
+4. `prediction.source === 'rule_based_fallback'`
+5. `prediction.listings_found === 0`
+6. `priceUnit` không phải `'MONTH'` hoặc `'YEAR'`
+
+**Về (4) và (5):** chỉ ẩn khi có **bằng chứng dương** rằng dữ liệu yếu. Nếu
+`source` hoặc `listings_found` là `undefined` thì **vẫn đánh giá** — thiếu thông
+tin không đồng nghĩa với fallback. Nếu bắt buộc phải có mặt, tính năng sẽ im lặng
+biến mất khi field vắng vì bất kỳ lý do gì.
+
+**Về (6):** `PriceUnit` khai báo `'MONTH' | 'YEAR' | 'DAY'` nhưng
+`validationSchemas.ts` chỉ cho phép `MONTH`/`YEAR`, nên `DAY` không tới được qua
+wizard. Xử lý bằng cách trả `null` thay vì đoán hệ số quy đổi — thà không đánh
+giá còn hơn so lệch 30 lần.
+
+### Quy đổi đơn vị
+
+AI luôn trả về **giá thuê theo tháng**. Giá user thì theo `priceUnit`.
+
+```
+MONTH → normalizedMonthlyPrice = price
+YEAR  → normalizedMonthlyPrice = price / 12
+```
+
+Mọi so sánh chạy trên `normalizedMonthlyPrice`. Phần **hiển thị** vẫn dùng giá
+gốc theo đúng đơn vị user chọn, để không gây bối rối.
+
+### Ngưỡng phân loại
+
+Đặt `p = normalizedMonthlyPrice`, `min`/`max` từ `price_range`.
+
+| Điều kiện | verdict | severity | differencePercent |
+|---|---|---|---|
+| `min ≤ p ≤ max` | `fair` | `null` | `0` |
+| `p < min`, lệch ≤ 25% | `below` | `mild` | `(min - p) / min × 100` |
+| `p < min`, lệch > 25% | `below` | `strong` | như trên |
+| `p > max`, lệch ≤ 25% | `above` | `mild` | `(p - max) / max × 100` |
+| `p > max`, lệch > 25% | `above` | `strong` | như trên |
+
+Biên là **inclusive** — `p === min` và `p === max` đều là `fair`.
+
+`differencePercent` trả ra đã làm tròn tới 1 chữ số thập phân. Nhưng việc **phân
+loại `mild` / `strong` so trên giá trị thô chưa làm tròn** — nếu không, lệch
+25.04% sẽ làm tròn thành 25.0 rồi bị xếp nhầm thành `mild`.
+
+Ngưỡng `25%` khai báo thành hằng số có tên (`STRONG_DEVIATION_PERCENT`) để dễ
+chỉnh sau.
+
+## UI
+
+Chèn vào `src/components/organisms/createPostSections/aiValuationSection.tsx`,
+trong khối `{prediction && (...)}`, **ngay dưới** dòng bằng chứng
+(`listings_found` / `confidence`) đã có từ #465.
+
+Nội dung:
+- Giá user đang đặt, định dạng qua `formatByLocale`, kèm nhãn đơn vị
+- Badge phân loại
+- Một dòng giải thích mức lệch
+
+Bảng màu — dùng lại đúng palette đang có trong file:
+
+| Trạng thái | Màu |
+|---|---|
+| `fair` | xanh lá (`green-600` / `green-400` dark) |
+| `mild` (cao hoặc thấp) | amber |
+| `strong` (quá cao hoặc quá thấp) | đỏ |
+
+Khi `evaluateAskingPrice` trả `null` thì không render gì cả — không có
+placeholder, không có dòng "chưa đánh giá được".
+
+## i18n
+
+Keys mới dưới `createPost.sections.aiValuation.results.priceEvaluation`:
+
+```
+yourPrice          "Giá bạn đang đặt"
+fair               "Hợp lý"
+below              "Thấp hơn thị trường"
+belowStrong        "Thấp hơn thị trường đáng kể"
+above              "Cao hơn thị trường"
+aboveStrong        "Cao hơn thị trường đáng kể"
+inRange            "Nằm trong khoảng AI đề xuất"
+deviationAbove     "Cao hơn khoảng đề xuất {percent}%"
+deviationBelow     "Thấp hơn khoảng đề xuất {percent}%"
+```
+
+Thêm cho cả `vi.json` và `en.json`. Có placeholder `{percent}` nên phải qua được
+`pnpm i18n:check` (script này so khớp placeholder giữa hai file).
+
+## Testing
+
+File mới: `src/utils/ai/priceEvaluation.test.ts` (vitest).
+
+Các case bắt buộc:
+
+- Nằm trong khoảng → `fair`, `differencePercent === 0`
+- Đúng biên `min` và đúng biên `max` → `fair` (kiểm tra inclusive)
+- Trên `max` 10% → `above` / `mild`
+- Trên `max` 50% → `above` / `strong`
+- Dưới `min` 10% → `below` / `mild`
+- Dưới `min` 50% → `below` / `strong`
+- Đúng ngưỡng 25% → `mild` (kiểm tra biên của severity)
+- Lệch 25.04% → `strong` (chứng minh phân loại so trên giá trị thô, không so
+  trên số đã làm tròn)
+- `priceUnit: 'YEAR'` → quy đổi /12 rồi mới so
+- `price` undefined / 0 / âm / NaN → `null`
+- `prediction` null → `null`
+- `source: 'rule_based_fallback'` → `null`
+- `listings_found: 0` → `null`
+- `source`/`listings_found` undefined → **vẫn đánh giá**
+- `priceUnit: 'DAY'` hoặc undefined → `null`
+- `price_range` có giá trị không hợp lệ (0, âm, NaN) → `null`
+
+## Xử lý lỗi
+
+Hàm thuần, không ném lỗi, không side effect. Mọi input không dùng được đều trả
+`null`. UI chỉ cần kiểm tra `null`.
+
+## Ảnh hưởng tới luồng sửa bài
+
+`aiValuationSection.tsx` được dùng chung: `createPostTemplate/AIValuationStep.tsx`
+và `updatePostTemplate/AIValuationStep.tsx` đều render đúng component này. Thay
+đổi sẽ xuất hiện ở cả hai luồng cùng lúc.
+
+Đã kiểm chứng luồng sửa bài an toàn:
+- `mapListingToFormData.ts:165-166` có hydrate `price` và `priceUnit` từ listing
+- `pages/seller/update-post/[id].tsx:179` có mount `CreatePostProvider`
+
+## Rủi ro đã biết
+
+**Khoảng giá quá hẹp.** Nếu agent trả về khoảng rất hẹp (ví dụ 6.0M–6.2M) thì
+gần như mọi giá đều rơi ra ngoài. Chấp nhận ở bản này: đây là thông báo chứ không
+chặn, và độ hẹp của khoảng là tín hiệu từ chính AI. Nếu thực tế cho thấy khó chịu
+thì xử lý sau bằng cách áp sàn độ rộng tối thiểu.
+
+**Ngưỡng 25% là phỏng đoán.** Chưa có dữ liệu thực nghiệm. Khai báo thành hằng số
+có tên để chỉnh nhanh khi có phản hồi.
+
+## Bước sau (không nằm trong phạm vi)
+
+- Đổi ô giá read-only ở bước này thành input để user sửa và thấy đánh giá cập
+  nhật ngay — hàm thuần đã sẵn sàng cho việc đó
+- Đưa đánh giá lên ngay cạnh ô nhập giá ở step 0 (cần prefetch prediction sớm hơn)
+- Cache / rate limit endpoint định giá — mỗi lần mount step vẫn là một agent run
+  tới 12 turn

--- a/src/components/organisms/createPostSections/aiValuationSection.tsx
+++ b/src/components/organisms/createPostSections/aiValuationSection.tsx
@@ -150,6 +150,8 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
 
   // Treat a range with no comparable listings behind it the same as an explicit
   // fallback: in both cases it is not backed by market data.
+  // Kept in sync by hand with the equivalent gate in evaluateAskingPrice
+  // (src/utils/ai/priceEvaluation.ts) - update both if either condition changes.
   const isFallbackEstimate =
     prediction?.source === 'rule_based_fallback' ||
     prediction?.listings_found === 0
@@ -346,10 +348,21 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
                         {t('results.priceEvaluation.yourPrice')}
                       </span>
                       <span className='text-sm font-semibold text-foreground'>
-                        {formatPrice(propertyInfo.price as number)}
+                        {formatPrice(propertyInfo.price ?? 0)}
                         {priceUnitSuffix}
                       </span>
                     </div>
+                    {propertyInfo.priceUnit === 'YEAR' && (
+                      <div className='flex justify-end mb-1'>
+                        <span className='text-xs text-muted-foreground'>
+                          {t('results.priceEvaluation.monthlyEquivalent', {
+                            price: formatPrice(
+                              priceEvaluation.normalizedMonthlyPrice,
+                            ),
+                          })}
+                        </span>
+                      </div>
+                    )}
                     <div className='flex flex-wrap items-center gap-x-2 gap-y-1'>
                       <span
                         className={`text-sm font-semibold ${evaluationTone.text}`}

--- a/src/components/organisms/createPostSections/aiValuationSection.tsx
+++ b/src/components/organisms/createPostSections/aiValuationSection.tsx
@@ -28,6 +28,7 @@ import {
   isTypeSupportedForAiValuation,
   resolveValuationAddress,
 } from '@/utils/ai/housingPredictor'
+import { evaluateAskingPrice } from '@/utils/ai/priceEvaluation'
 import { formatByLocale } from '@/utils/currency/convert'
 import type { HousingPredictorResponse } from '@/api/types/ai.type'
 import { toast } from 'sonner'
@@ -179,6 +180,58 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
         ? 'bg-amber-500'
         : 'bg-muted-foreground'
 
+  const priceEvaluation = useMemo(
+    () =>
+      evaluateAskingPrice(
+        propertyInfo.price,
+        propertyInfo.priceUnit,
+        prediction,
+      ),
+    [propertyInfo.price, propertyInfo.priceUnit, prediction],
+  )
+
+  const priceUnitSuffix =
+    propertyInfo.priceUnit === 'YEAR'
+      ? t('results.priceEvaluation.perYear')
+      : t('results.priceEvaluation.perMonth')
+
+  // Colour and wording for the verdict. Green reads as "no action needed",
+  // amber as "worth a second look", red as "probably a mistake".
+  const evaluationTone = useMemo(() => {
+    if (!priceEvaluation) return null
+
+    if (priceEvaluation.verdict === 'fair') {
+      return {
+        box: 'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950/40',
+        text: 'text-green-700 dark:text-green-400',
+        label: t('results.priceEvaluation.fair'),
+      }
+    }
+
+    const isStrong = priceEvaluation.severity === 'strong'
+    const isAbove = priceEvaluation.verdict === 'above'
+
+    return {
+      box: isStrong
+        ? 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/40'
+        : 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40',
+      text: isStrong
+        ? 'text-red-700 dark:text-red-400'
+        : 'text-amber-700 dark:text-amber-400',
+      label: isAbove
+        ? t(
+            isStrong
+              ? 'results.priceEvaluation.aboveStrong'
+              : 'results.priceEvaluation.above',
+          )
+        : t(
+            isStrong
+              ? 'results.priceEvaluation.belowStrong'
+              : 'results.priceEvaluation.below',
+          ),
+    }
+  }, [priceEvaluation, t])
+
   const canPredict = !!predictionRequest
   // AI valuation supports every listing property type. When prediction is
   // unavailable this still distinguishes "not supported for this type" (e.g. an
@@ -282,6 +335,41 @@ const AIValuationSection: React.FC<AIValuationSectionProps> = ({
                     )
                   )}
                 </div>
+
+                {/* How the user's own price sits against the range. Rendered
+                    only when the range is backed by comparable listings -
+                    evaluateAskingPrice returns null otherwise. */}
+                {priceEvaluation && evaluationTone && (
+                  <div className={`rounded-xl border p-4 ${evaluationTone.box}`}>
+                    <div className='flex items-center justify-between gap-3 mb-1'>
+                      <span className='text-sm text-muted-foreground'>
+                        {t('results.priceEvaluation.yourPrice')}
+                      </span>
+                      <span className='text-sm font-semibold text-foreground'>
+                        {formatPrice(propertyInfo.price as number)}
+                        {priceUnitSuffix}
+                      </span>
+                    </div>
+                    <div className='flex flex-wrap items-center gap-x-2 gap-y-1'>
+                      <span
+                        className={`text-sm font-semibold ${evaluationTone.text}`}
+                      >
+                        {evaluationTone.label}
+                      </span>
+                      <span className='text-xs text-muted-foreground'>
+                        {priceEvaluation.verdict === 'fair'
+                          ? t('results.priceEvaluation.inRange')
+                          : priceEvaluation.verdict === 'above'
+                            ? t('results.priceEvaluation.deviationAbove', {
+                                percent: priceEvaluation.differencePercent,
+                              })
+                            : t('results.priceEvaluation.deviationBelow', {
+                                percent: priceEvaluation.differencePercent,
+                              })}
+                      </span>
+                    </div>
+                  </div>
+                )}
 
                 {/* Price Details */}
                 <div className='space-y-3'>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1864,6 +1864,19 @@
             "high": "High",
             "medium": "Medium",
             "low": "Low"
+          },
+          "priceEvaluation": {
+            "yourPrice": "Your asking price",
+            "perMonth": "/month",
+            "perYear": "/year",
+            "fair": "Reasonable",
+            "above": "Above market",
+            "aboveStrong": "Well above market",
+            "below": "Below market",
+            "belowStrong": "Well below market",
+            "inRange": "Within the AI-suggested range",
+            "deviationAbove": "{percent}% above the suggested range",
+            "deviationBelow": "{percent}% below the suggested range"
           }
         }
       }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1869,6 +1869,7 @@
             "yourPrice": "Your asking price",
             "perMonth": "/month",
             "perYear": "/year",
+            "monthlyEquivalent": "≈ {price}/month",
             "fair": "Reasonable",
             "above": "Above market",
             "aboveStrong": "Well above market",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1869,6 +1869,7 @@
             "yourPrice": "Giá bạn đang đặt",
             "perMonth": "/tháng",
             "perYear": "/năm",
+            "monthlyEquivalent": "≈ {price}/tháng",
             "fair": "Hợp lý",
             "above": "Cao hơn thị trường",
             "aboveStrong": "Cao hơn thị trường đáng kể",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1864,6 +1864,19 @@
             "high": "Cao",
             "medium": "Trung bình",
             "low": "Thấp"
+          },
+          "priceEvaluation": {
+            "yourPrice": "Giá bạn đang đặt",
+            "perMonth": "/tháng",
+            "perYear": "/năm",
+            "fair": "Hợp lý",
+            "above": "Cao hơn thị trường",
+            "aboveStrong": "Cao hơn thị trường đáng kể",
+            "below": "Thấp hơn thị trường",
+            "belowStrong": "Thấp hơn thị trường đáng kể",
+            "inRange": "Nằm trong khoảng AI đề xuất",
+            "deviationAbove": "Cao hơn khoảng đề xuất {percent}%",
+            "deviationBelow": "Thấp hơn khoảng đề xuất {percent}%"
           }
         }
       }

--- a/src/utils/ai/priceEvaluation.test.ts
+++ b/src/utils/ai/priceEvaluation.test.ts
@@ -71,6 +71,17 @@ describe('evaluateAskingPrice', () => {
       expect(result?.differencePercent).toBe(25)
       expect(result?.severity).toBe('strong')
     })
+
+    it('treats a deviation that rounds to 0.0% as fair, not a hidden "above"', () => {
+      // 0.01% over the max - technically outside the range, but far too small
+      // to round to anything but 0.0%. Reporting "above" alongside a 0%
+      // deviation would look self-contradictory, so this counts as fair.
+      const justOver = 8_000_000 * 1.0001
+      const result = evaluateAskingPrice(justOver, 'MONTH', prediction())
+      expect(result?.verdict).toBe('fair')
+      expect(result?.severity).toBeNull()
+      expect(result?.differencePercent).toBe(0)
+    })
   })
 
   describe('below the range', () => {
@@ -119,7 +130,7 @@ describe('evaluateAskingPrice', () => {
       expect(evaluateAskingPrice(6_500_000, 'MONTH', null)).toBeNull()
     })
 
-    it('returns null for an invalid range', () => {
+    it('returns null when the range minimum is not positive', () => {
       expect(
         evaluateAskingPrice(
           6_500_000,
@@ -127,6 +138,9 @@ describe('evaluateAskingPrice', () => {
           prediction({ price_range: { min: 0, max: 8_000_000 } }),
         ),
       ).toBeNull()
+    })
+
+    it('returns null when the range minimum exceeds the maximum', () => {
       expect(
         evaluateAskingPrice(
           6_500_000,

--- a/src/utils/ai/priceEvaluation.test.ts
+++ b/src/utils/ai/priceEvaluation.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HousingPredictorResponse } from '@/api/types/ai.type'
+
+import { STRONG_DEVIATION_PERCENT, evaluateAskingPrice } from './priceEvaluation'
+
+const prediction = (
+  overrides: Partial<HousingPredictorResponse> = {},
+): HousingPredictorResponse => ({
+  price_range: { min: 5_000_000, max: 8_000_000 },
+  location: 'Thanh Xuân, Hà Nội',
+  property_type: 'APARTMENT',
+  currency: 'VND',
+  source: 'ai_comparables',
+  listings_found: 12,
+  confidence: 'medium',
+  ...overrides,
+})
+
+describe('evaluateAskingPrice', () => {
+  describe('inside the range', () => {
+    it('is fair with no deviation', () => {
+      const result = evaluateAskingPrice(6_500_000, 'MONTH', prediction())
+      expect(result).toEqual({
+        verdict: 'fair',
+        severity: null,
+        differencePercent: 0,
+        normalizedMonthlyPrice: 6_500_000,
+      })
+    })
+
+    it('treats the lower bound as fair', () => {
+      expect(evaluateAskingPrice(5_000_000, 'MONTH', prediction())?.verdict).toBe(
+        'fair',
+      )
+    })
+
+    it('treats the upper bound as fair', () => {
+      expect(evaluateAskingPrice(8_000_000, 'MONTH', prediction())?.verdict).toBe(
+        'fair',
+      )
+    })
+  })
+
+  describe('above the range', () => {
+    it('is mild at 10% over the max', () => {
+      const result = evaluateAskingPrice(8_800_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('above')
+      expect(result?.severity).toBe('mild')
+      expect(result?.differencePercent).toBe(10)
+    })
+
+    it('is strong at 50% over the max', () => {
+      const result = evaluateAskingPrice(12_000_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('above')
+      expect(result?.severity).toBe('strong')
+      expect(result?.differencePercent).toBe(50)
+    })
+
+    it('is still mild exactly at the threshold', () => {
+      const atThreshold = 8_000_000 * (1 + STRONG_DEVIATION_PERCENT / 100)
+      expect(evaluateAskingPrice(atThreshold, 'MONTH', prediction())?.severity).toBe(
+        'mild',
+      )
+    })
+
+    it('decides severity on the raw value, not the rounded one', () => {
+      // 25.04% over the max rounds to 25.0 but must still count as strong.
+      const justOver = 8_000_000 * 1.2504
+      const result = evaluateAskingPrice(justOver, 'MONTH', prediction())
+      expect(result?.differencePercent).toBe(25)
+      expect(result?.severity).toBe('strong')
+    })
+  })
+
+  describe('below the range', () => {
+    it('is mild at 10% under the min', () => {
+      const result = evaluateAskingPrice(4_500_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('below')
+      expect(result?.severity).toBe('mild')
+      expect(result?.differencePercent).toBe(10)
+    })
+
+    it('is strong at 50% under the min', () => {
+      const result = evaluateAskingPrice(2_500_000, 'MONTH', prediction())
+      expect(result?.verdict).toBe('below')
+      expect(result?.severity).toBe('strong')
+      expect(result?.differencePercent).toBe(50)
+    })
+  })
+
+  describe('unit conversion', () => {
+    it('converts a yearly price to monthly before comparing', () => {
+      // 78M/year = 6.5M/month, inside the range.
+      const result = evaluateAskingPrice(78_000_000, 'YEAR', prediction())
+      expect(result?.verdict).toBe('fair')
+      expect(result?.normalizedMonthlyPrice).toBe(6_500_000)
+    })
+
+    it('does not compare a yearly price as if it were monthly', () => {
+      // Without conversion this would read as wildly above the range.
+      expect(evaluateAskingPrice(78_000_000, 'YEAR', prediction())?.verdict).not.toBe(
+        'above',
+      )
+    })
+
+    it('refuses units it cannot convert', () => {
+      expect(evaluateAskingPrice(200_000, 'DAY', prediction())).toBeNull()
+      expect(evaluateAskingPrice(6_500_000, undefined, prediction())).toBeNull()
+    })
+  })
+
+  describe('unusable input', () => {
+    it.each([undefined, 0, -1, NaN])('returns null for price %s', (price) => {
+      expect(evaluateAskingPrice(price as number, 'MONTH', prediction())).toBeNull()
+    })
+
+    it('returns null without a prediction', () => {
+      expect(evaluateAskingPrice(6_500_000, 'MONTH', null)).toBeNull()
+    })
+
+    it('returns null for an invalid range', () => {
+      expect(
+        evaluateAskingPrice(
+          6_500_000,
+          'MONTH',
+          prediction({ price_range: { min: 0, max: 8_000_000 } }),
+        ),
+      ).toBeNull()
+      expect(
+        evaluateAskingPrice(
+          6_500_000,
+          'MONTH',
+          prediction({ price_range: { min: 9_000_000, max: 8_000_000 } }),
+        ),
+      ).toBeNull()
+    })
+  })
+
+  describe('evidence gating', () => {
+    it('stays silent on a rule-based fallback range', () => {
+      expect(
+        evaluateAskingPrice(
+          12_000_000,
+          'MONTH',
+          prediction({ source: 'rule_based_fallback' }),
+        ),
+      ).toBeNull()
+    })
+
+    it('stays silent when no comparable listings backed the range', () => {
+      expect(
+        evaluateAskingPrice(12_000_000, 'MONTH', prediction({ listings_found: 0 })),
+      ).toBeNull()
+    })
+
+    it('still evaluates when the evidence fields are absent', () => {
+      // Missing information is not evidence of a fallback; refusing here would
+      // make the feature vanish silently whenever a field is omitted.
+      const result = evaluateAskingPrice(
+        6_500_000,
+        'MONTH',
+        prediction({ source: undefined, listings_found: undefined }),
+      )
+      expect(result?.verdict).toBe('fair')
+    })
+  })
+})

--- a/src/utils/ai/priceEvaluation.ts
+++ b/src/utils/ai/priceEvaluation.ts
@@ -46,6 +46,8 @@ export const evaluateAskingPrice = (
   // "your price is 40% above market" off a hardcoded table would be worse than
   // staying quiet. Only positive evidence of unreliability suppresses the
   // verdict — absent fields do not.
+  // Kept in sync by hand with the equivalent isFallbackEstimate check in
+  // aiValuationSection.tsx - update both if either condition changes.
   if (prediction.source === 'rule_based_fallback') return null
   if (prediction.listings_found === 0) return null
 
@@ -70,11 +72,25 @@ export const evaluateAskingPrice = (
   const rawDeviation = isBelow
     ? ((min - monthly) / min) * 100
     : ((monthly - max) / max) * 100
+  const roundedDeviation = Math.round(rawDeviation * 10) / 10
+
+  // A deviation that rounds to 0.0% reads, on screen, as no deviation at all -
+  // report it as fair rather than an "above"/"below" verdict paired with a 0%
+  // gap. The rounded value decides this, not the raw one, since it is the
+  // rounded value the user actually sees.
+  if (roundedDeviation === 0) {
+    return {
+      verdict: 'fair',
+      severity: null,
+      differencePercent: 0,
+      normalizedMonthlyPrice: monthly,
+    }
+  }
 
   return {
     verdict: isBelow ? 'below' : 'above',
     severity: rawDeviation > STRONG_DEVIATION_PERCENT ? 'strong' : 'mild',
-    differencePercent: Math.round(rawDeviation * 10) / 10,
+    differencePercent: roundedDeviation,
     normalizedMonthlyPrice: monthly,
   }
 }

--- a/src/utils/ai/priceEvaluation.ts
+++ b/src/utils/ai/priceEvaluation.ts
@@ -1,0 +1,80 @@
+import type { HousingPredictorResponse } from '@/api/types/ai.type'
+import type { PriceUnit } from '@/api/types/property.type'
+
+export type PriceVerdict = 'below' | 'fair' | 'above'
+export type PriceSeverity = 'mild' | 'strong'
+
+export interface PriceEvaluation {
+  verdict: PriceVerdict
+  /** null when the verdict is 'fair' */
+  severity: PriceSeverity | null
+  /** Percent away from the nearest bound, rounded to 1 decimal. 0 when inside. */
+  differencePercent: number
+  /** The monthly VND figure actually compared against the range. */
+  normalizedMonthlyPrice: number
+}
+
+/** Deviation beyond a range bound, in percent, past which the gap is reported
+ *  as significant rather than moderate. A guess pending real feedback — named
+ *  so it is cheap to retune. */
+export const STRONG_DEVIATION_PERCENT = 25
+
+const MONTHS_PER_YEAR = 12
+
+const isPositiveFinite = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+/** The AI always quotes a monthly rent, so a yearly asking price has to be
+ *  brought onto the same footing before any comparison means anything. */
+const toMonthly = (price: number, unit: PriceUnit | undefined): number | null => {
+  if (unit === 'MONTH') return price
+  if (unit === 'YEAR') return price / MONTHS_PER_YEAR
+  // 'DAY' exists on the type but the create-post validation schema rejects it.
+  // Refuse rather than invent a conversion factor and be wrong by ~30x.
+  return null
+}
+
+export const evaluateAskingPrice = (
+  price: number | undefined,
+  priceUnit: PriceUnit | undefined,
+  prediction: HousingPredictorResponse | null,
+): PriceEvaluation | null => {
+  if (!isPositiveFinite(price)) return null
+  if (!prediction) return null
+
+  // Say nothing when the range itself is not backed by market data. Claiming
+  // "your price is 40% above market" off a hardcoded table would be worse than
+  // staying quiet. Only positive evidence of unreliability suppresses the
+  // verdict — absent fields do not.
+  if (prediction.source === 'rule_based_fallback') return null
+  if (prediction.listings_found === 0) return null
+
+  const min = prediction.price_range?.min
+  const max = prediction.price_range?.max
+  if (!isPositiveFinite(min) || !isPositiveFinite(max) || min > max) return null
+
+  const monthly = toMonthly(price, priceUnit)
+  if (monthly === null || !isPositiveFinite(monthly)) return null
+
+  if (monthly >= min && monthly <= max) {
+    return {
+      verdict: 'fair',
+      severity: null,
+      differencePercent: 0,
+      normalizedMonthlyPrice: monthly,
+    }
+  }
+
+  const isBelow = monthly < min
+  // Unrounded on purpose: rounding first would misfile 25.04% as mild.
+  const rawDeviation = isBelow
+    ? ((min - monthly) / min) * 100
+    : ((monthly - max) / max) * 100
+
+  return {
+    verdict: isBelow ? 'below' : 'above',
+    severity: rawDeviation > STRONG_DEVIATION_PERCENT ? 'strong' : 'mild',
+    differencePercent: Math.round(rawDeviation * 10) / 10,
+    normalizedMonthlyPrice: monthly,
+  }
+}


### PR DESCRIPTION
## Vấn đề

Bước "Đánh giá giá AI" trong đăng bài tên là *đánh giá giá* nhưng thực tế chỉ **gợi ý khoảng giá**. User phải tự nhẩm xem giá mình nhập có nằm trong khoảng đó không, lệch bao nhiêu.

`propertyInfo.price` được nhập ở step 0, trước bước định giá, nên dữ liệu đã có sẵn trong context — không cần plumbing mới.

## Thay đổi

Thêm `evaluateAskingPrice` (`src/utils/ai/priceEvaluation.ts`) — hàm thuần, không network — và render kết quả ngay dưới dòng bằng chứng đã có từ #465.

Hiển thị: giá đang đặt, phân loại, và mức lệch.

| Điều kiện | Kết quả | Màu |
|---|---|---|
| `min ≤ p ≤ max` | Hợp lý | xanh |
| ngoài khoảng, lệch ≤25% | Cao / Thấp hơn thị trường | amber |
| ngoài khoảng, lệch >25% | Cao / Thấp hơn thị trường đáng kể | đỏ |

Lệch tính theo biên gần nhất, không phải theo điểm giữa — độ rộng của khoảng đã phản ánh độ không chắc chắn, nên khoảng rộng tự động khoan dung hơn.

## Bốn quyết định thiết kế

**1. Tính hoàn toàn trên FE.** AI vẫn chỉ trả khoảng giá như cũ. Không sửa smartrent-ai, không sửa smartrent-backend, không tốn token LLM, và kết quả deterministic nên test được đầy đủ.

**2. Chỉ thông báo, không chặn.** Không disable nút, không gate step, không bắt xác nhận. Khoảng giá AI vẫn có lúc yếu; chặn user dựa trên số liệu yếu thì gây ức chế hơn là giúp.

**3. Ngưỡng dựa trên khoảng min–max**, không dựa trên % so với giá trung bình. Biên là inclusive — đúng `min` hoặc đúng `max` đều là hợp lý.

**4. Ẩn hoàn toàn khi khoảng giá không đáng tin.** Khi `source = rule_based_fallback` hoặc `listings_found = 0`, hàm trả `null` và UI không render gì. Nói "giá bạn cao hơn thị trường 40%" dựa trên bảng hardcode thì đi ngược lại đúng việc mà #89/#465 vừa làm.

Lưu ý là chỉ **bằng chứng dương** mới ẩn. Nếu `source`/`listings_found` là `undefined` (payload cũ) thì vẫn đánh giá — thiếu thông tin không đồng nghĩa với fallback, và nếu bắt buộc phải có thì tính năng sẽ im lặng biến mất khi field vắng.

## Quy đổi đơn vị

AI luôn báo giá **theo tháng**, còn user có thể chọn `MONTH` hoặc `YEAR`. Giá theo năm được chia 12 trước khi so — nếu không sẽ lệch 12 lần.

Với giá theo năm, UI hiện thêm dòng quy đổi (`≈ 6.500.000 ₫/tháng`) ngay dưới giá gốc. Không có dòng này thì màn hình *đúng nhưng trông sai*: khoảng đề xuất 5–8 triệu nằm ngay trên "78.000.000 ₫/năm — Hợp lý". Đây là phát hiện của vòng review cuối, không phải thiết kế ban đầu.

`DAY` có trong type nhưng validation schema chặn — hàm trả `null` thay vì đoán hệ số quy đổi.

## Một bất đối xứng có chủ ý

Khi các field bằng chứng vắng mặt, dòng "Dựa trên N tin đăng" bị **ẩn** (không khai cái mình không nhận được), nhưng khối đánh giá này **vẫn hiện**. Hai phản ứng ngược nhau trước cùng một sự không chắc chắn. Có chủ ý — ẩn đánh giá khi thiếu field sẽ làm tính năng biến mất trong lúc rollout — nhưng ghi ra đây để nó là quyết định được ghi nhận chứ không phải tai nạn.

## Kiểm chứng

```
vitest       62/62 pass, 7 files (trước: 39/6) — 23 test cho hàm mới
i18n:check   ✅ 3187 keys in sync, placeholder khớp
eslint       sạch trên toàn bộ file đã sửa
typecheck    24 lỗi trước = 24 lỗi sau, không lỗi nào ở file trong PR
```

Quy trình: spec → plan → TDD từng task, review sau mỗi task, cộng một vòng review toàn nhánh. Spec và plan nằm trong `docs/superpowers/`. Vòng cuối bắt được lỗi hiển thị YEAR ở trên và 4 điểm nhỏ, đã sửa hết trong `d286007`.

## Về `--no-verify`

Các commit dùng `--no-verify`. Pre-commit hook chạy full typecheck và fail khi cài lại từ đầu bằng **pnpm**, vì `framer-motion` và `@radix-ui/react-visually-hidden` được import trực tiếp nhưng không khai trong `package.json` — chúng vào theo dạng bắc cầu qua `motion` và `@radix-ui/react-select`/`react-tooltip`. npm hoist phẳng nên vẫn resolve; pnpm không hoist nên gãy.

> **Đính chính.** Bản đầu của mô tả này nói "CI xanh là bằng chứng yếu". Sai — `package-lock.json` được track và CI chạy `npm install`, nên cả hai package đều resolve đúng version và CI xanh **có** ý nghĩa. Vấn đề chỉ ảnh hưởng người dev dùng pnpm, và đang được xử lý ở một PR riêng.

Đã đo trước/sau (24 lỗi typecheck = baseline) để chắc PR này không thêm lỗi nào.

## Không nằm trong PR này

Không chặn submit, không cho sửa giá tại chỗ, không gọi AI, không nối XGBoost. Nếu sau muốn "sửa giá thấy đổi ngay" thì hàm thuần đã sẵn sàng — chỉ cần đổi ô read-only thành input.

