### PR TITLE
fix(create-post): guard edits to an existing draft, restore its package

### DIFF
--- a/src/api/types/draft.type.ts
+++ b/src/api/types/draft.type.ts
@@ -145,6 +145,13 @@ export interface DraftListingResponse {
   amenities: Amenity[]
   media: MediaItem[] | null
 
+  // Package / payment selection (backend V117). Note there is deliberately no
+  // postDate/expiryDate here — listing_drafts has no columns for those, so a
+  // scheduled post date cannot survive a draft round trip.
+  durationDays: number | null
+  useMembershipQuota: boolean | null
+  benefitIds: number[] | null
+
   // Timestamps
   createdAt: string
   updatedAt: string

--- a/src/components/molecules/createPostDraftGuard/index.tsx
+++ b/src/components/molecules/createPostDraftGuard/index.tsx
@@ -6,6 +6,10 @@ import { useCreatePost } from '@/contexts/createPost'
 import { useAuth } from '@/hooks/useAuth'
 import { useCreateDraft } from '@/hooks/useListings/useCreateDraft'
 import { useUpdateDraft } from '@/hooks/useListings/useUpdateDraft'
+import {
+  CREATE_POST_BYPASS_DRAFT_GUARD_EVENT,
+  CREATE_POST_DRAFT_SAVED_EVENT,
+} from '@/constants'
 import { toast } from 'sonner'
 
 interface CreatePostDraftGuardProps {
@@ -13,7 +17,29 @@ interface CreatePostDraftGuardProps {
 }
 
 const NAVIGATION_CANCELLED_ERROR = 'Navigation cancelled by draft guard'
-const CREATE_POST_BYPASS_DRAFT_GUARD_EVENT = 'create-post:bypass-draft-guard'
+
+/**
+ * Serialize form state for change detection, independent of key order.
+ * propertyInfo is rebuilt by spreading on every update, so a plain
+ * JSON.stringify reports a difference whenever a key is merely added or
+ * reordered — which would pop the "save draft?" dialog on untouched drafts.
+ * Array order is preserved: for media it carries the sort order.
+ */
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const source = value as Record<string, unknown>
+    return Object.keys(source)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = canonicalize(source[key])
+        return acc
+      }, {})
+  }
+  return value
+}
+
+const snapshotOf = (value: unknown): string => JSON.stringify(canonicalize(value))
 
 export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
   children,
@@ -33,6 +59,24 @@ export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
   const shouldBlockRef = useRef(false)
   const isNavigatingRef = useRef(false)
   const blockedUrlRef = useRef<string | null>(null)
+  // Snapshot of the draft as it was loaded, so editing an existing draft is
+  // guarded on what changed rather than on "there is data in the form".
+  const loadedDraftSnapshotRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!draftId) {
+      loadedDraftSnapshotRef.current = null
+      return
+    }
+    // First populated render after the draft lands is the baseline.
+    if (
+      loadedDraftSnapshotRef.current === null &&
+      propertyInfo &&
+      Object.keys(propertyInfo).length > 1
+    ) {
+      loadedDraftSnapshotRef.current = snapshotOf(propertyInfo)
+    }
+  }, [draftId, propertyInfo])
 
   const hasUnsavedChanges = useCallback((): boolean => {
     // Draft save flow only applies to authenticated users.
@@ -41,10 +85,18 @@ export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
     // Don't block if submit was successful
     if (isSubmitSuccess) return false
 
-    // Don't block if editing existing draft (already saved)
-    if (draftId) return false
-
     if (!propertyInfo) return false
+
+    // Editing an existing draft: the draft is only "saved" as of the moment it
+    // loaded. Block once the user has actually changed something — this used to
+    // return false outright, which turned the guard off entirely and silently
+    // discarded every edit made to an existing draft.
+    if (draftId) {
+      return (
+        loadedDraftSnapshotRef.current !== null &&
+        snapshotOf(propertyInfo) !== loadedDraftSnapshotRef.current
+      )
+    }
 
     // Check if propertyInfo has any meaningful data
     const hasAnyData = Object.entries(propertyInfo).some(([key, value]) => {
@@ -69,6 +121,19 @@ export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
   useEffect(() => {
     shouldBlockRef.current = hasUnsavedChanges()
   }, [hasUnsavedChanges])
+
+  // An explicit "update draft" persists what is on screen — adopt it as the new
+  // baseline so leaving the page doesn't ask to save the same thing again.
+  useEffect(() => {
+    const handleDraftSaved = (): void => {
+      loadedDraftSnapshotRef.current = snapshotOf(propertyInfo)
+      shouldBlockRef.current = false
+    }
+
+    window.addEventListener(CREATE_POST_DRAFT_SAVED_EVENT, handleDraftSaved)
+    return () =>
+      window.removeEventListener(CREATE_POST_DRAFT_SAVED_EVENT, handleDraftSaved)
+  }, [propertyInfo])
 
   // Allow specific flows (e.g., external payment redirect) to bypass this guard.
   useEffect(() => {

--- a/src/components/molecules/createPostDraftGuard/index.tsx
+++ b/src/components/molecules/createPostDraftGuard/index.tsx
@@ -30,7 +30,7 @@ const canonicalize = (value: unknown): unknown => {
   if (value && typeof value === 'object') {
     const source = value as Record<string, unknown>
     return Object.keys(source)
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .reduce<Record<string, unknown>>((acc, key) => {
         acc[key] = canonicalize(source[key])
         return acc

--- a/src/components/templates/createPostTemplate/index.tsx
+++ b/src/components/templates/createPostTemplate/index.tsx
@@ -1,4 +1,8 @@
-import { SELLER_ROUTES } from '@/constants'
+import {
+  SELLER_ROUTES,
+  CREATE_POST_BYPASS_DRAFT_GUARD_EVENT,
+  CREATE_POST_DRAFT_SAVED_EVENT,
+} from '@/constants'
 import React from 'react'
 import { useCreatePostSteps } from './hooks/useCreatePostSteps'
 import { useCreatePostValidation } from './hooks/useCreatePostValidation'
@@ -28,8 +32,6 @@ import { useAuth } from '@/hooks/useAuth'
 interface CreatePostTemplateProps {
   className?: string
 }
-
-const CREATE_POST_BYPASS_DRAFT_GUARD_EVENT = 'create-post:bypass-draft-guard'
 
 const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
   className,
@@ -320,6 +322,9 @@ const CreatePostTemplateContent: React.FC<{ className?: string }> = ({
         onSuccess: (response) => {
           if (response.success) {
             toast.success(tDraft('draftUpdated'))
+            // Re-baseline the guard: what is on screen is now what is stored, so
+            // leaving the page must not ask to save it again.
+            window.dispatchEvent(new CustomEvent(CREATE_POST_DRAFT_SAVED_EVENT))
           } else {
             toast.error(response.message || tDraft('draftUpdateFailed'))
           }

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,1 +1,10 @@
 export const OPEN_AI_CHAT_WIDGET_EVENT = 'ai-chat:open-widget'
+
+// Lets a flow that owns the navigation itself (the payment redirect) skip the
+// create-post draft guard.
+export const CREATE_POST_BYPASS_DRAFT_GUARD_EVENT =
+  'create-post:bypass-draft-guard'
+
+// Tells the draft guard that what is on screen has just been persisted, so it
+// should treat the current form state as the new saved baseline.
+export const CREATE_POST_DRAFT_SAVED_EVENT = 'create-post:draft-saved'

--- a/src/utils/property/mapDraftToFormData.test.ts
+++ b/src/utils/property/mapDraftToFormData.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { mapDraftToFormData } from './mapListingToFormData'
+import type { DraftListingResponse } from '@/api/types/draft.type'
+
+const makeDraft = (
+  overrides: Partial<DraftListingResponse> = {},
+): DraftListingResponse =>
+  ({
+    draftId: 1,
+    userId: 'user-1',
+    title: 'Căn hộ 2PN',
+    description: 'Mô tả',
+    listingType: 'RENT',
+    vipType: 'GOLD',
+    categoryId: 1,
+    productType: 'APARTMENT',
+    price: 5_000_000,
+    priceUnit: 'MONTH',
+    address: null,
+    area: 45,
+    bedrooms: 2,
+    bathrooms: 1,
+    direction: 'EAST',
+    furnishing: 'FULLY_FURNISHED',
+    roomCapacity: 4,
+    waterPrice: 'NEGOTIABLE',
+    electricityPrice: 'NEGOTIABLE',
+    internetPrice: 'NEGOTIABLE',
+    serviceFee: 'NEGOTIABLE',
+    amenities: [],
+    media: null,
+    durationDays: null,
+    useMembershipQuota: null,
+    benefitIds: null,
+    createdAt: '2026-07-20T10:00:00',
+    updatedAt: '2026-07-20T10:00:00',
+    ...overrides,
+  }) as DraftListingResponse
+
+describe('mapDraftToFormData — package selection round trip', () => {
+  it('restores the duration, quota flag and benefit ids the draft was saved with', () => {
+    const { propertyInfo } = mapDraftToFormData(
+      makeDraft({
+        durationDays: 30,
+        useMembershipQuota: true,
+        benefitIds: [7, 9],
+      }),
+    )
+
+    // Losing these is what flipped the CTA from "Đăng tin" to "Thanh toán" and
+    // asked the user to pay for a listing their membership already covered.
+    expect(propertyInfo.durationDays).toBe(30)
+    expect(propertyInfo.useMembershipQuota).toBe(true)
+    expect(propertyInfo.benefitIds).toEqual([7, 9])
+  })
+
+  it('leaves the package fields undefined when the draft never had them', () => {
+    const { propertyInfo } = mapDraftToFormData(makeDraft())
+
+    expect(propertyInfo.durationDays).toBeUndefined()
+    expect(propertyInfo.useMembershipQuota).toBeUndefined()
+    expect(propertyInfo.benefitIds).toBeUndefined()
+  })
+})

--- a/src/utils/property/mapListingToFormData.ts
+++ b/src/utils/property/mapListingToFormData.ts
@@ -44,6 +44,9 @@ interface ExtendedAddress {
 
 type ListingLikeDetail = ListingDetail | ListingOwnerDetail
 
+/** Province/district/ward codes arrive as either a string or a number. */
+type AddressCode = string | number | null
+
 // Extended listing type that includes direct categoryId field from API response
 type ExtendedListingDetail = ListingLikeDetail & { categoryId?: number }
 
@@ -421,9 +424,9 @@ export function mapDraftToFormData(
   if (draft.address) {
     const address = draft.address as DraftListingResponse['address'] & {
       // Unified address fields returned by current backend
-      provinceCode?: string | number | null
-      districtCode?: string | number | null
-      wardCode?: string | number | null
+      provinceCode?: AddressCode
+      districtCode?: AddressCode
+      wardCode?: AddressCode
       provinceName?: string | null
       wardName?: string | null
       street?: string | null

--- a/src/utils/property/mapListingToFormData.ts
+++ b/src/utils/property/mapListingToFormData.ts
@@ -306,14 +306,6 @@ export function mapListingToFormData(
 export function mapDraftToFormData(
   draft: DraftListingResponse,
 ): MappedFormData {
-  const draftAny = draft as DraftListingResponse & {
-    durationDays?: number | string | null
-    postDate?: string | Date | null
-    expiryDate?: string | Date | null
-    benefitIds?: Array<number | string> | null
-    useMembershipQuota?: boolean | null
-  }
-
   const amenityIds =
     draft.amenities?.map((a) => {
       if (typeof a === 'object' && a !== null) {
@@ -344,14 +336,10 @@ export function mapDraftToFormData(
       ? (draft.vipType.toUpperCase() as CreateListingRequest['vipType'])
       : undefined
 
-  const draftDurationDays = toNumber(draftAny.durationDays)
-  const draftPostDate = draftAny.postDate ? new Date(draftAny.postDate) : null
-  const draftExpiryDate = draftAny.expiryDate
-    ? new Date(draftAny.expiryDate)
-    : null
+  const draftDurationDays = toNumber(draft.durationDays)
 
-  const draftBenefitIds = Array.isArray(draftAny.benefitIds)
-    ? draftAny.benefitIds
+  const draftBenefitIds = Array.isArray(draft.benefitIds)
+    ? draft.benefitIds
         .map((id) => toNumber(id))
         .filter((id): id is number => typeof id === 'number' && !isNaN(id))
     : undefined
@@ -408,18 +396,13 @@ export function mapDraftToFormData(
     amenityIds: validAmenityIds,
     vipType,
     durationDays: draftDurationDays as CreateListingRequest['durationDays'],
-    postDate:
-      draftPostDate && !isNaN(draftPostDate.getTime())
-        ? draftPostDate
-        : undefined,
-    expiryDate:
-      draftExpiryDate && !isNaN(draftExpiryDate.getTime())
-        ? draftExpiryDate
-        : undefined,
+    // postDate/expiryDate are intentionally absent: listing_drafts has no columns
+    // for them, so they were read off a cast and were always undefined. The
+    // package step re-derives them from durationDays.
     benefitIds: draftBenefitIds,
     useMembershipQuota:
-      typeof draftAny.useMembershipQuota === 'boolean'
-        ? draftAny.useMembershipQuota
+      typeof draft.useMembershipQuota === 'boolean'
+        ? draft.useMembershipQuota
         : undefined,
   }
 


### PR DESCRIPTION
⚠️ Cần **backend PR Vuhuydiet/smartrent-backend#453 (V117)** lên trước thì ba cột mới mới có dữ liệu.

Hai lỗi, đều làm **mất việc của user trong im lặng**.

## 1. Guard tắt hoàn toàn khi đang sửa nháp

`createPostDraftGuard` mở đầu bằng `if (draftId) return false`. Cả bốn đường chặn — click link, `routeChangeStart`, `popstate`, `beforeunload` — đều treo trên đúng cờ đó. Mở nháp, sửa lại giá, bấm bất kỳ mục nào ở sidebar: **không dialog, không lưu, mất sạch**.

Hệ quả kèm theo: nhánh `if (draftId) updateDraft(...)` trong `saveDraft` là **dead code không bao giờ chạy tới**.

Comment biện minh bằng "already saved" — chỉ đúng tại thời điểm nháp vừa load, không đúng sau khi user gõ. Giờ snapshot lúc load và chỉ chặn khi **thực sự có thay đổi**.

Hai chi tiết để tránh phiền ngược lại:
- So sánh có chuẩn hoá thứ tự key trước. `propertyInfo` được dựng lại bằng spread mỗi lần update, nên `JSON.stringify` trần sẽ báo khác chỉ vì một key được thêm vào — và dialog sẽ nhảy ra trên cả nháp chưa đụng tới.
- Bấm "Cập nhật tin nháp" sẽ re-baseline snapshot qua một event mới, để lưu xong rồi rời trang không bị hỏi lưu lại lần nữa.

## 2. Mở lại nháp là mất gói đã chọn

`mapDraftToFormData` đọc `durationDays`, `useMembershipQuota`, `benefitIds`, `postDate`, `expiryDate` qua một cast tự viết:

```ts
const draftAny = draft as DraftListingResponse & { durationDays?: ... }
```

**Cả năm field đều không tồn tại** trên `DraftListingResponse`, và không có cột nào trên `listing_drafts` — nên chúng luôn là `undefined`. Chính cái cast che mắt `tsc`.

Kết quả: thời hạn âm thầm về mặc định, và vì hai field quota biến mất, `needsPaymentSelection` đổi CTA từ **"Đăng tin"** sang **"Thanh toán"** — đòi user trả tiền cho tin mà hội viên đã bao.

Ba field đầu là cột thật kể từ V117, giờ được khai báo trên `DraftListingResponse` và đọc trực tiếp, bỏ cast. `postDate`/`expiryDate` bỏ luôn cùng cast: không có cột, nên đoạn code giả vờ khôi phục chúng chỉ khôi phục `undefined`.

Ngoài ra hai tên event chuyển vào `constants/events.ts` thay vì literal lặp ở hai component.

## Kiểm tra

| Lệnh | Kết quả |
| --- | --- |
| `npm run typecheck` | exit 0 |
| `npx eslint src` | 0 error; 21 warning `text-2xl` đều là sẵn có ở file không đụng tới, file tôi sửa sạch |
| `npm run i18n:check` | in sync |
| `npm run test -- --run` | 41 passed (thêm 2 test round-trip gói) |

Chưa chạy thử tay trên app: guard là hành vi điều hướng, cần bấm thật để xác nhận không có dialog thừa.