### PR TITLE
fix(styles): exclude docs/ from Tailwind content scan

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,11 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* Exclude non-source prose from Tailwind's content scan: it treats any
+   backslash-escape-looking text (e.g. Windows paths in docs) as a CSS
+   unicode escape and can crash on out-of-range codepoints. */
+@source not "../../docs";
+
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
Tailwind v4 auto-scans the whole repo for class candidates. A Windows path in docs/superpowers/plans/2026-07-20-asking-price-evaluation.md (\b65821b0-...) was parsed as a CSS unicode escape and decoded to an out-of-range codepoint, crashing dev/build with
`RangeError: Invalid code point`.