### PR TITLE
Remove client-side caching for homepage VIP-tier listing carousels

### DIFF
--- a/src/hooks/useListings/useRecommendedListingsByVip.ts
+++ b/src/hooks/useListings/useRecommendedListingsByVip.ts
@@ -41,12 +41,8 @@ export const useRecommendedListingsByVip = (
       return response.data || []
     },
     enabled: enabled,
-    // Matches the backend's shared listing.search cache TTL (5m) for every
-    // homepage-tier carousel — Nổi bật/Đề xuất/Mới all read from the same
-    // Redis bucket, so a shorter client staleTime would just refetch the
-    // same cached response.
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
+    staleTime: 0,
+    gcTime: 0,
   })
 
   return {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,12 +50,10 @@ const queryClient = new QueryClient()
 // API is only hit when the cache is missing (or stale, via background revalidate).
 // Persisted:
 //   - homepage stats: province-stats (địa điểm) + category-stats (danh mục)
-//   - homepage VIP-tier carousels (recommended-listings-by-vip), incl. "Tin mới"
-// so those carousels show cached listings instantly on refresh instead of a
-// skeleton, then revalidate in the background per their staleTime.
-// Everything else (auth, search results, detail pages, …) is intentionally NOT
-// persisted. SSR-safe: localStorage only exists in the browser, so the persister
-// is null on the server and we fall back to a plain QueryClientProvider there.
+// Everything else (auth, search results, homepage VIP-tier carousels, detail
+// pages, …) is intentionally NOT persisted. SSR-safe: localStorage only exists
+// in the browser, so the persister is null on the server and we fall back to a
+// plain QueryClientProvider there.
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
 const queryPersister =
@@ -72,8 +70,7 @@ const shouldPersistQuery = (query: Query): boolean => {
   if (scope === 'homepage') {
     return section === 'province-stats' || section === 'category-stats'
   }
-  // Homepage VIP-tier carousels (DIAMOND/GOLD/SILVER/NORMAL incl. "Tin mới").
-  return scope === 'recommended-listings-by-vip'
+  return false
 }
 
 function AppContent({ Component, pageProps }: AppPropsWithLayout) {


### PR DESCRIPTION
Tin nổi bật/Tin đề xuất/Đáng chú ý/Tin mới should always show fresh listings instead of stale react-query cache or localStorage-persisted data.