### PR TITLE
fix(styles): prevent horizontal scroll on mobile

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -321,6 +321,15 @@
     min-height: 100dvh;
     width: 100%;
   }
+  /* Actually enforce the "no horizontal scroll" intent above. `clip` (not
+     `hidden`) contains any element that bleeds past the viewport edge without
+     creating a scroll container, so the sticky header keeps working. Applied
+     to body/#__next rather than html because `clip` does not propagate to the
+     viewport from the root element. */
+  body,
+  #__next {
+    overflow-x: clip;
+  }
   @supports (min-height: 100svh) {
     html,
     body,


### PR DESCRIPTION
The html/body/#__next rule claimed to "avoid horizontal scroll" but only set width:100% and never enforced it, so any element bleeding past the viewport edge produced a horizontal scrollbar on mobile. Add overflow-x: clip on body/#__next — clip contains the overflow without creating a scroll container (so the sticky header keeps working) and is set on body/#__next rather than html because clip does not propagate to the viewport from the root element.