### PR TITLE
fix(recently-viewed): persist broker fields so card shows broker frame

### DIFF
--- a/src/utils/localstorage/recentlyViewed.ts
+++ b/src/utils/localstorage/recentlyViewed.ts
@@ -46,6 +46,13 @@ export interface RecentlyViewedListing {
     phoneCode?: string
     phoneNumber?: string
     email?: string
+    isBroker?: boolean | null
+    brokerVerificationStatus?:
+      | 'NONE'
+      | 'PENDING'
+      | 'APPROVED'
+      | 'REJECTED'
+      | null
   }
   // Property details
   bedrooms?: number

--- a/src/utils/recentlyViewed/mapper.ts
+++ b/src/utils/recentlyViewed/mapper.ts
@@ -58,6 +58,8 @@ export const mapListingToRecentlyViewed = (
           phoneCode: listing.user.phoneCode,
           phoneNumber: listing.user.phoneNumber,
           email: listing.user.email,
+          isBroker: listing.user.isBroker,
+          brokerVerificationStatus: listing.user.brokerVerificationStatus,
         }
       : undefined,
     // Property details
@@ -256,6 +258,9 @@ export const mapRecentlyViewedToListing = (
           email: recentlyViewed.user.email || '',
           phoneNumber: recentlyViewed.user.phoneNumber || '',
           phoneCode: recentlyViewed.user.phoneCode || '',
+          isBroker: recentlyViewed.user.isBroker,
+          brokerVerificationStatus:
+            recentlyViewed.user.brokerVerificationStatus,
           idDocument: '',
           taxNumber: '',
           contactPhoneNumber: '',


### PR DESCRIPTION
Recently-viewed pipeline dropped isBroker/brokerVerificationStatus when saving to localStorage, so PropertyCard's isProfessionalBroker was always false and the broker frame never rendered in 'Tin đăng đã xem'. Carry both fields through the localStorage user type and both mapper directions.