### PR TITLE
fix(create-post): seed useMembershipQuota default in initial property…

### DIFF
--- a/src/contexts/createPost/index.tsx
+++ b/src/contexts/createPost/index.tsx
@@ -103,6 +103,7 @@ export const CreatePostProvider: React.FC<CreatePostProviderProps> = ({
       listingType: LISTING_TYPE.RENT,
       vipType: 'NORMAL',
       durationDays: DURATIONDAYS.DAYS_10,
+      useMembershipQuota: false,
       postDate,
       expiryDate: new Date(postDate.getTime() + 10 * 24 * 60 * 60 * 1000),
     }


### PR DESCRIPTION
…Info

The create-post form seeds vipType/durationDays as package defaults but never seeded useMembershipQuota, so a draft saved before the user opens the benefits picker sends the field as undefined and it's dropped from the JSON body, tripping a backend NOT NULL constraint on listing_drafts.use_membership_quota.