### PR TITLE
fix(create-post): clarify draft-leave dialog copy when updating an ex…

### DIFF
--- a/src/components/molecules/createPostDraftGuard/index.tsx
+++ b/src/components/molecules/createPostDraftGuard/index.tsx
@@ -39,7 +39,8 @@ const canonicalize = (value: unknown): unknown => {
   return value
 }
 
-const snapshotOf = (value: unknown): string => JSON.stringify(canonicalize(value))
+const snapshotOf = (value: unknown): string =>
+  JSON.stringify(canonicalize(value))
 
 export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
   children,
@@ -132,7 +133,10 @@ export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
 
     window.addEventListener(CREATE_POST_DRAFT_SAVED_EVENT, handleDraftSaved)
     return () =>
-      window.removeEventListener(CREATE_POST_DRAFT_SAVED_EVENT, handleDraftSaved)
+      window.removeEventListener(
+        CREATE_POST_DRAFT_SAVED_EVENT,
+        handleDraftSaved,
+      )
   }, [propertyInfo])
 
   // Allow specific flows (e.g., external payment redirect) to bypass this guard.
@@ -383,6 +387,7 @@ export const CreatePostDraftGuard: React.FC<CreatePostDraftGuardProps> = ({
         onCancel={handleCancel}
         onClose={handleClose}
         isSaving={isDraftSaving}
+        isExistingDraft={Boolean(draftId)}
       />
     </>
   )

--- a/src/components/molecules/saveDraftDialog/index.tsx
+++ b/src/components/molecules/saveDraftDialog/index.tsx
@@ -17,6 +17,7 @@ interface SaveDraftDialogProps {
   onCancel: () => void
   onClose?: () => void
   isSaving?: boolean
+  isExistingDraft?: boolean
 }
 
 const DIALOG_CONTAINER_CLASS =
@@ -28,6 +29,7 @@ export const SaveDraftDialog: React.FC<SaveDraftDialogProps> = ({
   onCancel,
   onClose,
   isSaving = false,
+  isExistingDraft = false,
 }) => {
   const t = useTranslations('createPost.draftDialog')
 
@@ -69,10 +71,10 @@ export const SaveDraftDialog: React.FC<SaveDraftDialogProps> = ({
 
             <DialogHeader className='gap-2 pb-0 text-left'>
               <DialogTitle className='text-xl leading-tight font-semibold'>
-                {t('title')}
+                {t(isExistingDraft ? 'titleUpdate' : 'title')}
               </DialogTitle>
               <DialogDescription className='text-sm leading-6 text-muted-foreground'>
-                {t('description')}
+                {t(isExistingDraft ? 'descriptionUpdate' : 'description')}
               </DialogDescription>
             </DialogHeader>
           </div>
@@ -91,7 +93,13 @@ export const SaveDraftDialog: React.FC<SaveDraftDialogProps> = ({
               disabled={isSaving}
               className='w-full sm:w-auto sm:min-w-[160px]'
             >
-              {isSaving ? t('saving') : t('save')}
+              {isExistingDraft
+                ? isSaving
+                  ? t('savingUpdate')
+                  : t('saveUpdate')
+                : isSaving
+                  ? t('saving')
+                  : t('save')}
             </Button>
           </DialogFooter>
         </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1086,7 +1086,11 @@
     "draftDialog": {
       "title": "Save as Draft?",
       "description": "You have unsaved changes. Do you want to save this post as a draft before leaving?",
+      "titleUpdate": "Save draft update?",
+      "descriptionUpdate": "You have unsaved changes. Do you want to update this draft before leaving?",
       "save": "Save Draft",
+      "saveUpdate": "Update Draft",
+      "savingUpdate": "Updating...",
       "dontSave": "Don't Save",
       "discard": "Discard",
       "cancel": "Cancel",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1086,7 +1086,11 @@
     "draftDialog": {
       "title": "Lưu bản nháp?",
       "description": "Bạn có thay đổi chưa được lưu. Bạn có muốn lưu tin đăng này thành bản nháp trước khi rời đi không?",
+      "titleUpdate": "Lưu bản cập nhật nháp?",
+      "descriptionUpdate": "Bạn có thay đổi chưa được lưu. Bạn có muốn cập nhật các thay đổi này vào bản nháp trước khi rời đi không?",
       "save": "Lưu bản nháp",
+      "saveUpdate": "Cập nhật bản nháp",
+      "savingUpdate": "Đang cập nhật...",
       "dontSave": "Không Lưu",
       "discard": "Hủy bỏ",
       "cancel": "Hủy",


### PR DESCRIPTION
…isting draft

The leave-page save dialog always said "save this listing as a draft", even when the user already has a draft (draftId set) and the save action calls updateDraft rather than createDraft. Show update-specific title/description/button copy in that case so the wording matches the actual API call.