### PR TITLE
fix(customer-dialog): always refetch phone-click stats, no 30s stale …

### DIFF
--- a/src/hooks/usePhoneClickDetails/index.ts
+++ b/src/hooks/usePhoneClickDetails/index.ts
@@ -160,7 +160,7 @@ export const usePhoneClickStats = (listingId: string | number) => {
       return response.data
     },
     enabled: !!listingId,
-    staleTime: 30 * 1000,
+    staleTime: 0,
     gcTime: 5 * 60 * 1000,
   })
 }
@@ -184,7 +184,7 @@ export const useOwnerPhoneClickStats = () => {
 
       return response.data
     },
-    staleTime: 30 * 1000,
+    staleTime: 0,
     gcTime: 5 * 60 * 1000,
   })
 }
@@ -216,7 +216,7 @@ export const useUsersForMyListings = (
       return response.data
     },
     placeholderData: keepPreviousData,
-    staleTime: 30 * 1000,
+    staleTime: 0,
     gcTime: 5 * 60 * 1000,
   })
 }
@@ -247,7 +247,7 @@ export const useUsersWhoClickedListing = (
       return response.data
     },
     enabled: !!listingId,
-    staleTime: 30 * 1000,
+    staleTime: 0,
     gcTime: 5 * 60 * 1000,
   })
 }


### PR DESCRIPTION
…window

The seller customer page/dialog stat cards (total clicks, last click, per-listing click counts) were served from a 30s React Query cache, so a fresh click wouldn't show up until the cache expired even after the backend recorded it. Set staleTime to 0 on the hooks backing these views so remounting the page or refocusing the tab always pulls current data.