### PR TITLE
feat(chat): deep-link action chips + honour listing-status deep links

### DIFF
--- a/src/api/types/ai.type.ts
+++ b/src/api/types/ai.type.ts
@@ -276,7 +276,14 @@ export interface ChatSuggestion {
   /** Text shown on the chip. */
   label: string
   /** Message sent when the chip is tapped (often equals label). */
-  query: string
+  query?: string
+  /**
+   * In-app path to open instead of sending a message — set by the backend for
+   * deep-link chips ("Xem tất cả tin đăng" → /seller/listings?...). Built
+   * server-side from the tool's own arguments, never by the model. Exactly one
+   * of `query` / `url` is present.
+   */
+  url?: string
 }
 
 export interface ChatStreamSuggestionsPayload {

--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Link from 'next/link'
-import { LogIn, Maximize2, Phone } from 'lucide-react'
+import { ArrowUpRight, LogIn, Maximize2, Phone } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { TChatMessage } from '@/hooks/useChatAi'
@@ -31,6 +31,13 @@ type TAiChatBubbleProps = {
   onOpenFullDetail?: (listingId: number) => void
   onSuggestionClick?: (query: string) => void
 }
+
+// Follow-up chips share a pill shape; only the fill differs — a deep-link chip
+// is a filled primary action, a query chip is the softer outlined variant.
+const CHIP_BASE_CLASS =
+  'h-auto rounded-full px-3.5 py-1.5 text-2xs font-medium leading-normal shadow-sm transition-colors'
+const CHIP_QUERY_CLASS =
+  'border-primary/30 bg-gradient-to-br from-primary-50 to-primary-100 text-primary hover:border-primary/40 hover:from-primary-100 hover:to-primary-200 hover:text-primary'
 
 // Convert [Mã tin: xxx] to clickable links
 const processListingIds = (text: string): string => {
@@ -423,18 +430,37 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
               className='mt-2 flex flex-wrap gap-2'
               aria-label={tAi('suggestionsLabel')}
             >
-              {message.suggestions.map((suggestion) => (
-                <Button
-                  key={suggestion.query}
-                  type='button'
-                  variant='outline'
-                  size='sm'
-                  className='h-auto rounded-full border-primary/30 bg-gradient-to-br from-primary-50 to-primary-100 px-3.5 py-1.5 text-2xs font-medium leading-normal text-primary shadow-sm transition-colors hover:border-primary/40 hover:from-primary-100 hover:to-primary-200 hover:text-primary'
-                  onClick={() => onSuggestionClick?.(suggestion.query)}
-                >
-                  {suggestion.label}
-                </Button>
-              ))}
+              {message.suggestions.map((suggestion) =>
+                suggestion.url ? (
+                  // Deep link into the app (e.g. "Xem tất cả tin đăng"). The
+                  // chat panel only ever shows a few rows, so this hands the
+                  // user off to the page that owns the full list instead of
+                  // asking them to find it. Filled, so it reads as an action
+                  // rather than another thing to ask.
+                  <Button
+                    key={suggestion.url}
+                    asChild
+                    size='sm'
+                    className={CHIP_BASE_CLASS}
+                  >
+                    <Link href={suggestion.url}>
+                      {suggestion.label}
+                      <ArrowUpRight className='size-3.5' />
+                    </Link>
+                  </Button>
+                ) : (
+                  <Button
+                    key={suggestion.query}
+                    type='button'
+                    variant='outline'
+                    size='sm'
+                    className={cn(CHIP_BASE_CLASS, CHIP_QUERY_CLASS)}
+                    onClick={() => onSuggestionClick?.(suggestion.query ?? '')}
+                  >
+                    {suggestion.label}
+                  </Button>
+                ),
+              )}
             </div>
           )}
       </div>

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -48,9 +48,26 @@ import {
   isModerationFilterStatus,
   getModerationStatuses,
   extractModerationStatus,
+  toModerationFilterStatus,
   LISTING_STATUS_MODERATION_MAP,
   type ListingFilterStatus,
 } from '@/constants/postStatus'
+
+// Inverse of handleStatusChange: which tab do these filters represent? Used to
+// seed the tab from URL query params on first render. A listing status with
+// sub-filters and no moderationStatus keeps the parent tab selected — the list
+// really is showing every sub-state, so no sub-tab should look active.
+const statusFromFilters = (
+  filters: Partial<ListingFilterRequest>,
+): ListingFilterStatus => {
+  if (filters.moderationStatus) {
+    return toModerationFilterStatus(filters.moderationStatus)
+  }
+  if (filters.listingStatus) {
+    return filters.listingStatus as ListingFilterStatus
+  }
+  return POST_STATUS.ALL as ListingFilterStatus
+}
 
 const ListingsWithPagination = () => {
   const router = useRouter()
@@ -542,15 +559,19 @@ export const ListingsManagementTemplate: React.FC<
 > = ({ children }) => {
   const tNav = useTranslations('navigation.seller')
   const { user } = useAuthContext()
-  const [status, setStatus] = useState<ListingFilterStatus>(
-    POST_STATUS.ALL as ListingFilterStatus,
-  )
   const [filterOpen, setFilterOpen] = useState(false)
   const {
     items: listings,
     filters,
     updateFilters,
   } = useListContext<ListingFilterRequest>()
+  // Seeded from the filters the page parsed out of the URL, so a deep link
+  // (?listingStatus=EXPIRING_SOON — e.g. the chatbot's "Xem tất cả" chip)
+  // lands on the matching tab instead of highlighting "Tất cả" while showing
+  // a filtered list.
+  const [status, setStatus] = useState<ListingFilterStatus>(() =>
+    statusFromFilters(filters),
+  )
 
   // ── Sync tab UI when filters are externally reset ──
   // e.g. ResidentialFilterDialog "Reset" calls resetFilters() on the context,

--- a/src/pages/seller/listings/index.tsx
+++ b/src/pages/seller/listings/index.tsx
@@ -172,6 +172,15 @@ const ListingsPage: NextPageWithLayout = () => {
     [pushFiltersToQuery],
   )
 
+  // ListProvider snapshots initialFilters once, and on a cold load (typed URL,
+  // refresh, new tab) router.query is still empty on the first render — so a
+  // deep link like ?listingStatus=EXPIRING_SOON used to be dropped and the page
+  // fetched everything. Hold the tree back the one tick until the query is
+  // parsed; client-side navigations have it ready immediately.
+  if (!router.isReady) {
+    return <SeoHead title={t('userMenu.listings')} noindex />
+  }
+
   return (
     <>
       <SeoHead title={t('userMenu.listings')} noindex />
@@ -179,9 +188,7 @@ const ListingsPage: NextPageWithLayout = () => {
         <ListProvider
           fetcher={fetcher}
           initialData={[]}
-          initialFilters={
-            router?.query ? getFiltersFromQuery(router.query) : {}
-          }
+          initialFilters={getFiltersFromQuery(router.query)}
           initialPagination={{
             currentPage: 0,
             pageSize: DEFAULT_PER_PAGE,


### PR DESCRIPTION
## Vì sao

Chatbot tóm tắt tin của chủ nhà tối đa 5 dòng rồi viết bằng lời *"vui lòng truy cập mục Quản lý tin đăng"* — user không có gì để bấm. Kèm theo đó, deep link `?listingStatus=...` vào trang quản lý vốn **không hoạt động**.

## Thay đổi

- `ChatSuggestion.url` — chip có `url` render thành `Link` nền primary (kèm mũi tên) thay vì gửi message; chip `query` giữ nguyên pill viền nhạt. Backend (smartrent-ai) dựng URL từ chính tham số của tool, model không tự bịa được.
- `listingsManagementTemplate` seed tab từ filter đọc ra từ URL → `?listingStatus=EXPIRING_SOON` không còn sáng tab "Tất cả" trong khi danh sách đã lọc.
- `seller/listings` chờ `router.isReady` mới mount `ListProvider`. `ListProvider` chỉ chụp `initialFilters` một lần, mà ở lần render đầu của cold load (gõ URL / F5 / mở tab mới) `router.query` còn rỗng → mọi filter trên query param bị nuốt. Đây là bug có sẵn, sửa luôn vì deep link phụ thuộc vào nó.

## Kiểm chứng

```
npm run typecheck   # exit 0
npm run lint        # 0 errors, 21 warnings — đều là cảnh báo có sẵn ở file khác
npm run i18n:check  # 3192 keys, exit 0
npx vitest run src/hooks/useChatAi src/components/molecules/aiChatBubble  # 15 passed
```

Chưa có unit test cho `aiChatBubble` / template (repo cũng chưa có sẵn) — phần render chip chỉ được che bởi typecheck + lint.

Cần đi kèm smartrent-ai PR phát `url` trong event `suggestions`.