### PR TITLE
fix(push-listing): re-fetch push quota before deciding to charge

### DIFF
--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -190,7 +190,15 @@ const ListingsWithPagination = () => {
       return
     }
 
-    const hasQuota = quotaData?.data && quotaData.data.totalAvailable > 0
+    // Re-fetch right before deciding instead of trusting the cached
+    // `quotaData` closure value — on a fresh page load (or after the 60s
+    // staleTime lapses) that value can still be `undefined` while the
+    // query is in flight, which silently fell through to the paid flow
+    // even though the seller had membership quota available.
+    const { data: freshQuotaData } = await refetchQuota()
+    const latestQuotaData = freshQuotaData ?? quotaData
+    const hasQuota =
+      latestQuotaData?.data && latestQuotaData.data.totalAvailable > 0
     const useMembershipQuota = hasQuota ?? false
 
     if (!useMembershipQuota) {


### PR DESCRIPTION
handlePushListing decided whether to use the seller's membership push quota based on the cached usePushQuota() result, which is still undefined right after a fresh page load or once its 60s staleTime lapses. That silently defaulted to the paid flow even when the seller had quota available, so their benefit was never consumed. Refetch quota synchronously right before the decision instead of trusting the stale closure value.