### PR TITLE
feat(map): read the photo-count badge from imageCount

### DIFF
--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -254,6 +254,12 @@ export interface ListingApi {
   title: string
   description: string
   media: MediaItem[]
+  /**
+   * Real number of images on the listing, which can exceed `media.length`:
+   * map-bounds sends only the thumbnail per pin. Absent on the endpoints that
+   * still return every image.
+   */
+  imageCount?: number
   user: UserApi
   postDate: Date
   expiryDate: string

--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -79,10 +79,14 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
     vipType,
     roomCapacity,
     media,
+    imageCount,
   } = listing
 
   const images = media?.filter((m) => m.mediaType === 'IMAGE') || []
-  const totalImages = images.length
+  // map-bounds ships only the thumbnail (one image per pin, up to 500 pins a
+  // request) and reports the real total separately. Fall back to the list
+  // length for the callers that still send every image.
+  const totalImages = imageCount ?? images.length
   const mainImage = images[0]?.url
   const displayAddress = address?.fullNewAddress || address?.fullAddress
   const { firstName, lastName } = user || {}


### PR DESCRIPTION
## Vì sao

Card trên bản đồ chỉ render **1 thumbnail + badge "N ảnh"**, nhưng `map-bounds` đang serialize **toàn bộ URL ảnh của mọi pin** chỉ để badge đó có số đếm — mỗi tin 5-6 ảnh, nhân với tối đa 500 pin mỗi request.

## Thay đổi

Backend (Vuhuydiet/smartrent-backend#470) giờ gửi riêng thumbnail kèm field `imageCount` mang tổng thật. Badge đọc từ đó, **fallback về `media.length`** nên vẫn chạy đúng với backend hiện tại và với các endpoint khác vẫn trả đủ ảnh.

`imageCount?: number` thêm vào `ListingApi` (optional).

## Thứ tự merge

PR này nên **merge trước** BE. Nhờ có fallback nên nó vô hại khi đứng một mình; ngược lại nếu BE lên trước thì badge sẽ hiển thị "1" cho tới khi FE deploy.

## Kiểm chứng

- `tsc --noEmit` — pass
- `eslint` trên 2 file đổi — pass