### PR TITLE
fix(ai-chat): keep chat window border stable instead of tying it to hover

### DIFF
--- a/src/components/organisms/aiChatWidget/index.tsx
+++ b/src/components/organisms/aiChatWidget/index.tsx
@@ -199,8 +199,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
         <div
           className={cn(
             'fixed z-50 animate-in fade-in slide-in-from-bottom-8 duration-300',
-            'resize overflow-hidden rounded-2xl border-2 border-primary/20 bg-background shadow-2xl',
-            'transition-colors hover:border-primary/40',
+            'resize overflow-hidden rounded-2xl border-2 border-primary/40 bg-background shadow-2xl',
             position === 'bottom-right'
               ? 'bottom-24 right-6'
               : 'bottom-24 left-6',


### PR DESCRIPTION
## Vấn đề
Border của cửa sổ chatbot (desktop) "nhấp nháy" theo con trỏ: gần như vô hình khi không hover, chỉ hiện rõ khi rê chuột vào (kể cả khi rê qua header) — trông như mất/hiện viền.

## Root cause
Container ở [aiChatWidget/index.tsx](../blob/main/src/components/organisms/aiChatWidget/index.tsx) buộc border vào trạng thái hover của cả cửa sổ:
```
border-2 border-primary/20          // gần như vô hình lúc nghỉ
transition-colors hover:border-primary/40   // chỉ hiện khi hover
```

## Fix
Ghim border ở `border-primary/40` cố định, bỏ `transition-colors hover:border-primary/40` → viền **luôn hiển thị, ổn định**, không phản ứng theo hover nữa.

```diff
-  'resize overflow-hidden rounded-2xl border-2 border-primary/20 bg-background shadow-2xl',
-  'transition-colors hover:border-primary/40',
+  'resize overflow-hidden rounded-2xl border-2 border-primary/40 bg-background shadow-2xl',
```

## Verify
Chạy sau khi sửa (node_modules thật):
- `eslint src/components/organisms/aiChatWidget/index.tsx` → **exit 0**, no warnings
- `tsc --noEmit` → **exit 0**
- i18n:check → n/a (không đổi string)