### PR TITLE
fix: make footer policy pages (QUY ĐỊNH) public

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,6 +48,9 @@ function isPublicPath(pathname: string) {
   if (pathname.startsWith('/compare')) return true
   if (pathname.startsWith('/news')) return true
   if (pathname.startsWith('/maps')) return true
+  // Policy/legal pages (listing rules, terms, privacy, complaints) are linked
+  // from the footer and must be readable by prospects without logging in.
+  if (pathname.startsWith('/policies')) return true
 
   // Payment gateway redirect must stay public so callback page can mount
   if (pathname.startsWith('/payment/result')) return true


### PR DESCRIPTION
## Vấn đề

Cột **QUY ĐỊNH** ở footer link tới 4 trang chính sách:

- `/policies/listing-rules` — Quy định đăng tin
- `/policies/terms` — Điều khoản thỏa thuận
- `/policies/privacy` — Chính sách bảo mật
- `/policies/complaints` — Giải quyết khiếu nại

Nhưng `isPublicPath()` trong [src/middleware.ts](src/middleware.ts) chưa whitelist prefix `/policies`. Vì vậy user **chưa đăng nhập** khi bấm vào các link này sẽ bị middleware redirect sang `?auth=login` (mở dialog đăng nhập) thay vì đọc được nội dung.

Các trang này chỉ là nội dung tĩnh (dùng `MainLayout`, không có `getServerSideProps`, không có auth guard) — đúng ra phải đọc được không cần login.

## Fix

Thêm `/policies` vào danh sách public path, giống các mục công khai khác (news, maps, guides):

```ts
if (pathname.startsWith('/policies')) return true
```

Một dòng bao trọn cả 4 route vì đều bắt đầu bằng `/policies`.

## Kiểm chứng

- 4 route ở footer đều khớp prefix `/policies` ✓
- Các trang policy dùng `MainLayout` (layout public của homepage), không tự gate auth ✓

> ⚠️ Không chạy được `typecheck`/`lint` trong worktree tạm (chưa cài node_modules). Thay đổi là 1 dòng, cùng cấu trúc với 6 dòng whitelist phía trên, không thêm import/type/string mới nên không thể gây lỗi type/lint/i18n.