### PR TITLE
fix(seller-customers): remove duplicate unique-users stat card

### DIFF
--- a/src/components/molecules/customerManagement/customerManagementSkeleton/index.tsx
+++ b/src/components/molecules/customerManagement/customerManagementSkeleton/index.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/atoms/skeleton'
 import { Card } from '@/components/atoms/card'
 import { PageContainer } from '@/components/atoms/pageContainer'
 
-const STAT_KEYS = ['totalCustomers', 'totalClicks', 'uniqueUsers']
+const STAT_KEYS = ['totalCustomers', 'totalClicks']
 const ROW_KEYS = ['row-1', 'row-2', 'row-3', 'row-4', 'row-5', 'row-6']
 
 /** Skeleton for just the customer rows — reused while a search/page refetches. */
@@ -37,7 +37,7 @@ const CustomerManagementSkeleton: React.FC = () => {
       </div>
 
       {/* Stats cards */}
-      <div className='grid gap-4 grid-cols-1 md:grid-cols-3'>
+      <div className='grid gap-4 grid-cols-1 md:grid-cols-2'>
         {STAT_KEYS.map((key) => (
           <Card key={key} className='p-5'>
             <div className='flex items-center gap-3 mb-3'>

--- a/src/components/templates/customerManagementTemplate/index.tsx
+++ b/src/components/templates/customerManagementTemplate/index.tsx
@@ -17,7 +17,6 @@ import {
   ChevronRight,
   Users,
   MousePointerClick,
-  TrendingUp,
   Loader2,
   X,
 } from 'lucide-react'
@@ -93,7 +92,6 @@ const CustomerManagementTemplate = () => {
     () => ({
       totalCustomers: data?.totalElements || 0,
       totalClicks: ownerStats?.totalClicks || 0,
-      uniqueUsers: ownerStats?.uniqueUsers || 0,
     }),
     [data, ownerStats],
   )
@@ -183,12 +181,6 @@ const CustomerManagementTemplate = () => {
       label: t('stats.totalClicks'),
       iconClass: 'bg-orange-500/10 text-orange-600',
     },
-    {
-      icon: TrendingUp,
-      value: stats.uniqueUsers,
-      label: t('stats.uniqueUsers'),
-      iconClass: 'bg-green-500/10 text-green-600',
-    },
   ]
 
   const openListingDetail = (listing: ListingClickInfo) => {
@@ -206,7 +198,7 @@ const CustomerManagementTemplate = () => {
       </div>
 
       {/* Stats Cards - Desktop Grid */}
-      <div className='hidden md:grid gap-4 md:grid-cols-3'>
+      <div className='hidden md:grid gap-4 md:grid-cols-2'>
         {statCards.map(({ icon: Icon, value, label, iconClass }) => (
           <Card
             key={label}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3304,7 +3304,6 @@
       "stats": {
         "totalCustomers": "Total Customers",
         "totalClicks": "Total Phone Clicks",
-        "uniqueUsers": "Unique Users",
         "thisMonth": "This Month"
       },
       "listingCard": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3302,7 +3302,6 @@
       "stats": {
         "totalCustomers": "Tổng khách hàng",
         "totalClicks": "Tổng nhấn xem SĐT",
-        "uniqueUsers": "Người dùng duy nhất",
         "thisMonth": "Tháng này"
       },
       "listingCard": {


### PR DESCRIPTION
uniqueUsers and totalCustomers were both computed as a distinct-user count over the owner's listings (same WHERE pc.listing.userId = :ownerId condition, just via two different backend queries), so the two cards always showed the same number.