### PR TITLE
fix(customer-management): show phone click history in Vietnam time

### DIFF
--- a/src/components/molecules/customerManagement/utils.ts
+++ b/src/components/molecules/customerManagement/utils.ts
@@ -25,12 +25,26 @@ export const getInitials = (firstName: string, lastName: string): string => {
   return `${firstName?.[0] || ''}${lastName?.[0] || ''}`.toUpperCase()
 }
 
+const HAS_TIMEZONE_MARKER = /(Z|[+-]\d{2}:?\d{2})$/
+
 /**
- * Format date string to Vietnamese locale
+ * Backend serializes `clickedAt` as a naive `LocalDateTime` in UTC with no
+ * timezone suffix (e.g. "2026-07-11T03:00:00"). `new Date()` would otherwise
+ * parse it as the viewer's local time instead of UTC, shifting the displayed
+ * value by the runtime's UTC offset. Treat any string missing a timezone
+ * marker as UTC.
+ */
+export const parseApiDate = (dateString: string): Date =>
+  new Date(HAS_TIMEZONE_MARKER.test(dateString) ? dateString : `${dateString}Z`)
+
+/**
+ * Format date string to Vietnam local time, regardless of the viewer's
+ * runtime timezone
  */
 export const formatDate = (dateString: string): string => {
   try {
-    return new Date(dateString).toLocaleDateString('vi-VN', {
+    return parseApiDate(dateString).toLocaleDateString('vi-VN', {
+      timeZone: 'Asia/Ho_Chi_Minh',
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',

--- a/src/components/templates/customerManagementTemplate/hooks/useCustomerManagement.ts
+++ b/src/components/templates/customerManagementTemplate/hooks/useCustomerManagement.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import type { PhoneClickDetail } from '@/api/types/phone-click-detail.type'
 import type { Customer, ListingWithCustomers } from '@/api/types/customer.type'
 import { useMyPhoneClicks } from '@/hooks/usePhoneClickDetails'
+import { parseApiDate } from '@/components/molecules/customerManagement/utils'
 
 interface UseCustomerManagementOptions {
   isMobile: boolean
@@ -21,7 +22,7 @@ const getInitialsFromName = (name: string): string => {
  * Format relative time from ISO date string
  */
 const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString)
+  const date = parseApiDate(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
@@ -50,19 +51,18 @@ const formatRelativeTime = (dateString: string): string => {
 }
 
 /**
- * Format date to readable format
+ * Format date to readable format, in Vietnam local time regardless of the
+ * viewer's runtime timezone
  */
-const formatDate = (dateString: string): string => {
-  const date = new Date(dateString)
-  const month = date.toLocaleString('en-US', { month: 'short' })
-  const day = date.getDate()
-  const hours = date.getHours()
-  const minutes = date.getMinutes()
-  const ampm = hours >= 12 ? 'PM' : 'AM'
-  const displayHours = hours % 12 || 12
-  const displayMinutes = minutes.toString().padStart(2, '0')
-  return `${month} ${day}, ${displayHours}:${displayMinutes} ${ampm}`
-}
+const formatDate = (dateString: string): string =>
+  new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Ho_Chi_Minh',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(parseApiDate(dateString))
 
 export const useCustomerManagement = ({
   isMobile,


### PR DESCRIPTION
The backend serializes clickedAt as a naive LocalDateTime in UTC with no timezone suffix, so new Date() parsed it as the viewer's local time instead of UTC — shifting displayed timestamps in the "Lịch sử xem số điện thoại" dialog and customer/listing cards away from actual Vietnam time. Normalize the string as UTC before formatting and pin the display to Asia/Ho_Chi_Minh.