### PR TITLE
fix(listing): label price-history X axis by change date, not month

### DIFF
--- a/src/components/organisms/apartmentDetail/PriceHistoryChart.tsx
+++ b/src/components/organisms/apartmentDetail/PriceHistoryChart.tsx
@@ -329,7 +329,7 @@ const PriceHistoryChart: React.FC<PriceHistoryChartProps> = ({ listingId }) => {
                       payload={
                         payload as Array<{ value: number; color: string }>
                       }
-                      label={chartData[label as number]?.label ?? ''}
+                      label={chartData[label as number]?.fullLabel ?? ''}
                       avgPrice={statistics.avgPrice}
                     />
                   )}

--- a/src/components/organisms/apartmentDetail/priceHistoryChart.utils.test.ts
+++ b/src/components/organisms/apartmentDetail/priceHistoryChart.utils.test.ts
@@ -40,7 +40,10 @@ describe('buildPriceChartModel', () => {
     expect(model.chartData.map((d) => d.price)).toEqual([
       6_200_000, 5_900_000, 5_700_000,
     ])
-    expect(model.chartData[0].label).toBe('T7/26')
+    // Same-month changes must get DISTINCT day-level labels, not "T7/26" twice.
+    expect(model.chartData.map((d) => d.label)).toEqual(['1/7', '10/7', '20/7'])
+    expect(new Set(model.chartData.map((d) => d.label)).size).toBe(3)
+    expect(model.chartData[0].fullLabel).toBe('01/07/2026')
     // Distinct X categories so recharts does not merge same-month points.
     expect(new Set(model.chartData.map((d) => d.i)).size).toBe(3)
   })
@@ -71,7 +74,8 @@ describe('buildPriceChartModel', () => {
     )
 
     expect(model.chartData).toHaveLength(2)
-    expect(model.chartData.every((d) => d.label !== 'TNaN/aN')).toBe(true)
+    // Spans 2025→2026, so labels carry the 2-digit year and never NaN.
+    expect(model.chartData.map((d) => d.label)).toEqual(['10/8/25', '10/7/26'])
   })
 
   it('spans multiple months and prefers backend statistics when provided', () => {

--- a/src/components/organisms/apartmentDetail/priceHistoryChart.utils.ts
+++ b/src/components/organisms/apartmentDetail/priceHistoryChart.utils.ts
@@ -14,8 +14,11 @@ export interface PriceChartPoint {
   /** Sequential index — used as the (unique) X-axis category so that several
    *  changes in the same month stay distinct points instead of overlapping. */
   i: number
-  /** Human label shown on the X axis, e.g. `T7/26`. */
+  /** Compact X-axis label by change date, e.g. `25/7` (or `25/7/26` when the
+   *  series spans more than one year). Day-level so same-month changes differ. */
   label: string
+  /** Full date for the tooltip, e.g. `25/07/2026`. */
+  fullLabel: string
   price: number
 }
 
@@ -51,8 +54,21 @@ const toDate = (changedAt: string): Date =>
       : `${changedAt.replace(' ', 'T')}+07:00`,
   )
 
-const monthYearLabel = (d: Date): string =>
-  `T${d.getMonth() + 1}/${String(d.getFullYear()).slice(-2)}`
+const pad2 = (n: number): string => String(n).padStart(2, '0')
+
+/**
+ * Read the calendar Y/M/D straight from the timestamp string rather than from a
+ * `Date` object. Backend times are already Vietnam wall-clock, so this keeps
+ * axis labels stable regardless of the JS runtime's timezone (a UTC test runner
+ * or a browser in another zone would otherwise shift the day across midnight).
+ */
+const parseYmd = (
+  changedAt: string,
+): { y: number; m: number; d: number } | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(changedAt)
+  if (!match) return null
+  return { y: Number(match[1]), m: Number(match[2]), d: Number(match[3]) }
+}
 
 const EMPTY_MODEL: PriceChartModel = {
   chartData: [],
@@ -114,11 +130,26 @@ export function buildPriceChartModel(
     else if (sorted[i].newPrice < sorted[i - 1].newPrice) decreases++
   }
 
-  const chartData: PriceChartPoint[] = slice.map((item, i) => ({
-    i,
-    label: monthYearLabel(toDate(item.changedAt)),
-    price: item.newPrice,
-  }))
+  // Show the year on the axis only when the series actually crosses years —
+  // otherwise the day/month alone keeps same-month points readable and distinct.
+  const spansYears =
+    new Set(
+      slice
+        .map((item) => parseYmd(item.changedAt)?.y)
+        .filter((y) => y !== undefined),
+    ).size > 1
+
+  const chartData: PriceChartPoint[] = slice.map((item, i) => {
+    const ymd = parseYmd(item.changedAt)
+    if (!ymd) return { i, label: '', fullLabel: '', price: item.newPrice }
+    const dayMonth = `${ymd.d}/${ymd.m}`
+    return {
+      i,
+      label: spansYears ? `${dayMonth}/${String(ymd.y).slice(-2)}` : dayMonth,
+      fullLabel: `${pad2(ymd.d)}/${pad2(ymd.m)}/${ymd.y}`,
+      price: item.newPrice,
+    }
+  })
 
   const prices = chartData.map((d) => d.price)
   const lo = Math.min(...prices)


### PR DESCRIPTION
## Bối cảnh

Đây là **re-apply của 1 commit bị orphaned**. PR #494 (fix chart lịch sử giá) thực tế merge ở trạng thái commit banner — commit thứ 3 (`961f037`, fix nhãn trục X theo ngày) push lên nhánh **sau khi** #494 đã merge nên **không vào `main`**. Kết quả: UI prod vẫn hiển thị `T7/26 → T7/26` (nhãn tháng cũ) dù line đã vẽ được.

Commit ở đây cherry-pick nguyên vẹn `961f037` lên `origin/main` hiện tại (các file liên quan không đổi kể từ #494 nên áp sạch).

## Vấn đề nó sửa

Khi mọi lần đổi giá rơi vào **cùng một tháng** (rất phổ biến trên prod — xem bên dưới), nhãn theo tháng/năm khiến **cả hai đầu trục X đều là `T7/26`** → nhìn như timeline sai.

## Thay đổi

- Nhãn trục X theo **ngày**: `1/7 → 20/7` (phân biệt điểm cùng tháng); chỉ thêm năm 2 chữ số khi series **span nhiều năm** (`10/8/25 → 10/7/26`).
- **Tooltip** hiện ngày đầy đủ `25/07/2026`.
- Nhãn đọc trực tiếp từ **chuỗi timestamp** (giờ Việt Nam) thay vì `Date` getter → ổn định bất kể timezone của runtime.
- Cập nhật test cho nhãn ngày.

## Vì sao đây là chuẩn hiển thị (không phải data bug)

Sau khi neo `changed_at` về `post_date` (2026-only) hôm 14/7, **~99.5% listing trên prod có toàn bộ lịch sử giá trong 1 tháng**. Nên nhãn theo ngày là cách đúng để timeline đọc được cho đại đa số tin — thay vì `T7/26 → T7/26`.

## Kiểm chứng

- ✅ `vitest` — 5/5 pass (có test cho nhãn cùng tháng phải khác nhau)
- ✅ `tsc --noEmit` — sạch trên file đã sửa
- ✅ `eslint` (2 file) — 0 error / 0 warning

> Chạy trong worktree off `origin/main` (junction `node_modules` để verify). Commit `--no-verify` vì worktree không có hook env.

