### PR TITLE
feat(contact): gate all contact-reveal buttons behind login + audit

### DIFF
--- a/src/api/services/contactReveal.service.ts
+++ b/src/api/services/contactReveal.service.ts
@@ -1,0 +1,34 @@
+/**
+ * Contact Reveal Service
+ * Fire-and-forget audit of contact reveals. Every time an authenticated user
+ * reveals a seller's contact (phone / email / zalo) we POST to the backend so
+ * the access is tracked. Tracking must never disrupt the contact UX, so this
+ * always resolves and never throws.
+ * @module api/services/contactReveal
+ */
+
+import { apiRequest } from '@/configs/axios/instance'
+
+export type ContactRevealChannel = 'PHONE' | 'EMAIL' | 'ZALO'
+
+export class ContactRevealService {
+  static async logReveal(
+    sellerUserId: string | undefined,
+    channel: ContactRevealChannel,
+    listingId?: number,
+  ): Promise<void> {
+    if (!sellerUserId) return
+
+    // apiRequest already swallows errors and returns { success: false }; the
+    // extra guard keeps a rejected promise from ever surfacing to the caller.
+    try {
+      await apiRequest({
+        method: 'POST',
+        url: `/v1/users/${sellerUserId}/reveal-contact`,
+        data: { channel, listingId },
+      })
+    } catch {
+      // no-op: reveal logging is best-effort
+    }
+  }
+}

--- a/src/components/atoms/copy-button/index.tsx
+++ b/src/components/atoms/copy-button/index.tsx
@@ -16,6 +16,8 @@ interface CopyButtonProps {
   className?: string
   iconSize?: number
   variant?: 'ghost' | 'outline' | 'default'
+  /** Called after a successful copy — used to audit contact reveals. */
+  onCopy?: () => void
 }
 
 const CopyButton: React.FC<CopyButtonProps> = ({
@@ -24,6 +26,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   className,
   iconSize = 14,
   variant = 'ghost',
+  onCopy,
 }) => {
   const [copied, setCopied] = useState(false)
 
@@ -32,6 +35,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)
+      onCopy?.()
       if (successMessage) {
         toast.success(successMessage)
       }

--- a/src/components/molecules/aiChatContactCard/index.tsx
+++ b/src/components/molecules/aiChatContactCard/index.tsx
@@ -7,6 +7,9 @@ import { Phone, Mail, ArrowRight } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/atoms/avatar'
 import { cn } from '@/lib/utils'
 import type { ChatListing } from '@/api/types/ai.type'
+import { useContactRevealGuard } from '@/hooks/useAuth'
+import { ContactRevealService } from '@/api/services/contactReveal.service'
+import LoginRequiredDialog from '@/components/molecules/loginRequiredDialog'
 
 interface AiChatContactCardProps {
   listing: ChatListing
@@ -29,11 +32,99 @@ const formatVNPhone = (phone: string): string => {
   return phone
 }
 
+const CONTACT_ROW_CLASSNAME =
+  'flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent transition-colors w-full text-left'
+
+interface ContactRowProps {
+  icon: React.ReactNode
+  label: string
+  value: string
+  href: string
+  isAuthenticated: boolean
+  onRequireAuth: () => void
+  guestLabel: string
+  external?: boolean
+  /** When true, the real value is replaced with `guestLabel` for guests. */
+  hideValueForGuest?: boolean
+  trailing?: React.ReactNode
+  /** Audit callback fired when an authenticated user opens this contact. */
+  onReveal?: () => void
+}
+
+// A guest never gets the real value or a live href in the DOM — the row is a
+// plain button that opens the login gate. Only after auth is the real
+// phone/email/link wired into an anchor.
+const ContactRow: React.FC<ContactRowProps> = ({
+  icon,
+  label,
+  value,
+  href,
+  isAuthenticated,
+  onRequireAuth,
+  guestLabel,
+  external = false,
+  hideValueForGuest = false,
+  trailing,
+  onReveal,
+}) => {
+  const displayValue =
+    !isAuthenticated && hideValueForGuest ? guestLabel : value
+
+  const body = (
+    <>
+      <div className='w-8 h-8 rounded-md bg-muted/50 border border-border flex items-center justify-center flex-shrink-0'>
+        {icon}
+      </div>
+      <div className='min-w-0 flex-1 overflow-hidden'>
+        <p className='text-xs uppercase tracking-wide text-muted-foreground leading-none mb-1'>
+          {label}
+        </p>
+        <p className='text-sm text-foreground truncate leading-tight'>
+          {displayValue}
+        </p>
+      </div>
+      {trailing}
+    </>
+  )
+
+  if (!isAuthenticated) {
+    return (
+      <button
+        type='button'
+        className={CONTACT_ROW_CLASSNAME}
+        onClick={(e) => {
+          e.stopPropagation()
+          onRequireAuth()
+        }}
+      >
+        {body}
+      </button>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      className={CONTACT_ROW_CLASSNAME}
+      onClick={(e) => {
+        e.stopPropagation()
+        onReveal?.()
+      }}
+    >
+      {body}
+    </a>
+  )
+}
+
 const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
   listing,
   className,
 }) => {
   const t = useTranslations('chat.contact')
+  const tContact = useTranslations('contactAccess')
+  const { isAuthenticated, requireAuth, dialogProps } = useContactRevealGuard()
   const { user, ownerContactPhoneNumber, ownerZaloLink } = listing
 
   if (!user) return null
@@ -44,6 +135,8 @@ const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
   const email = user.email
   const zaloLink = ownerZaloLink
   const sellerPageUrl = `/properties/seller/${user.userId}`
+  const guestLabel = tContact('viewContactCta')
+  const onRequireAuth = () => requireAuth()
 
   return (
     <div
@@ -76,65 +169,50 @@ const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
 
       <div className='mx-3 border-t border-border' />
 
-      {/* ── Contact rows ── */}
+      {/* ── Contact rows (gated behind login) ── */}
       <div className='p-2 space-y-0.5'>
         {phone && (
-          <a
-            href={`https://zalo.me/${phone.replace(/\D/g, '')}`}
-            target='_blank'
-            rel='noopener noreferrer'
-            className='flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent transition-colors'
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className='w-8 h-8 rounded-md bg-muted/50 border border-border flex items-center justify-center flex-shrink-0'>
+          <ContactRow
+            icon={
               <Phone
                 className='w-3.5 h-3.5 text-muted-foreground'
                 aria-hidden='true'
               />
-            </div>
-            <div className='min-w-0 flex-1'>
-              <p className='text-xs uppercase tracking-wide text-muted-foreground leading-none mb-1'>
-                Điện thoại
-              </p>
-              <p className='text-sm text-foreground tabular-nums leading-tight'>
-                {formatVNPhone(phone)}
-              </p>
-            </div>
-          </a>
+            }
+            label='Điện thoại'
+            value={formatVNPhone(phone)}
+            href={`https://zalo.me/${phone.replace(/\D/g, '')}`}
+            external
+            hideValueForGuest
+            isAuthenticated={isAuthenticated}
+            onRequireAuth={onRequireAuth}
+            guestLabel={guestLabel}
+            onReveal={() => ContactRevealService.logReveal(user.userId, 'PHONE')}
+          />
         )}
 
         {email && (
-          <a
-            href={`mailto:${email}`}
-            className='flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent transition-colors'
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className='w-8 h-8 rounded-md bg-muted/50 border border-border flex items-center justify-center flex-shrink-0'>
+          <ContactRow
+            icon={
               <Mail
                 className='w-3.5 h-3.5 text-muted-foreground'
                 aria-hidden='true'
               />
-            </div>
-            <div className='min-w-0 flex-1 overflow-hidden'>
-              <p className='text-xs uppercase tracking-wide text-muted-foreground leading-none mb-1'>
-                Email
-              </p>
-              <p className='text-sm text-foreground truncate leading-tight'>
-                {email}
-              </p>
-            </div>
-          </a>
+            }
+            label='Email'
+            value={email}
+            href={`mailto:${email}`}
+            hideValueForGuest
+            isAuthenticated={isAuthenticated}
+            onRequireAuth={onRequireAuth}
+            guestLabel={guestLabel}
+            onReveal={() => ContactRevealService.logReveal(user.userId, 'EMAIL')}
+          />
         )}
 
         {zaloLink && (
-          <a
-            href={zaloLink}
-            target='_blank'
-            rel='noopener noreferrer'
-            className='flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent transition-colors'
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className='w-8 h-8 rounded-md bg-muted/50 border border-border flex items-center justify-center flex-shrink-0'>
+          <ContactRow
+            icon={
               <Image
                 src='/svg/zalo.svg'
                 alt='Zalo'
@@ -142,21 +220,25 @@ const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
                 height={16}
                 aria-hidden='true'
               />
-            </div>
-            <div className='min-w-0 flex-1'>
-              <p className='text-xs uppercase tracking-wide text-muted-foreground leading-none mb-1'>
-                Nhắn tin
-              </p>
-              <p className='text-sm text-foreground leading-tight'>Zalo</p>
-            </div>
-            <span className='text-xs font-medium bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 flex-shrink-0'>
-              Mở
-            </span>
-          </a>
+            }
+            label='Nhắn tin'
+            value='Zalo'
+            href={zaloLink}
+            external
+            isAuthenticated={isAuthenticated}
+            onRequireAuth={onRequireAuth}
+            guestLabel={guestLabel}
+            onReveal={() => ContactRevealService.logReveal(user.userId, 'ZALO')}
+            trailing={
+              <span className='text-xs font-medium bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 flex-shrink-0'>
+                Mở
+              </span>
+            }
+          />
         )}
       </div>
 
-      {/* ── CTA footer link ── */}
+      {/* ── CTA footer link (navigation only, not gated) ── */}
       <Link
         href={sellerPageUrl}
         target='_blank'
@@ -173,6 +255,8 @@ const AiChatContactCard: React.FC<AiChatContactCardProps> = ({
           aria-hidden='true'
         />
       </Link>
+
+      <LoginRequiredDialog {...dialogProps} />
     </div>
   )
 }

--- a/src/components/molecules/loginRequiredDialog/index.test.tsx
+++ b/src/components/molecules/loginRequiredDialog/index.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import LoginRequiredDialog from './index'
+
+// next-intl is globally mocked in src/test/setup.ts to echo the key back, so
+// assertions below match on the translation keys.
+describe('LoginRequiredDialog', () => {
+  it('renders the shared login-required copy when open', () => {
+    render(
+      <LoginRequiredDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />,
+    )
+
+    expect(screen.getByText('loginRequiredTitle')).toBeInTheDocument()
+    expect(screen.getByText('loginRequiredDescription')).toBeInTheDocument()
+    expect(screen.getByText('loginNow')).toBeInTheDocument()
+    expect(screen.getByText('cancel')).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when the login button is clicked', () => {
+    const onConfirm = vi.fn()
+    render(
+      <LoginRequiredDialog open onOpenChange={vi.fn()} onConfirm={onConfirm} />,
+    )
+
+    fireEvent.click(screen.getByText('loginNow'))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes via onOpenChange when cancel is clicked', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <LoginRequiredDialog
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('cancel'))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('prefers explicit title/description overrides when provided', () => {
+    render(
+      <LoginRequiredDialog
+        open
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+        title='Custom title'
+        description='Custom description'
+      />,
+    )
+
+    expect(screen.getByText('Custom title')).toBeInTheDocument()
+    expect(screen.getByText('Custom description')).toBeInTheDocument()
+  })
+})

--- a/src/components/molecules/loginRequiredDialog/index.tsx
+++ b/src/components/molecules/loginRequiredDialog/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/atoms/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/atoms/dialog'
+
+interface LoginRequiredDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  /** Optional overrides; default to the shared `contactAccess` copy. */
+  title?: string
+  description?: string
+}
+
+/**
+ * Shared "you must log in first" confirmation used before any action that
+ * would reveal a user's real contact details (phone / email / Zalo). Pairs
+ * with the `useContactRevealGuard` hook, which owns the open/confirm state.
+ */
+const LoginRequiredDialog: React.FC<LoginRequiredDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  title,
+  description,
+}) => {
+  const t = useTranslations('contactAccess')
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='w-[92vw] max-w-md p-5 sm:p-6'>
+        <DialogHeader className='pb-2'>
+          <DialogTitle>{title ?? t('loginRequiredTitle')}</DialogTitle>
+          <DialogDescription>
+            {description ?? t('loginRequiredDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className='mt-2'>
+          <Button variant='outline' onClick={() => onOpenChange(false)}>
+            {t('cancel')}
+          </Button>
+          <Button onClick={onConfirm}>{t('loginNow')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default LoginRequiredDialog

--- a/src/components/molecules/sellerPublicProfileCard/index.tsx
+++ b/src/components/molecules/sellerPublicProfileCard/index.tsx
@@ -13,9 +13,15 @@ import { Skeleton } from '@/components/atoms/skeleton'
 import { Typography } from '@/components/atoms/typography'
 import CopyButton from '@/components/atoms/copy-button'
 import { UserApi } from '@/api/types'
-import { Mail, MessageCircle, Phone, ShieldCheck } from 'lucide-react'
+import { Copy, Mail, MessageCircle, Phone, ShieldCheck } from 'lucide-react'
 import BrokerAvatar from '@/components/molecules/brokerAvatar'
 import FollowButton from '@/components/molecules/followButton'
+import LoginRequiredDialog from '@/components/molecules/loginRequiredDialog'
+import { useContactRevealGuard } from '@/hooks/useAuth'
+import {
+  ContactRevealService,
+  type ContactRevealChannel,
+} from '@/api/services/contactReveal.service'
 
 interface SellerPublicProfileCardProps {
   seller?: UserApi | null
@@ -52,11 +58,90 @@ const maskEmail = (value: string): string => {
 const CONTACT_PILL_CLASSNAME =
   'flex items-center gap-2.5 text-sm rounded-lg border border-primary/25 p-2.5 bg-background/85 transition-colors hover:border-primary/45 w-full'
 
+const ICON_BUTTON_CLASSNAME = 'h-8 w-8 text-primary hover:bg-primary/10'
+
+const ZALO_BUTTON_CLASSNAME =
+  'w-full justify-center gap-2 border-primary/30 text-primary hover:bg-primary/10'
+
+// Real phone/email are never written into the DOM (href / copy payload) for a
+// guest — the buttons just trigger the login gate. Only after auth do we wire
+// the actual value, so anonymous visitors cannot scrape it from the markup.
+interface ContactActionsProps {
+  item: ContactItem
+  isAuthenticated: boolean
+  onRequireAuth: () => void
+  /** Audit callback fired when an authenticated user reveals this contact. */
+  onReveal: () => void
+}
+
+const ContactActions: React.FC<ContactActionsProps> = ({
+  item,
+  isAuthenticated,
+  onRequireAuth,
+  onReveal,
+}) => {
+  if (!isAuthenticated) {
+    return (
+      <div className='flex items-center gap-1 shrink-0'>
+        <Button
+          size='icon'
+          variant='ghost'
+          className={ICON_BUTTON_CLASSNAME}
+          onClick={onRequireAuth}
+          aria-label={item.actionLabel}
+        >
+          {item.actionIcon}
+        </Button>
+        <Button
+          size='icon'
+          variant='ghost'
+          className={ICON_BUTTON_CLASSNAME}
+          onClick={onRequireAuth}
+          aria-label={item.label}
+        >
+          <Copy className='h-4 w-4' />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex items-center gap-1 shrink-0'>
+      <Button
+        asChild
+        size='icon'
+        variant='ghost'
+        className={ICON_BUTTON_CLASSNAME}
+      >
+        <a
+          href={item.actionHref}
+          target='_blank'
+          rel='noreferrer'
+          aria-label={item.actionLabel}
+          onClick={onReveal}
+        >
+          {item.actionIcon}
+        </a>
+      </Button>
+      <CopyButton
+        text={item.copyText}
+        successMessage={item.copySuccess}
+        className='h-8 w-8'
+        onCopy={onReveal}
+      />
+    </div>
+  )
+}
+
 const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
   seller,
   isLoading = false,
 }) => {
   const t = useTranslations('sellerDetailPage')
+  const { isAuthenticated, requireAuth, dialogProps } = useContactRevealGuard()
+
+  const logReveal = (channel: ContactRevealChannel) =>
+    ContactRevealService.logReveal(seller?.userId, channel)
 
   if (isLoading) {
     return (
@@ -136,6 +221,13 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
     })
   }
 
+  const zaloButtonContent = (
+    <>
+      <MessageCircle className='h-4 w-4' />
+      {t('profile.actions.chatZalo')}
+    </>
+  )
+
   return (
     <Card className='border-primary/20 overflow-hidden bg-gradient-to-br from-background via-primary/[0.02] to-primary/[0.06] shadow-sm'>
       <CardHeader className='pb-3'>
@@ -208,28 +300,14 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
                       {item.masked}
                     </span>
                   </div>
-                  <div className='flex items-center gap-1 shrink-0'>
-                    <Button
-                      asChild
-                      size='icon'
-                      variant='ghost'
-                      className='h-8 w-8 text-primary hover:bg-primary/10'
-                    >
-                      <a
-                        href={item.actionHref}
-                        target='_blank'
-                        rel='noreferrer'
-                        aria-label={item.actionLabel}
-                      >
-                        {item.actionIcon}
-                      </a>
-                    </Button>
-                    <CopyButton
-                      text={item.copyText}
-                      successMessage={item.copySuccess}
-                      className='h-8 w-8'
-                    />
-                  </div>
+                  <ContactActions
+                    item={item}
+                    isAuthenticated={isAuthenticated}
+                    onRequireAuth={() => requireAuth()}
+                    onReveal={() =>
+                      logReveal(item.key === 'phone' ? 'PHONE' : 'EMAIL')
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -239,24 +317,31 @@ const SellerPublicProfileCard: React.FC<SellerPublicProfileCardProps> = ({
             </Typography>
           )}
 
-          {zaloPhone && (
-            <Button
-              asChild
-              variant='outline'
-              className='w-full justify-center gap-2 border-primary/30 text-primary hover:bg-primary/10'
-            >
-              <a
-                href={`https://zalo.me/${zaloPhone}`}
-                target='_blank'
-                rel='noreferrer'
+          {zaloPhone &&
+            (isAuthenticated ? (
+              <Button asChild variant='outline' className={ZALO_BUTTON_CLASSNAME}>
+                <a
+                  href={`https://zalo.me/${zaloPhone}`}
+                  target='_blank'
+                  rel='noreferrer'
+                  onClick={() => logReveal('ZALO')}
+                >
+                  {zaloButtonContent}
+                </a>
+              </Button>
+            ) : (
+              <Button
+                variant='outline'
+                className={ZALO_BUTTON_CLASSNAME}
+                onClick={() => requireAuth()}
               >
-                <MessageCircle className='h-4 w-4' />
-                {t('profile.actions.chatZalo')}
-              </a>
-            </Button>
-          )}
+                {zaloButtonContent}
+              </Button>
+            ))}
         </div>
       </CardContent>
+
+      <LoginRequiredDialog {...dialogProps} />
     </Card>
   )
 }

--- a/src/components/organisms/apartmentDetail/SellerContact.tsx
+++ b/src/components/organisms/apartmentDetail/SellerContact.tsx
@@ -1,24 +1,16 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
-import { useRouter } from 'next/router'
 import { Typography } from '@/components/atoms/typography'
 import { Button } from '@/components/atoms/button'
 import { Card, CardContent } from '@/components/atoms/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/atoms/dialog'
 import { LayoutList, Mail, Phone } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { PUBLIC_ROUTES, buildSellerDetailRoute } from '@/constants/route'
 import { UserApi } from '@/api/types'
-import { useAuth } from '@/hooks/useAuth'
-import { useAuthDialog } from '@/contexts/authDialog'
+import { useContactRevealGuard } from '@/hooks/useAuth'
+import { ContactRevealService } from '@/api/services/contactReveal.service'
+import LoginRequiredDialog from '@/components/molecules/loginRequiredDialog'
 import BrokerAvatar from '@/components/molecules/brokerAvatar'
 import FollowButton from '@/components/molecules/followButton'
 import { cn } from '@/lib/utils'
@@ -36,12 +28,9 @@ const SellerContact: React.FC<SellerContactProps> = ({
 }) => {
   const t = useTranslations('apartmentDetail')
   const tCommon = useTranslations()
-  const router = useRouter()
-  const { isAuthenticated } = useAuth()
-  const { openAuth } = useAuthDialog()
+  const { requireAuth, dialogProps } = useContactRevealGuard()
 
   const [showPhone, setShowPhone] = React.useState(false)
-  const [openLoginRequired, setOpenLoginRequired] = React.useState(false)
 
   React.useEffect(() => {
     setShowPhone(false)
@@ -73,25 +62,28 @@ const SellerContact: React.FC<SellerContactProps> = ({
     : PUBLIC_ROUTES.PROPERTIES_PREFIX
 
   const handleZaloClick = () => {
-    if (zaloLink) {
-      window.open(zaloLink, '_blank')
-    }
-    onChatZalo?.()
+    requireAuth(() => {
+      void ContactRevealService.logReveal(host.userId, 'ZALO')
+      if (zaloLink) {
+        window.open(zaloLink, '_blank')
+      }
+      onChatZalo?.()
+    })
+  }
+
+  const handleEmailClick = () => {
+    requireAuth(() => {
+      void ContactRevealService.logReveal(host.userId, 'EMAIL')
+      window.location.href = `mailto:${email}`
+    })
   }
 
   const handleCall = () => {
-    if (!isAuthenticated) {
-      setOpenLoginRequired(true)
-      return
-    }
-
-    setShowPhone(true)
-    onPhoneClick?.()
-  }
-
-  const handleLoginToViewPhone = () => {
-    setOpenLoginRequired(false)
-    openAuth('login', router.asPath)
+    requireAuth(() => {
+      void ContactRevealService.logReveal(host.userId, 'PHONE')
+      setShowPhone(true)
+      onPhoneClick?.()
+    })
   }
 
   const hasPhone = Boolean(phone)
@@ -185,16 +177,14 @@ const SellerContact: React.FC<SellerContactProps> = ({
 
           {hasEmail && (
             <Button
-              asChild
               className='w-full bg-card hover:bg-primary/10 text-foreground border-2 border-primary h-9 md:h-10 text-xs md:text-sm font-semibold shadow-sm hover:shadow-md transition-all dark:bg-primary dark:hover:bg-primary/90 dark:text-primary-foreground dark:border-primary/80'
+              onClick={handleEmailClick}
               aria-label={t('actions.sendEmail')}
             >
-              <a href={`mailto:${email}`}>
-                <Mail className='w-3.5 h-3.5 md:w-4 md:h-4 mr-1.5' />
-                <span className='text-xs md:text-sm'>
-                  {t('actions.sendEmail')}
-                </span>
-              </a>
+              <Mail className='w-3.5 h-3.5 md:w-4 md:h-4 mr-1.5' />
+              <span className='text-xs md:text-sm'>
+                {t('actions.sendEmail')}
+              </span>
             </Button>
           )}
 
@@ -212,27 +202,7 @@ const SellerContact: React.FC<SellerContactProps> = ({
         </div>
       </CardContent>
 
-      <Dialog open={openLoginRequired} onOpenChange={setOpenLoginRequired}>
-        <DialogContent className='w-[92vw] max-w-md p-5 sm:p-6'>
-          <DialogHeader className='pb-2'>
-            <DialogTitle>{t('phoneAccess.loginRequiredTitle')}</DialogTitle>
-            <DialogDescription>
-              {t('phoneAccess.loginRequiredDescription')}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className='mt-2'>
-            <Button
-              variant='outline'
-              onClick={() => setOpenLoginRequired(false)}
-            >
-              {t('phoneAccess.cancel')}
-            </Button>
-            <Button onClick={handleLoginToViewPhone}>
-              {t('phoneAccess.loginNow')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <LoginRequiredDialog {...dialogProps} />
     </Card>
   )
 }

--- a/src/hooks/useAuth/index.tsx
+++ b/src/hooks/useAuth/index.tsx
@@ -25,6 +25,7 @@ import { clearChatSessionStorage } from '@/hooks/useChatAi/useChatSession'
 export { useAuthGuard, useForceLogout } from './useAuthGuard'
 export { useChangePassword } from './useChangePassword'
 export { useUpdateProfile } from './useUpdateProfile'
+export { useContactRevealGuard } from './useContactRevealGuard'
 
 export const useAuth = () => {
   return useAuthStore(

--- a/src/hooks/useAuth/useContactRevealGuard.test.ts
+++ b/src/hooks/useAuth/useContactRevealGuard.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const { authState, openAuthMock } = vi.hoisted(() => ({
+  authState: { isAuthenticated: false },
+  openAuthMock: vi.fn(),
+}))
+
+vi.mock('@/store/auth/index.store', () => ({
+  useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) =>
+    selector({ isAuthenticated: authState.isAuthenticated }),
+}))
+
+vi.mock('@/contexts/authDialog', () => ({
+  useAuthDialog: () => ({ openAuth: openAuthMock }),
+}))
+
+import { useContactRevealGuard } from './useContactRevealGuard'
+
+beforeEach(() => {
+  authState.isAuthenticated = false
+  openAuthMock.mockClear()
+})
+
+describe('useContactRevealGuard', () => {
+  it('runs the action immediately when authenticated and keeps the dialog closed', () => {
+    authState.isAuthenticated = true
+    const action = vi.fn()
+    const { result } = renderHook(() => useContactRevealGuard())
+
+    act(() => {
+      result.current.requireAuth(action)
+    })
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(result.current.dialogProps.open).toBe(false)
+    expect(openAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks the action and opens the login dialog for a guest', () => {
+    const action = vi.fn()
+    const { result } = renderHook(() => useContactRevealGuard())
+
+    act(() => {
+      result.current.requireAuth(action)
+    })
+
+    expect(action).not.toHaveBeenCalled()
+    expect(result.current.dialogProps.open).toBe(true)
+    expect(openAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('opens the auth flow with the current path and closes the dialog on confirm', () => {
+    const { result } = renderHook(() => useContactRevealGuard())
+
+    act(() => {
+      result.current.requireAuth()
+    })
+    expect(result.current.dialogProps.open).toBe(true)
+
+    act(() => {
+      result.current.dialogProps.onConfirm()
+    })
+
+    // asPath comes from the global next/router mock in src/test/setup.ts
+    expect(openAuthMock).toHaveBeenCalledWith('login', '/')
+    expect(result.current.dialogProps.open).toBe(false)
+  })
+})

--- a/src/hooks/useAuth/useContactRevealGuard.ts
+++ b/src/hooks/useAuth/useContactRevealGuard.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/router'
+import { useAuthStore } from '@/store/auth/index.store'
+import { useAuthDialog } from '@/contexts/authDialog'
+
+interface ContactRevealGuardDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+interface UseContactRevealGuardResult {
+  isAuthenticated: boolean
+  /**
+   * Run `action` only when the visitor is authenticated. Otherwise open the
+   * login-required dialog and skip the action entirely — the real contact
+   * value is never revealed to a guest.
+   */
+  requireAuth: (action?: () => void) => void
+  /** Spread onto {@link LoginRequiredDialog}. */
+  dialogProps: ContactRevealGuardDialogProps
+}
+
+/**
+ * Gate for any action that reveals a user's real contact details (show phone,
+ * open Zalo/mailto, copy). Reads auth straight from the store (not the
+ * `useAuth` barrel) to avoid a circular import through `hooks/useAuth/index`.
+ */
+export const useContactRevealGuard = (): UseContactRevealGuardResult => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const { openAuth } = useAuthDialog()
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  const requireAuth = useCallback(
+    (action?: () => void) => {
+      if (isAuthenticated) {
+        action?.()
+        return
+      }
+      setOpen(true)
+    },
+    [isAuthenticated],
+  )
+
+  const onConfirm = useCallback(() => {
+    setOpen(false)
+    openAuth('login', router.asPath)
+  }, [openAuth, router.asPath])
+
+  return {
+    isAuthenticated,
+    requireAuth,
+    dialogProps: { open, onOpenChange: setOpen, onConfirm },
+  }
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -105,6 +105,13 @@
     "showMore": "Show {count} more results",
     "showLess": "Show less"
   },
+  "contactAccess": {
+    "loginRequiredTitle": "Log in to view contact details",
+    "loginRequiredDescription": "You need to log in to view and contact the poster. This helps protect everyone's information.",
+    "cancel": "Later",
+    "loginNow": "Log in now",
+    "viewContactCta": "Log in to view contact"
+  },
   "common": {
     "or": "Or",
     "loading": "Loading...",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -105,6 +105,13 @@
     "showMore": "Xem thêm {count} kết quả",
     "showLess": "Thu gọn"
   },
+  "contactAccess": {
+    "loginRequiredTitle": "Đăng nhập để xem thông tin liên hệ",
+    "loginRequiredDescription": "Bạn cần đăng nhập để xem và liên hệ với người đăng tin. Việc này giúp bảo vệ thông tin của các bên.",
+    "cancel": "Để sau",
+    "loginNow": "Đăng nhập ngay",
+    "viewContactCta": "Đăng nhập để xem liên hệ"
+  },
   "common": {
     "or": "Hoặc",
     "loading": "Đang tải...",


### PR DESCRIPTION
## What & why

On public seller pages (`/properties/seller/{id}`) and listing detail, seller contact (phone/email/zalo) was reachable **without login** — only "Hiện số" gated, while Zalo / email / copy did not. This makes the login wall **consistent across every contact-reveal action** and lays the groundwork for tracking who accessed a seller's contact.

Pairs with backend PR **Vuhuydiet/smartrent-backend#484** (reveal-contact endpoint + `contact_reveal_log`).

## Changes

**Shared primitive (no duplicated logic):**
- `useContactRevealGuard()` — `requireAuth(action)`: runs the action when authed, otherwise opens the login dialog (reads auth from the store to avoid a circular import through `hooks/useAuth`).
- `LoginRequiredDialog` molecule — extracted from the old inline "Hiện số" dialog.

**Gated on all 3 contact surfaces:**
- `apartmentDetail/SellerContact` — Zalo, email, and "Hiện số".
- `sellerPublicProfileCard` — copy phone/email, action buttons, big Zalo button.
- `aiChatContactCard` — the 3 contact rows (guests see "Đăng nhập để xem liên hệ").

**Guest hardening:** the real phone/email is no longer written into the DOM (`href` / `copyText`) until the user is authenticated — a guest button only opens the login gate.

**Audit hook:** `contactReveal.service.ts` fires `POST /v1/users/{sellerId}/reveal-contact` (fire-and-forget) on each authed reveal; `CopyButton` gains an optional `onCopy` callback so copies are logged too. Until the backend PR ships, these calls 404 harmlessly (swallowed) — no UX impact.

**i18n:** new `contactAccess.*` namespace (en + vi).

## Not in scope (deliberate)

Withholding contact from **anonymous API responses** (payload strip) is a follow-up — it ripples to the AI/chatbot + mobile consumers and needs coordination. So this PR is deterrence + tracking-enabler; the full hard-block lands with the payload strip.

## Verification

- `tsc --noEmit` → 0 errors
- `eslint` → 0 errors/warnings on touched files
- `i18n:check` → en/vi in sync
- `vitest` → 7/7 (useContactRevealGuard + LoginRequiredDialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
