### PR TITLE
Add hover tooltips to compare/save buttons across card lists

### DIFF
--- a/src/components/molecules/CardListingAIMini/index.tsx
+++ b/src/components/molecules/CardListingAIMini/index.tsx
@@ -8,6 +8,12 @@ import { Card, CardContent } from '@/components/atoms/card'
 import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
 import { Typography } from '@/components/atoms/typography'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/atoms/tooltip'
 import { cn } from '@/lib/utils'
 import { formatByLocale } from '@/utils/currency/convert'
 import { useLanguage } from '@/hooks/useLanguage'
@@ -116,42 +122,64 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
               </div>
             )}
             <div className='absolute flex gap-1 bottom-2 left-2'>
-              <button
-                onClick={handleSaveClick}
-                disabled={isSaveLoading}
-                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 disabled:opacity-50 h-7 w-7'
-                aria-label={
-                  isSaved ? tSaved('actions.saved') : tSaved('actions.save')
-                }
-              >
-                <Heart
-                  className={cn(
-                    'w-4 h-4 transition-all duration-200',
-                    isSaved
-                      ? 'fill-red-500 stroke-red-500'
-                      : 'fill-none stroke-muted-foreground',
-                    isSaveLoading && 'animate-pulse',
-                  )}
-                />
-              </button>
-              <button
-                onClick={handleCompareClick}
-                className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 h-7 w-7'
-                aria-label={
-                  isInCompareList
-                    ? tCompare('actions.removeFromCompare')
-                    : tCompare('actions.addToCompare')
-                }
-              >
-                <Plus
-                  className={cn(
-                    'w-4 h-4 transition-all duration-200',
-                    isInCompareList
-                      ? 'rotate-45 stroke-primary'
-                      : 'stroke-muted-foreground',
-                  )}
-                />
-              </button>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleSaveClick}
+                      disabled={isSaveLoading}
+                      className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 disabled:opacity-50 h-7 w-7'
+                      aria-label={
+                        isSaved
+                          ? tSaved('tooltip.saved')
+                          : tSaved('tooltip.save')
+                      }
+                    >
+                      <Heart
+                        className={cn(
+                          'w-4 h-4 transition-all duration-200',
+                          isSaved
+                            ? 'fill-red-500 stroke-red-500'
+                            : 'fill-none stroke-muted-foreground',
+                          isSaveLoading && 'animate-pulse',
+                        )}
+                      />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side='top' avoidCollisions={false}>
+                    {isSaved ? tSaved('tooltip.saved') : tSaved('tooltip.save')}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleCompareClick}
+                      className='flex items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-all duration-200 active:scale-95 h-7 w-7'
+                      aria-label={
+                        isInCompareList
+                          ? tCompare('tooltip.remove')
+                          : tCompare('tooltip.add')
+                      }
+                    >
+                      <Plus
+                        className={cn(
+                          'w-4 h-4 transition-all duration-200',
+                          isInCompareList
+                            ? 'rotate-45 stroke-primary'
+                            : 'stroke-muted-foreground',
+                        )}
+                      />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side='top' avoidCollisions={false}>
+                    {isInCompareList
+                      ? tCompare('tooltip.remove')
+                      : tCompare('tooltip.add')}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </div>
 

--- a/src/components/molecules/compareToggleBtn/index.tsx
+++ b/src/components/molecules/compareToggleBtn/index.tsx
@@ -4,6 +4,12 @@ import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/atoms/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/atoms/tooltip'
 import { ListingApi } from '@/api/types/property.type'
 import { useCompareStore } from '@/store/compare/useCompareStore'
 import { cn } from '@/lib/utils'
@@ -75,6 +81,8 @@ const CompareToggleBtn: React.FC<CompareToggleBtnProps> = ({
     )
   }
 
+  const tooltipLabel = isInList ? t('tooltip.remove') : t('tooltip.add')
+
   const buttonContent = (
     <Button
       variant={variant}
@@ -86,6 +94,7 @@ const CompareToggleBtn: React.FC<CompareToggleBtnProps> = ({
       )}
       onClick={handleToggle}
       data-action-button='true'
+      aria-label={tooltipLabel}
     >
       {isInList ? (
         <CheckCircle className='w-4 h-4' />
@@ -102,7 +111,16 @@ const CompareToggleBtn: React.FC<CompareToggleBtnProps> = ({
     </Button>
   )
 
-  return buttonContent
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{buttonContent}</TooltipTrigger>
+        <TooltipContent side='top' avoidCollisions={false}>
+          {tooltipLabel}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
 }
 
 export default CompareToggleBtn

--- a/src/components/molecules/saveListingButton/index.tsx
+++ b/src/components/molecules/saveListingButton/index.tsx
@@ -4,6 +4,12 @@ import React from 'react'
 import { Heart } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/atoms/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/atoms/tooltip'
 import { useToggleSaveListing } from '@/hooks/useSavedListings'
 import { cn } from '@/lib/utils'
 
@@ -74,9 +80,22 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
     </>
   )
 
+  const tooltipLabel = isSaved ? t('tooltip.saved') : t('tooltip.save')
+
+  const withTooltip = (trigger: React.ReactNode) => (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent side='top' avoidCollisions={false}>
+          {tooltipLabel}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+
   // Compact variant - just the icon, inline with text
   if (variant === 'compact') {
-    return (
+    return withTooltip(
       <button
         onClick={handleClick}
         disabled={disabled || isLoading || !listingId}
@@ -87,17 +106,17 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
           'disabled:opacity-50 disabled:cursor-not-allowed',
           className,
         )}
-        aria-label={isSaved ? t('tooltip.saved') : t('tooltip.save')}
+        aria-label={tooltipLabel}
         data-action-button='true'
       >
         {buttonContent}
-      </button>
+      </button>,
     )
   }
 
   // Icon variant - for cards and listing detail
   if (variant === 'icon') {
-    return (
+    return withTooltip(
       <Button
         variant='ghost'
         size='icon'
@@ -109,26 +128,26 @@ export const SaveListingButton: React.FC<SaveListingButtonProps> = ({
           'rounded-full',
           className,
         )}
-        aria-label={isSaved ? t('tooltip.saved') : t('tooltip.save')}
+        aria-label={tooltipLabel}
       >
         {buttonContent}
-      </Button>
+      </Button>,
     )
   }
 
   // Default variant - full button with optional label
-  return (
+  return withTooltip(
     <Button
       variant='outline'
       size={size}
       onClick={handleClick}
       disabled={disabled || isLoading || !listingId}
       className={cn(className)}
-      aria-label={isSaved ? t('tooltip.saved') : t('tooltip.save')}
+      aria-label={tooltipLabel}
       data-action-button='true'
     >
       {buttonContent}
-    </Button>
+    </Button>,
   )
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -4232,6 +4232,10 @@
       "compareNow": "Compare Now",
       "viewDetails": "View Details"
     },
+    "tooltip": {
+      "add": "Add to compare",
+      "remove": "Remove from compare"
+    },
     "messages": {
       "added": "Added to compare",
       "removed": "Removed from compare",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -4230,6 +4230,10 @@
       "compareNow": "So sánh ngay",
       "viewDetails": "Xem chi tiết"
     },
+    "tooltip": {
+      "add": "Thêm vào so sánh",
+      "remove": "Bỏ khỏi so sánh"
+    },
     "messages": {
       "added": "Đã thêm vào so sánh",
       "removed": "Đã bỏ khỏi so sánh",


### PR DESCRIPTION
Wire up the existing Tooltip primitive on CompareToggleBtn, SaveListingButton, and CardListingAIMini's inline actions so hovering shows the action label, forcing side="top" with avoidCollisions disabled so it always renders above the card instead of flipping below.