### PR TITLE
Add centered vertical divider and row lines to characteristics grid

### DIFF
--- a/src/components/organisms/apartmentDetail/PropertyHeader.tsx
+++ b/src/components/organisms/apartmentDetail/PropertyHeader.tsx
@@ -233,6 +233,21 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
     },
   ].filter((item) => item.value)
 
+  const characteristicsPairCount =
+    characteristics.length - (characteristics.length % 2)
+  const characteristicsLastItem =
+    characteristics.length % 2 === 1
+      ? characteristics[characteristics.length - 1]
+      : null
+  const characteristicsColumns = [
+    characteristics
+      .slice(0, characteristicsPairCount)
+      .filter((_, index) => index % 2 === 0),
+    characteristics
+      .slice(0, characteristicsPairCount)
+      .filter((_, index) => index % 2 === 1),
+  ]
+
   const listingForCompare: ListingApi = {
     listingId: listing.listingId,
     title: listing.title || '',
@@ -408,36 +423,34 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
         {/* Property Characteristics */}
         {characteristics.length > 0 && (
           <Card>
-            <CardContent className='p-4 md:p-5'>
+            <CardContent className='p-3.5 md:p-4'>
               <Typography variant='h4' className='text-base font-bold mb-1'>
                 {t('apartmentDetail.sections.characteristics')}
               </Typography>
               <div className='grid grid-cols-1 sm:grid-cols-2 sm:divide-x sm:divide-border'>
-                {[
-                  characteristics.filter((_, index) => index % 2 === 0),
-                  characteristics.filter((_, index) => index % 2 === 1),
-                ].map((column, columnIndex) => (
+                {characteristicsColumns.map((column, columnIndex) => (
                   <div
                     key={columnIndex}
-                    className={`divide-y divide-border ${columnIndex === 0 ? 'sm:pr-5' : 'sm:pl-5'}`}
+                    className={`divide-y divide-border ${columnIndex === 0 ? 'sm:pr-3' : 'sm:pl-3'}`}
                   >
                     {column.map((item) => (
                       <div
                         key={item.key}
-                        className='flex items-center justify-between gap-3 py-3'
+                        className='flex items-center justify-center gap-2 py-2.5'
                       >
-                        <div className='flex items-center gap-2 text-muted-foreground min-w-0'>
-                          <item.icon size={16} className='shrink-0' />
-                          <Typography
-                            variant='p'
-                            className='text-xs sm:text-sm truncate'
-                          >
-                            {item.label}
-                          </Typography>
-                        </div>
+                        <item.icon
+                          size={16}
+                          className='shrink-0 text-muted-foreground'
+                        />
                         <Typography
                           variant='p'
-                          className='text-xs sm:text-sm font-semibold text-foreground text-right shrink-0'
+                          className='text-xs sm:text-sm text-muted-foreground truncate'
+                        >
+                          {item.label}
+                        </Typography>
+                        <Typography
+                          variant='p'
+                          className='text-xs sm:text-sm font-semibold text-foreground shrink-0'
                         >
                           {item.value}
                         </Typography>
@@ -446,6 +459,26 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
                   </div>
                 ))}
               </div>
+              {characteristicsLastItem && (
+                <div className='flex items-center justify-center gap-2 py-2.5 border-t border-border'>
+                  <characteristicsLastItem.icon
+                    size={16}
+                    className='shrink-0 text-muted-foreground'
+                  />
+                  <Typography
+                    variant='p'
+                    className='text-xs sm:text-sm text-muted-foreground truncate'
+                  >
+                    {characteristicsLastItem.label}
+                  </Typography>
+                  <Typography
+                    variant='p'
+                    className='text-xs sm:text-sm font-semibold text-foreground shrink-0'
+                  >
+                    {characteristicsLastItem.value}
+                  </Typography>
+                </div>
+              )}
             </CardContent>
           </Card>
         )}

--- a/src/components/organisms/apartmentDetail/PropertyHeader.tsx
+++ b/src/components/organisms/apartmentDetail/PropertyHeader.tsx
@@ -409,24 +409,40 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
         {characteristics.length > 0 && (
           <Card>
             <CardContent className='p-4 md:p-5'>
-              <Typography variant='h4' className='text-base font-bold mb-3'>
+              <Typography variant='h4' className='text-base font-bold mb-1'>
                 {t('apartmentDetail.sections.characteristics')}
               </Typography>
-              <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4'>
-                {characteristics.map((item) => (
-                  <div key={item.key} className='flex flex-col gap-1'>
-                    <div className='flex items-center gap-2 text-muted-foreground'>
-                      <item.icon size={16} className='shrink-0' />
-                      <Typography variant='p' className='text-xs sm:text-sm'>
-                        {item.label}
-                      </Typography>
-                    </div>
-                    <Typography
-                      variant='p'
-                      className='text-sm font-semibold text-foreground pl-6'
-                    >
-                      {item.value}
-                    </Typography>
+              <div className='grid grid-cols-1 sm:grid-cols-2 sm:divide-x sm:divide-border'>
+                {[
+                  characteristics.filter((_, index) => index % 2 === 0),
+                  characteristics.filter((_, index) => index % 2 === 1),
+                ].map((column, columnIndex) => (
+                  <div
+                    key={columnIndex}
+                    className={`divide-y divide-border ${columnIndex === 0 ? 'sm:pr-5' : 'sm:pl-5'}`}
+                  >
+                    {column.map((item) => (
+                      <div
+                        key={item.key}
+                        className='flex items-center justify-between gap-3 py-3'
+                      >
+                        <div className='flex items-center gap-2 text-muted-foreground min-w-0'>
+                          <item.icon size={16} className='shrink-0' />
+                          <Typography
+                            variant='p'
+                            className='text-xs sm:text-sm truncate'
+                          >
+                            {item.label}
+                          </Typography>
+                        </div>
+                        <Typography
+                          variant='p'
+                          className='text-xs sm:text-sm font-semibold text-foreground text-right shrink-0'
+                        >
+                          {item.value}
+                        </Typography>
+                      </div>
+                    ))}
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
Split the two columns into explicit lists so a single vertical rule sits dead-center between them, with horizontal divider lines between rows in each column — reads as a proper spec table instead of a bare grid.