### PR TITLE
Split utility fees into their own section with a distinct style

### DIFF
--- a/src/components/organisms/apartmentDetail/PropertyHeader.tsx
+++ b/src/components/organisms/apartmentDetail/PropertyHeader.tsx
@@ -207,6 +207,14 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
       label: t('apartmentDetail.property.furnishing'),
       value: furnishing ? t(getFurnishingTranslationKey(furnishing)) : null,
     },
+  ].filter((item) => item.value)
+
+  const utilityFees: {
+    key: string
+    icon: LucideIcon
+    label: string
+    value: string | null
+  }[] = [
     {
       key: 'electricityPrice',
       icon: Zap,
@@ -427,6 +435,41 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
                     <Typography
                       variant='p'
                       className='text-sm font-semibold text-foreground'
+                    >
+                      {item.value}
+                    </Typography>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Utility Fees */}
+        {utilityFees.length > 0 && (
+          <Card>
+            <CardContent className='p-3.5 md:p-4'>
+              <Typography variant='h4' className='text-base font-bold mb-3'>
+                {t('apartmentDetail.sections.utilityFees')}
+              </Typography>
+              <div className='flex flex-col gap-2'>
+                {utilityFees.map((item) => (
+                  <div
+                    key={item.key}
+                    className='flex items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2'
+                  >
+                    <div className='flex items-center gap-2 text-muted-foreground min-w-0'>
+                      <item.icon size={16} className='shrink-0' />
+                      <Typography
+                        variant='p'
+                        className='text-xs sm:text-sm truncate'
+                      >
+                        {item.label}
+                      </Typography>
+                    </div>
+                    <Typography
+                      variant='p'
+                      className='text-xs sm:text-sm font-semibold text-primary shrink-0'
                     >
                       {item.value}
                     </Typography>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3488,6 +3488,7 @@
     "sections": {
       "features": "Property Features",
       "characteristics": "Property Characteristics",
+      "utilityFees": "Utility Fees",
       "description": "Description",
       "priceHistory": "Price History for {district}",
       "location": "View on Map",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3486,6 +3486,7 @@
     "sections": {
       "features": "Tiện ích",
       "characteristics": "Đặc điểm bất động sản",
+      "utilityFees": "Chi phí tiện ích",
       "description": "Thông tin mô tả",
       "priceHistory": "Lịch sử giá bán nhà riêng tại {district}",
       "location": "Xem trên bản đồ",


### PR DESCRIPTION
Electricity/water/internet/service fee were mixed into the physical characteristics tile grid, making it harder to tell "what the place is" from "what it costs to run". Move them into a separate "Chi phí tiện ích" card styled as highlighted list rows (primary-colored values) instead of tiles, so the two kinds of info are easy to tell apart at a glance.