### PR TITLE
Match value color and trim excess card padding

### DIFF
--- a/src/components/organisms/apartmentDetail/PropertyHeader.tsx
+++ b/src/components/organisms/apartmentDetail/PropertyHeader.tsx
@@ -415,7 +415,7 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
 
         {/* Property Characteristics */}
         {characteristics.length > 0 && (
-          <Card>
+          <Card className='py-0'>
             <CardContent className='p-3.5 md:p-4'>
               <Typography variant='h4' className='text-base font-bold mb-3'>
                 {t('apartmentDetail.sections.characteristics')}
@@ -447,7 +447,7 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
 
         {/* Utility Fees */}
         {utilityFees.length > 0 && (
-          <Card>
+          <Card className='py-0'>
             <CardContent className='p-3.5 md:p-4'>
               <Typography variant='h4' className='text-base font-bold mb-3'>
                 {t('apartmentDetail.sections.utilityFees')}
@@ -469,7 +469,7 @@ const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
                     </div>
                     <Typography
                       variant='p'
-                      className='text-xs sm:text-sm font-semibold text-primary shrink-0'
+                      className='text-xs sm:text-sm font-semibold text-foreground shrink-0'
                     >
                       {item.value}
                     </Typography>


### PR DESCRIPTION
Utility fee values used text-primary while characteristics used text-foreground — switch to text-foreground for visual consistency. Also cancel the Card atom's default py-6 (it was stacking on top of CardContent's own padding, making the space above the title and below the last row disproportionately large).