### PR TITLE
Confirm quota deduction before pushing a listing

### DIFF
--- a/src/components/molecules/pushQuotaConfirmModal/index.tsx
+++ b/src/components/molecules/pushQuotaConfirmModal/index.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Rocket, Ticket } from 'lucide-react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/atoms/dialog'
+import { Button } from '@/components/atoms/button'
+import { Typography } from '@/components/atoms/typography'
+import { cn } from '@/lib/utils'
+import { ListingOwnerDetail } from '@/api/types'
+
+export interface PushQuotaConfirmModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  listing: ListingOwnerDetail | null
+  remainingQuota: number
+  isLoading?: boolean
+  onConfirm: () => void
+}
+
+// Shown before a push that spends membership quota — the seller needs to
+// see the deduction up front rather than discover it after the fact.
+export const PushQuotaConfirmModal: React.FC<PushQuotaConfirmModalProps> = ({
+  open,
+  onOpenChange,
+  listing,
+  remainingQuota,
+  isLoading = false,
+  onConfirm,
+}) => {
+  const t = useTranslations('seller.listingManagement.card.pushQuotaDialog')
+
+  if (!listing) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-md p-0 overflow-hidden gap-0'>
+        <div className='bg-gradient-to-br from-primary to-primary/80 px-6 py-5 text-primary-foreground'>
+          <DialogHeader className='gap-1.5'>
+            <DialogTitle asChild>
+              <div className='flex items-center gap-2 text-base font-semibold'>
+                <Rocket size={18} />
+                {t('title')}
+              </div>
+            </DialogTitle>
+            <DialogDescription className='text-primary-foreground/90 text-sm'>
+              {t('description')}
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className='px-6 py-5 space-y-4'>
+          <div className='rounded-lg border border-border bg-muted/30 p-3'>
+            <Typography
+              variant='small'
+              className='text-xs text-muted-foreground'
+            >
+              {t('listingLabel')}
+            </Typography>
+            <Typography
+              variant='small'
+              className='font-semibold line-clamp-1 mt-0.5'
+            >
+              {listing.title}
+            </Typography>
+          </div>
+
+          <div
+            className={cn(
+              'rounded-lg border-2 border-primary/30 bg-primary/[0.04] p-4',
+              'flex items-center gap-3',
+            )}
+          >
+            <div className='shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-primary text-primary-foreground'>
+              <Ticket size={20} />
+            </div>
+            <div className='flex-1 min-w-0'>
+              <Typography variant='small' className='font-semibold'>
+                {t('quota.title')}
+              </Typography>
+              <Typography
+                variant='small'
+                className='text-lg font-bold text-primary mt-0.5 block'
+              >
+                {t('quota.remaining', { count: remainingQuota })}
+              </Typography>
+            </div>
+          </div>
+
+          <Typography variant='small' className='text-xs text-muted-foreground'>
+            {t('hint')}
+          </Typography>
+        </div>
+
+        <div className='border-t border-border bg-muted/20 px-6 py-4 flex gap-3 justify-end'>
+          <Button
+            variant='outline'
+            disabled={isLoading}
+            onClick={() => onOpenChange(false)}
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            disabled={isLoading}
+            onClick={onConfirm}
+            className='min-w-[140px]'
+          >
+            {isLoading ? t('loading') : t('confirm')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default PushQuotaConfirmModal

--- a/src/components/templates/listingsManagementTemplate/index.tsx
+++ b/src/components/templates/listingsManagementTemplate/index.tsx
@@ -26,6 +26,7 @@ import { MembershipPushDisplay } from '@/components/molecules/listings/Membershi
 import { usePushListing, usePushQuota } from '@/hooks/usePush'
 import PushLimitModal from '@/components/molecules/pushLimitModal'
 import PushPaymentConfirmModal from '@/components/molecules/pushPaymentConfirmModal'
+import PushQuotaConfirmModal from '@/components/molecules/pushQuotaConfirmModal'
 import { PushLimitError } from '@/api/types/push.type'
 import { PageContainer } from '@/components/atoms/pageContainer'
 import { Typography } from '@/components/atoms/typography'
@@ -120,6 +121,11 @@ const ListingsWithPagination = () => {
     open: boolean
     listing: ListingOwnerDetail | null
   }>({ open: false, listing: null })
+  const [pushQuotaConfirmState, setPushQuotaConfirmState] = useState<{
+    open: boolean
+    listing: ListingOwnerDetail | null
+    remainingQuota: number
+  }>({ open: false, listing: null, remainingQuota: 0 })
 
   const { ref: loadMoreRef } = useIntersectionObserver({
     onIntersect: () => {
@@ -232,7 +238,13 @@ const ListingsWithPagination = () => {
       return
     }
 
-    await runPushMutation(listing, true)
+    // Quota available — pushing spends a membership benefit, so confirm
+    // with the seller before deducting it rather than doing it silently.
+    setPushQuotaConfirmState({
+      open: true,
+      listing,
+      remainingQuota: latestQuotaData?.data?.totalAvailable ?? 0,
+    })
   }
 
   if (isLoading && listings.length === 0) {
@@ -479,6 +491,26 @@ const ListingsWithPagination = () => {
               if (!listing) return
               setPushPaymentState({ open: false, listing: null })
               runPushMutation(listing, false)
+            }}
+          />
+
+          <PushQuotaConfirmModal
+            open={pushQuotaConfirmState.open}
+            onOpenChange={(open) =>
+              setPushQuotaConfirmState((prev) => ({ ...prev, open }))
+            }
+            listing={pushQuotaConfirmState.listing}
+            remainingQuota={pushQuotaConfirmState.remainingQuota}
+            isLoading={pushMutation.isPending}
+            onConfirm={() => {
+              const listing = pushQuotaConfirmState.listing
+              if (!listing) return
+              setPushQuotaConfirmState({
+                open: false,
+                listing: null,
+                remainingQuota: 0,
+              })
+              runPushMutation(listing, true)
             }}
           />
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3137,6 +3137,19 @@
           "cancel": "Cancel",
           "loading": "Processing..."
         },
+        "pushQuotaDialog": {
+          "title": "Confirm push",
+          "description": "This will use one push from your membership benefits.",
+          "listingLabel": "Listing",
+          "quota": {
+            "title": "Membership push quota",
+            "remaining": "{count, plural, =0 {0 pushes left} one {# push left} other {# pushes left}}"
+          },
+          "hint": "Confirming will deduct one push from your membership benefits and push the listing to the top.",
+          "confirm": "Confirm",
+          "cancel": "Cancel",
+          "loading": "Processing..."
+        },
         "takeDownConfirm": {
           "title": "Take down this listing?",
           "description": "Are you sure you want to take down this listing? Please review the consequences below before confirming.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3135,6 +3135,19 @@
           "cancel": "Huỷ",
           "loading": "Đang xử lý..."
         },
+        "pushQuotaDialog": {
+          "title": "Xác nhận đẩy tin",
+          "description": "Thao tác này sẽ sử dụng 1 lượt đẩy tin trong quyền lợi hội viên của bạn.",
+          "listingLabel": "Tin đăng",
+          "quota": {
+            "title": "Lượt đẩy tin hội viên",
+            "remaining": "Còn {count, plural, =0 {0 lượt} other {# lượt}}"
+          },
+          "hint": "Sau khi xác nhận, bạn sẽ bị trừ 1 lượt trong quyền lợi hội viên và tin sẽ được đẩy lên đầu.",
+          "confirm": "Xác nhận",
+          "cancel": "Huỷ",
+          "loading": "Đang xử lý..."
+        },
         "takeDownConfirm": {
           "title": "Ẩn tin đăng?",
           "description": "Bạn có chắc chắn muốn ẩn tin đăng này? Vui lòng đọc kỹ các lưu ý bên dưới trước khi xác nhận.",


### PR DESCRIPTION
Pushing with membership quota applied instantly with no warning that it would spend a benefit. Add a confirmation dialog showing the remaining push quota before the deduction happens; the paid (no-quota) push flow already had an equivalent confirm step.