### PR TITLE
Round price input down to nearest 1,000 VND on blur

### DIFF
--- a/src/components/atoms/number-field/index.tsx
+++ b/src/components/atoms/number-field/index.tsx
@@ -30,6 +30,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
   className,
   min = 0,
   max,
+  step,
   decimals = 0,
   disabled,
   required,
@@ -46,6 +47,14 @@ export const NumberField: React.FC<NumberFieldProps> = ({
     if (min !== undefined && next < min) next = min
     if (max !== undefined && next > max) next = max
     onChange(next)
+  }
+
+  const handleBlur = () => {
+    setTouched(true)
+    if (step && step > 1) {
+      const rounded = Math.floor(value / step) * step
+      if (rounded !== value) onChange(rounded)
+    }
   }
 
   return (
@@ -81,7 +90,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
             compact && 'h-10 text-sm',
           )}
           disabled={disabled}
-          onBlur={() => setTouched(true)}
+          onBlur={handleBlur}
         />
         {suffix && (
           <span className='absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-muted-foreground'>

--- a/src/components/organisms/createPostSections/propertyInfoSection.tsx
+++ b/src/components/organisms/createPostSections/propertyInfoSection.tsx
@@ -786,6 +786,7 @@ const PropertyInfoSection: React.FC<PropertyInfoSectionProps> = ({
                       placeholder={tPlaceholders('enterPrice')}
                       suffix='VND'
                       min={0}
+                      step={1000}
                       required
                       error={
                         error?.message


### PR DESCRIPTION
Prevents entering non-zero hundreds/tens/units digits in the seller create/update post price field by snapping the value down to the nearest thousand when the field loses focus.