### PR TITLE
Require price to be at least 100,000 VND

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1030,6 +1030,7 @@
       "locationRequired": "Please select location on map",
       "areaRequired": "Area is required",
       "priceRequired": "Price is required",
+      "priceMinValue": "Price must be at least 100,000 VND",
       "priceUnitRequired": "Price unit is required",
       "priceUnitInvalid": "Invalid price unit",
       "mediaImagesOrYoutube": "Please add at least 4 images or 1 video",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1031,6 +1031,7 @@
       "locationRequired": "Vui lòng chọn vị trí trên bản đồ",
       "areaRequired": "Diện tích là bắt buộc",
       "priceRequired": "Giá là bắt buộc",
+      "priceMinValue": "Giá phải từ 100.000 VNĐ trở lên",
       "priceUnitRequired": "Vui lòng chọn đơn vị giá",
       "priceUnitInvalid": "Đơn vị giá không hợp lệ",
       "mediaImagesOrYoutube": "Vui lòng thêm ít nhất 4 ảnh hoặc 1 video",

--- a/src/utils/createPost/validationSchemas.ts
+++ b/src/utils/createPost/validationSchemas.ts
@@ -12,6 +12,7 @@ const PROPERTY_TYPES = [
 ] as const
 const LISTING_TYPES = ['RENT', 'SHARE'] as const
 const PRICE_UNITS = ['MONTH', 'YEAR'] as const
+const MIN_PRICE = 100_000
 const UTILITY_PRICE_TYPES = [
   'NEGOTIABLE',
   'SET_BY_OWNER',
@@ -148,12 +149,12 @@ const getPropertyInfoFields = (mode: ValidationMode = 'strict') => {
           .number()
           .required('priceRequired')
           .positive('priceRequired')
-          .min(1, 'priceRequired')
+          .min(MIN_PRICE, 'priceMinValue')
       : yup
           .number()
           .optional()
           .positive('priceRequired')
-          .min(1, 'priceRequired'),
+          .min(MIN_PRICE, 'priceMinValue'),
     priceUnit: strictMode
       ? yup
           .string()


### PR DESCRIPTION
Applies to both create-post and update-post since they share the property-info validation schema; adds a dedicated priceMinValue message instead of reusing the generic priceRequired copy.