### PR TITLE
Reject prices that aren't round thousands

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1031,6 +1031,7 @@
       "areaRequired": "Area is required",
       "priceRequired": "Price is required",
       "priceMinValue": "Price must be at least 100,000 VND",
+      "priceNotRound": "Price must be a round number of thousands, with no odd hundreds",
       "priceUnitRequired": "Price unit is required",
       "priceUnitInvalid": "Invalid price unit",
       "mediaImagesOrYoutube": "Please add at least 4 images or 1 video",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1032,6 +1032,7 @@
       "areaRequired": "Diện tích là bắt buộc",
       "priceRequired": "Giá là bắt buộc",
       "priceMinValue": "Giá phải từ 100.000 VNĐ trở lên",
+      "priceNotRound": "Giá phải là số chẵn nghìn, không được lẻ hàng trăm",
       "priceUnitRequired": "Vui lòng chọn đơn vị giá",
       "priceUnitInvalid": "Đơn vị giá không hợp lệ",
       "mediaImagesOrYoutube": "Vui lòng thêm ít nhất 4 ảnh hoặc 1 video",

--- a/src/utils/createPost/validationSchemas.ts
+++ b/src/utils/createPost/validationSchemas.ts
@@ -13,6 +13,8 @@ const PROPERTY_TYPES = [
 const LISTING_TYPES = ['RENT', 'SHARE'] as const
 const PRICE_UNITS = ['MONTH', 'YEAR'] as const
 const MIN_PRICE = 100_000
+const isRoundThousand = (value?: number) =>
+  value === undefined || value % 1000 === 0
 const UTILITY_PRICE_TYPES = [
   'NEGOTIABLE',
   'SET_BY_OWNER',
@@ -150,11 +152,13 @@ const getPropertyInfoFields = (mode: ValidationMode = 'strict') => {
           .required('priceRequired')
           .positive('priceRequired')
           .min(MIN_PRICE, 'priceMinValue')
+          .test('price-round-thousand', 'priceNotRound', isRoundThousand)
       : yup
           .number()
           .optional()
           .positive('priceRequired')
-          .min(MIN_PRICE, 'priceMinValue'),
+          .min(MIN_PRICE, 'priceMinValue')
+          .test('price-round-thousand', 'priceNotRound', isRoundThousand),
     priceUnit: strictMode
       ? yup
           .string()


### PR DESCRIPTION
The live 5-free-digit mask only forces the last digit to 0 for 6-digit prices (e.g. 150,111 -> 150,110), so a non-round value could still slip through typing and reach submit. Add a Yup test requiring price % 1000 === 0 as a submit-time safety net, for both create and update post.