### PR TITLE
Add glossary and per-plan guidance notes to membership pricing cards

### DIFF
--- a/src/components/molecules/pricingPlanCard/index.tsx
+++ b/src/components/molecules/pricingPlanCard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 import { Leaf, Sparkles, Crown } from 'lucide-react'
 import {
@@ -13,6 +13,7 @@ import { Typography } from '@/components/atoms/typography'
 import { cn } from '@/lib/utils'
 import { formatByLocale } from '@/utils/currency/convert'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
+import { useVipTiers } from '@/hooks/useVipTiers'
 import { motion } from 'framer-motion'
 // MembershipPackageLevel is imported below with BenefitType
 import { PricingHeader } from './PricingHeader'
@@ -23,6 +24,7 @@ import {
   formatDiscountText,
 } from './translations'
 import { getCardStyles, getButtonStyles } from './styles'
+import { getHighestVipType, getMaxImagesForVipType } from './vipTierHelpers'
 import type { Membership } from '@/api/types/membership.type'
 import { MembershipPackageLevel } from '@/api/types/membership.type'
 
@@ -93,6 +95,11 @@ const PricingPlanCard: React.FC<PricingPlanCardProps> = ({
   const t = useTranslations('pricing')
   const { language } = useSwitchLanguage()
   const locale = language
+  const { data: vipTiers = [] } = useVipTiers()
+  const maxImages = useMemo(() => {
+    const highestVipType = getHighestVipType(membership.benefits)
+    return getMaxImagesForVipType(vipTiers, highestVipType)
+  }, [membership.benefits, vipTiers])
 
   const translations = getPricingTranslations(t)
   const hasDiscount = membership.discountPercentage > 0
@@ -151,6 +158,14 @@ const PricingPlanCard: React.FC<PricingPlanCardProps> = ({
           />
         </CardHeader>
         <CardContent>
+          <Typography
+            variant='muted'
+            as='p'
+            className='rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed'
+          >
+            {t(`whyChoose.${membership.packageLevel}`)}
+            {maxImages ? ` ${t('photoLimitNote', { count: maxImages })}` : null}
+          </Typography>
           <PricingFeatures benefits={membership.benefits} compact={compact} />
         </CardContent>
         {showCta && (

--- a/src/components/molecules/pricingPlanCard/vipTierHelpers.ts
+++ b/src/components/molecules/pricingPlanCard/vipTierHelpers.ts
@@ -1,0 +1,33 @@
+import { BENEFIT_TYPE_TO_VIP_TYPE } from '@/utils/createPost/benefitTier'
+import type { MembershipBenefit } from '@/api/types/membership.type'
+import type { VipType } from '@/api/types/property.type'
+import type { VipTier } from '@/api/types/vip-tier.type'
+
+const VIP_TYPE_RANK: Record<VipType, number> = {
+  NORMAL: 0,
+  SILVER: 1,
+  GOLD: 2,
+  DIAMOND: 3,
+}
+
+/** Highest VIP tier among a package's post benefits — used to look up the
+ *  real photo limit for that tier instead of hardcoding a number in copy. */
+export const getHighestVipType = (
+  benefits: readonly MembershipBenefit[],
+): VipType | undefined =>
+  benefits.reduce<VipType | undefined>((highest, benefit) => {
+    const vipType = BENEFIT_TYPE_TO_VIP_TYPE[benefit.benefitType]
+    if (!vipType) return highest
+    if (!highest || VIP_TYPE_RANK[vipType] > VIP_TYPE_RANK[highest]) {
+      return vipType
+    }
+    return highest
+  }, undefined)
+
+export const getMaxImagesForVipType = (
+  vipTiers: readonly VipTier[],
+  vipType: VipType | undefined,
+): number | undefined =>
+  vipType
+    ? vipTiers.find((tier) => tier.tierCode === vipType)?.maxImages
+    : undefined

--- a/src/components/templates/membershipRegisterTemplate/MembershipGlossaryNote.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipGlossaryNote.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Info } from 'lucide-react'
+import { Alert, AlertTitle, AlertDescription } from '@/components/atoms/alert'
+import { Typography } from '@/components/atoms/typography'
+
+export const MembershipGlossaryNote: React.FC = () => {
+  const t = useTranslations('membershipPage.glossary')
+
+  return (
+    <Alert>
+      <Info />
+      <AlertTitle>{t('title')}</AlertTitle>
+      <AlertDescription>
+        <Typography as='ul' className='list-disc space-y-1 pl-4'>
+          <li>{t('vip')}</li>
+          <li>{t('push')}</li>
+          <li>{t('media')}</li>
+        </Typography>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/components/templates/membershipRegisterTemplate/MembershipPlansGrid.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipPlansGrid.tsx
@@ -15,6 +15,7 @@ import {
   CarouselContent,
   CarouselItem,
 } from '@/components/atoms/carousel'
+import { MembershipGlossaryNote } from './MembershipGlossaryNote'
 
 interface MembershipPlansGridProps {
   readonly loading?: boolean
@@ -79,34 +80,40 @@ export const MembershipPlansGrid: React.FC<MembershipPlansGridProps> = ({
   // Mobile only: carousel (limited width, one card at a time)
   if (isMobile) {
     return (
-      <motion.div
-        className='relative'
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
-      >
-        <Carousel
-          opts={{
-            align: 'start',
-            loop: false,
-          }}
-          className='w-full'
+      <div className='flex flex-col gap-4'>
+        <MembershipGlossaryNote />
+        <motion.div
+          className='relative'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
         >
-          <CarouselContent className='-ml-2'>
-            {safeMemberships.map((plan) => (
-              <CarouselItem key={plan.membershipId} className='pl-2 basis-full'>
-                <div className='h-full'>
-                  <PricingPlanCard
-                    membership={plan}
-                    showCta={showCta}
-                    onSelect={() => handlePlanSelect(plan.membershipId)}
-                  />
-                </div>
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-        </Carousel>
-      </motion.div>
+          <Carousel
+            opts={{
+              align: 'start',
+              loop: false,
+            }}
+            className='w-full'
+          >
+            <CarouselContent className='-ml-2'>
+              {safeMemberships.map((plan) => (
+                <CarouselItem
+                  key={plan.membershipId}
+                  className='pl-2 basis-full'
+                >
+                  <div className='h-full'>
+                    <PricingPlanCard
+                      membership={plan}
+                      showCta={showCta}
+                      onSelect={() => handlePlanSelect(plan.membershipId)}
+                    />
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+          </Carousel>
+        </motion.div>
+      </div>
     )
   }
 
@@ -136,25 +143,28 @@ export const MembershipPlansGrid: React.FC<MembershipPlansGridProps> = ({
   }
 
   return (
-    <motion.div
-      className='flex flex-wrap justify-center gap-6'
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-    >
-      {safeMemberships.map((plan) => (
-        <motion.div
-          key={plan.membershipId}
-          variants={itemVariants}
-          className='flex w-full md:w-[calc(50%_-_0.75rem)] xl:w-[calc(33.333%_-_1rem)] max-w-md'
-        >
-          <PricingPlanCard
-            membership={plan}
-            showCta={showCta}
-            onSelect={() => handlePlanSelect(plan.membershipId)}
-          />
-        </motion.div>
-      ))}
-    </motion.div>
+    <div className='flex flex-col gap-6'>
+      <MembershipGlossaryNote />
+      <motion.div
+        className='flex flex-wrap justify-center gap-6'
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+      >
+        {safeMemberships.map((plan) => (
+          <motion.div
+            key={plan.membershipId}
+            variants={itemVariants}
+            className='flex w-full md:w-[calc(50%_-_0.75rem)] xl:w-[calc(33.333%_-_1rem)] max-w-md'
+          >
+            <PricingPlanCard
+              membership={plan}
+              showCta={showCta}
+              onSelect={() => handlePlanSelect(plan.membershipId)}
+            />
+          </motion.div>
+        ))}
+      </motion.div>
+    </div>
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1932,6 +1932,12 @@
     "buyNow": "Buy Now",
     "saveUpTo": "Save up to",
     "perMonthSuffix": "per month",
+    "whyChoose": {
+      "BASIC": "Entry plan: Silver-tier listings only, no Gold or Diamond yet — fits occasional posting.",
+      "STANDARD": "More than Basic: double the Silver listings and pushes, plus unlocks Diamond and Gold listings — the two priority tiers Basic doesn't have.",
+      "ADVANCED": "More than Standard across every tier and pushes — built for sellers posting high volume, needing continuous visibility."
+    },
+    "photoLimitNote": "Post up to {count} photos for this plan's highest listing tier.",
     "pricing": {
       "bestSeller": "Best Seller",
       "buyNow": "Buy Now",
@@ -1953,6 +1959,12 @@
   "membershipPage": {
     "title": "Service Packages",
     "subtitle": "Compare Membership packages and Push Voucher bundles to choose the best solution for your sales needs.",
+    "glossary": {
+      "title": "Before you choose a plan, here's what these terms mean",
+      "vip": "Silver / Gold / Diamond listings: the display priority tier of a listing (Diamond ranks highest, then Gold, then Silver). Higher tiers rank higher in listings/search and show their own badge on the post, boosting buyer trust.",
+      "push": "Listing push: brings an already-posted Normal listing back to the top when newer listings have pushed it down — it maintains position over time, unlike VIP tiers which get priority from the start.",
+      "media": "The photo limit per listing also scales with its VIP tier — higher tiers allow more photos in the posting flow."
+    },
     "tabs": {
       "membership": "Membership Packages",
       "voucher": "Push Voucher Packages",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2473,6 +2473,12 @@
     "buyNow": "Mua ngay",
     "saveUpTo": "Tiết kiệm đến",
     "perMonthSuffix": "₫/tháng",
+    "whyChoose": {
+      "BASIC": "Gói khởi điểm: chỉ có tin VIP Bạc, chưa có Vàng/Kim Cương — phù hợp nếu đăng tin không thường xuyên.",
+      "STANDARD": "Hơn Cơ Bản: gấp đôi số tin Bạc và lượt đẩy tin, đồng thời mở khóa thêm tin VIP Kim Cương và Vàng — 2 hạng ưu tiên cao nhất mà Cơ Bản không có.",
+      "ADVANCED": "Hơn Tiêu Chuẩn ở mọi hạng tin và lượt đẩy — dành cho seller đăng số lượng lớn, cần độ phủ liên tục."
+    },
+    "photoLimitNote": "Được đăng tối đa {count} ảnh cho tin ở hạng cao nhất của gói này.",
     "pricing": {
       "bestSeller": "Bán chạy nhất",
       "buyNow": "Mua ngay",
@@ -2494,6 +2500,12 @@
   "membershipPage": {
     "title": "Gói dịch vụ",
     "subtitle": "So sánh gói Hội viên và gói voucher Đẩy tin để chọn giải pháp tối ưu cho nhu cầu bán hàng.",
+    "glossary": {
+      "title": "Trước khi chọn gói, hiểu nhanh các khái niệm",
+      "vip": "Tin VIP Bạc / Vàng / Kim Cương: thứ hạng ưu tiên hiển thị của tin đăng (Kim Cương cao nhất, rồi đến Vàng, Bạc). Hạng càng cao, tin càng lên đầu danh sách/tìm kiếm và có badge riêng trên tin, tăng độ tin cậy với người xem.",
+      "push": "Lượt đẩy tin: đưa tin Thường đã đăng quay lại đầu danh sách khi bị các tin mới đẩy trôi xuống — dùng để duy trì vị trí theo thời gian, khác với tin VIP là được ưu tiên ngay từ đầu.",
+      "media": "Số lượng ảnh đăng tin cũng tăng theo hạng VIP của tin — hạng càng cao, giới hạn ảnh trong bước đăng tin càng nhiều."
+    },
     "tabs": {
       "membership": "Gói Hội viên",
       "voucher": "Gói voucher Đẩy tin",

--- a/src/utils/createPost/benefitTier.ts
+++ b/src/utils/createPost/benefitTier.ts
@@ -1,7 +1,7 @@
 import { BenefitType, type UserBenefit } from '@/api/types/membership.type'
 import type { VipType } from '@/api/types/property.type'
 
-const BENEFIT_TYPE_TO_VIP_TYPE: Partial<Record<BenefitType, VipType>> = {
+export const BENEFIT_TYPE_TO_VIP_TYPE: Partial<Record<BenefitType, VipType>> = {
   [BenefitType.POST_NORMAL]: 'NORMAL',
   [BenefitType.POST_STANDARD]: 'NORMAL',
   [BenefitType.POST_SILVER]: 'SILVER',


### PR DESCRIPTION
Prospects saw VIP tier and push-listing benefits with no explanation of what they do or why a given plan is worth buying. Add a shared glossary note above the plan grid/carousel covering VIP tier priority, listing pushes, and photo limits, plus a per-card note explaining what each plan unlocks over the previous one.

The photo-limit figure in each card note is resolved at render time from the real VIP tier data (via useVipTiers) instead of being hardcoded, so it stays correct if tier limits change on the backend.