### PR TITLE
Improve legibility and copy accuracy of membership plan notes

### DIFF
--- a/src/components/molecules/pricingPlanCard/index.tsx
+++ b/src/components/molecules/pricingPlanCard/index.tsx
@@ -159,9 +159,8 @@ const PricingPlanCard: React.FC<PricingPlanCardProps> = ({
         </CardHeader>
         <CardContent>
           <Typography
-            variant='muted'
             as='p'
-            className='rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed'
+            className='rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-foreground'
           >
             {t(`whyChoose.${membership.packageLevel}`)}
             {maxImages ? ` ${t('photoLimitNote', { count: maxImages })}` : null}

--- a/src/components/templates/membershipRegisterTemplate/MembershipGlossaryNote.tsx
+++ b/src/components/templates/membershipRegisterTemplate/MembershipGlossaryNote.tsx
@@ -10,9 +10,12 @@ export const MembershipGlossaryNote: React.FC = () => {
   return (
     <Alert>
       <Info />
-      <AlertTitle>{t('title')}</AlertTitle>
+      <AlertTitle className='text-base font-bold'>{t('title')}</AlertTitle>
       <AlertDescription>
-        <Typography as='ul' className='list-disc space-y-1 pl-4'>
+        <Typography
+          as='ul'
+          className='list-disc space-y-1 pl-4 text-foreground'
+        >
           <li>{t('vip')}</li>
           <li>{t('push')}</li>
           <li>{t('media')}</li>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3997,7 +3997,7 @@
         },
         "step2": {
           "title": "2. Choose a membership plan",
-          "description": "Based on the number of properties you want to advertise, choose a suitable plan: Basic (15 listings), Standard (30 listings), or Premium (50 listings)."
+          "description": "Based on your posting needs, choose a suitable plan: Basic (Silver-tier listings, lowest cost), Standard (adds Diamond and Gold listings — higher priority), or Advanced (the most priority listings and pushes)."
         },
         "step3": {
           "title": "3. Start posting",
@@ -4009,14 +4009,14 @@
         "description": "How the membership plan system works",
         "choosingPlan": {
           "title": "Choose the Right Plan",
-          "tip1": "Basic Plan: Suitable if you have 10-15 properties to advertise",
-          "tip2": "Standard Plan: Best for professional agents with 20-30 properties",
-          "tip3": "Premium Plan: For agents with large inventory or need many VIP listings"
+          "tip1": "Basic Plan: Silver-tier listings only, no Gold or Diamond yet — fits occasional posting",
+          "tip2": "Standard Plan: more Silver listings and pushes than Basic, plus unlocks Diamond and Gold listings — the two priority tiers Basic doesn't have",
+          "tip3": "Advanced Plan: the most of every listing tier and pushes — for high-volume, continuous posting"
         },
         "monthlyAllocation": {
           "title": "Monthly Listing Allocation",
           "description": "Each month you receive a fixed number of listings according to your plan. Unused listings do not carry over to the next month.",
-          "example": "Example: Standard Plan = 30 listings/month. If you only use 25 listings this month, the remaining 5 will be lost when the new month starts."
+          "example": "Example: the Standard Plan includes 10 Silver listings/month. If you only use 7 this month, the remaining 3 are lost when the new month starts — they don't roll over."
         }
       },
       "posts": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -4108,7 +4108,7 @@
         },
         "step2": {
           "title": "2. Chọn gói hội viên",
-          "description": "Dựa trên số lượng bất động sản bạn muốn quảng cáo, chọn gói phù hợp: Cơ bản (15 tin), Tiêu chuẩn (30 tin) hoặc Cao cấp (50 tin)."
+          "description": "Dựa trên nhu cầu đăng tin, chọn gói phù hợp: Cơ Bản (tin VIP Bạc, chi phí thấp), Tiêu Chuẩn (thêm tin VIP Kim Cương và Vàng — ưu tiên cao hơn) hoặc Nâng Cao (nhiều tin ưu tiên và lượt đẩy nhất)."
         },
         "step3": {
           "title": "3. Bắt đầu đăng tin",
@@ -4120,14 +4120,14 @@
         "description": "Cách thức hoạt động của hệ thống gói hội viên",
         "choosingPlan": {
           "title": "Chọn Gói Phù Hợp",
-          "tip1": "Gói Cơ bản: Phù hợp nếu bạn có 10-15 BDS cần quảng cáo",
-          "tip2": "Gói Tiêu chuẩn: Tốt nhất cho môi giới chuyên nghiệp với 20-30 BDS",
-          "tip3": "Gói Cao cấp: Dành cho môi giới có lượng hàng lớn hoặc cần VIP nhiều"
+          "tip1": "Gói Cơ Bản: có tin VIP Bạc, chưa có Vàng/Kim Cương — phù hợp nếu đăng tin không thường xuyên",
+          "tip2": "Gói Tiêu Chuẩn: nhiều tin Bạc và lượt đẩy hơn Cơ Bản, mở khóa thêm tin VIP Kim Cương và Vàng — 2 hạng ưu tiên cao nhất mà Cơ Bản không có",
+          "tip3": "Gói Nâng Cao: nhiều nhất ở mọi hạng tin và lượt đẩy — phù hợp khi đăng số lượng lớn, cần độ phủ liên tục"
         },
         "monthlyAllocation": {
           "title": "Số Tin Đăng Hàng Tháng",
           "description": "Mỗi tháng bạn nhận được số lượng tin đăng cố định theo gói. Tin chưa dùng sẽ không chuyển sang tháng sau.",
-          "example": "Ví dụ: Gói Tiêu chuẩn = 30 tin/tháng. Nếu tháng này bạn chỉ dùng 25 tin, 5 tin còn lại sẽ mất khi sang tháng mới."
+          "example": "Ví dụ: Gói Tiêu Chuẩn có 10 tin VIP Bạc/tháng. Nếu tháng này bạn chỉ dùng 7 tin, 3 tin còn lại sẽ mất khi sang tháng mới, không cộng dồn."
         }
       },
       "posts": {


### PR DESCRIPTION
The glossary note title blended into the body text, and the per-plan "why choose this" notes used muted gray that was hard to read. Bold and enlarge the glossary title, and switch both notes to text-foreground so they read clearly in light and dark mode.

Also correct stale copy on the usage guide page: the plan-choosing tips and monthly-allocation example referenced a flat listing count per plan that no longer matches the real benefit structure (VIP tier mix + push quota), and now mirror the same "what this plan adds over the previous one" framing used on the pricing guide.