### PR TITLE
Add per-tier guidance note to package type selector, default to Diamond

### DIFF
--- a/src/components/molecules/createPostSections/PackageTierNote.tsx
+++ b/src/components/molecules/createPostSections/PackageTierNote.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Info } from 'lucide-react'
+import { Alert, AlertDescription } from '@/components/atoms/alert'
+import { cn } from '@/lib/utils'
+import type { VipTier } from '@/api/types/vip-tier.type'
+
+interface PackageTierNoteProps {
+  /** The currently selected VIP tier. Falls back to the general guidance
+   *  note when absent, e.g. before tiers finish loading or while posting
+   *  under a membership benefit (tier selection is locked in that case). */
+  tier?: VipTier
+  className?: string
+}
+
+const KNOWN_TIER_CODES = ['NORMAL', 'SILVER', 'GOLD', 'DIAMOND']
+
+const PackageTierNote: React.FC<PackageTierNoteProps> = ({
+  tier,
+  className,
+}) => {
+  const t = useTranslations('createPost.sections.packageConfig.tierNotes')
+  const tierCode = tier?.tierCode
+  const resolvedKey =
+    tierCode && KNOWN_TIER_CODES.includes(tierCode) ? tierCode : 'default'
+
+  return (
+    <Alert className={cn('bg-muted/40 border-border', className)}>
+      <Info />
+      <AlertDescription className='text-foreground'>
+        {resolvedKey === 'default'
+          ? t('default')
+          : t(resolvedKey, { maxImages: tier?.maxImages ?? 0 })}
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+export { PackageTierNote }
+export type { PackageTierNoteProps }

--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -30,6 +30,7 @@ import {
 import { cn } from '@/lib/utils'
 import { resolveBenefitVipType } from '@/utils/createPost/benefitTier'
 import { SelectBenefitDialog } from '@/components/molecules/createPostSections/SelectPromotionDialog'
+import { PackageTierNote } from '@/components/molecules/createPostSections/PackageTierNote'
 
 interface PackageConfigSectionProps {
   className?: string
@@ -156,13 +157,17 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
   useEffect(() => {
     if (vipTiers.length === 0) return
 
-    const firstTier = vipTiers[0]
+    // Default to the highest tier (Diamond) so first-time posters see the
+    // best-performing option pre-selected, rather than the cheapest one.
+    const defaultTier =
+      vipTiers.find((tier) => tier.tierCode === 'DIAMOND') ??
+      vipTiers[vipTiers.length - 1]
     const hasCurrentTier = !!vipTiers.find(
       (tier) => tier.tierCode === propertyInfo.vipType,
     )
     const resolvedVipType = hasCurrentTier
       ? (propertyInfo.vipType as VipType)
-      : (firstTier.tierCode as VipType)
+      : (defaultTier.tierCode as VipType)
 
     const resolvedDuration =
       propertyInfo.durationDays ?? (useMembershipQuota ? 30 : 10)
@@ -570,6 +575,9 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
                 )}
               </Button>
             ))}
+          </CardContent>
+          <CardContent className='px-0 sm:px-6 pt-0'>
+            <PackageTierNote tier={useMembership ? undefined : selectedTier} />
           </CardContent>
         </Card>
 

--- a/src/components/organisms/updatePostSections/packageConfigSection.tsx
+++ b/src/components/organisms/updatePostSections/packageConfigSection.tsx
@@ -26,6 +26,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { PackageTierNote } from '@/components/molecules/createPostSections/PackageTierNote'
 
 interface PackageConfigSectionProps {
   className?: string
@@ -173,6 +174,9 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
                 )}
               </div>
             ))}
+          </CardContent>
+          <CardContent className='pt-0'>
+            <PackageTierNote tier={selectedTier} />
           </CardContent>
         </Card>
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1168,6 +1168,13 @@
             "description": "Display at bottom"
           }
         },
+        "tierNotes": {
+          "default": "Each package differs in display priority, badge, and max photo count — pick the one that fits your budget and reach goals.",
+          "NORMAL": "Standard: listed in chronological order, use listing pushes to return to the top, no badge. Lowest cost, best if you post infrequently.",
+          "SILVER": "VIP Silver: ranks above Standard listings, gets its own badge, and allows up to {maxImages} photos per listing — a balance of cost and reach.",
+          "GOLD": "VIP Gold: ranks above Silver with a more eye-catching badge and up to {maxImages} photos per listing — for when you need more reach.",
+          "DIAMOND": "VIP Diamond: top placement with the most eye-catching badge for maximum attention, plus up to {maxImages} photos per listing — for listings that need to rent or sell fastest."
+        },
         "perDay": "day",
         "priceShownPerDay": "Prices are shown per day",
         "days": "days",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1168,6 +1168,13 @@
             "description": "Hiện thị dưới cùng"
           }
         },
+        "tierNotes": {
+          "default": "Mỗi hạng tin khác nhau về mức độ ưu tiên hiển thị, badge và số ảnh tối đa — chọn hạng phù hợp với ngân sách và mục tiêu tiếp cận của bạn.",
+          "NORMAL": "Tin Thường: hiển thị theo thứ tự thời gian, dùng lượt đẩy tin để quay lại đầu danh sách, không có badge. Chi phí thấp nhất, phù hợp nếu bạn đăng không thường xuyên.",
+          "SILVER": "VIP Bạc: ưu tiên hiển thị trên tin Thường, có badge riêng và tối đa {maxImages} ảnh mỗi tin — cân bằng giữa chi phí và độ phủ.",
+          "GOLD": "VIP Vàng: hiển thị trên VIP Bạc, badge nổi bật hơn Bạc và tối đa {maxImages} ảnh mỗi tin — phù hợp khi cần tiếp cận nhiều người xem hơn.",
+          "DIAMOND": "VIP Kim Cương: hiển thị trên cùng, badge nổi bật nhất, thu hút sự chú ý cao nhất, độ phủ tối đa và tối đa {maxImages} ảnh mỗi tin — dành cho tin cần cho thuê/bán nhanh nhất."
+        },
         "perDay": "ngày",
         "priceShownPerDay": "Giá hiển thị theo ngày",
         "days": "ngày",


### PR DESCRIPTION
Sellers picking a package on create/update-post had no explanation of what each VIP tier unlocks, so add a note below "Chọn loại tin" that explains display priority, badge prominence, and photo limit per tier, falling back to general guidance when no tier context applies (e.g. posting under a membership benefit). Also default new posts to the Diamond tier instead of the cheapest one, since that's the option most likely to match what a first-time poster actually wants.