### PR TITLE
Add breathing room around the package tier note

### DIFF
--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -576,7 +576,7 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
               </Button>
             ))}
           </CardContent>
-          <CardContent className='px-0 sm:px-6 pt-0'>
+          <CardContent className='px-0 sm:px-6 py-row-lg'>
             <PackageTierNote tier={useMembership ? undefined : selectedTier} />
           </CardContent>
         </Card>

--- a/src/components/organisms/updatePostSections/packageConfigSection.tsx
+++ b/src/components/organisms/updatePostSections/packageConfigSection.tsx
@@ -175,7 +175,7 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
               </div>
             ))}
           </CardContent>
-          <CardContent className='pt-0'>
+          <CardContent className='py-row-lg'>
             <PackageTierNote tier={selectedTier} />
           </CardContent>
         </Card>


### PR DESCRIPTION
The note sat flush against the tier grid above it with no top or bottom padding, reading as cramped. Give it symmetric row spacing.