### PR TITLE
Bold the tier name in the package note

### DIFF
--- a/src/components/molecules/createPostSections/PackageTierNote.tsx
+++ b/src/components/molecules/createPostSections/PackageTierNote.tsx
@@ -28,9 +28,14 @@ const PackageTierNote: React.FC<PackageTierNoteProps> = ({
     <Alert className={cn('bg-muted/40 border-border', className)}>
       <Info />
       <AlertDescription className='text-foreground'>
-        {resolvedKey === 'default'
-          ? t('default')
-          : t(resolvedKey, { maxImages: tier?.maxImages ?? 0 })}
+        {resolvedKey === 'default' ? (
+          t('default')
+        ) : (
+          <>
+            <strong className='font-semibold'>{tier?.tierName}</strong>:{' '}
+            {t(resolvedKey, { maxImages: tier?.maxImages ?? 0 })}
+          </>
+        )}
       </AlertDescription>
     </Alert>
   )

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1170,10 +1170,10 @@
         },
         "tierNotes": {
           "default": "Each package differs in display priority, badge, and max photo count — pick the one that fits your budget and reach goals.",
-          "NORMAL": "Standard: listed in chronological order, use listing pushes to return to the top, no badge. Lowest cost, best if you post infrequently.",
-          "SILVER": "VIP Silver: ranks above Standard listings, gets its own badge, and allows up to {maxImages} photos per listing — a balance of cost and reach.",
-          "GOLD": "VIP Gold: ranks above Silver with a more eye-catching badge and up to {maxImages} photos per listing — for when you need more reach.",
-          "DIAMOND": "VIP Diamond: top placement with the most eye-catching badge for maximum attention, plus up to {maxImages} photos per listing — for listings that need to rent or sell fastest."
+          "NORMAL": "listed in chronological order, use listing pushes to return to the top, no badge. Lowest cost, best if you post infrequently.",
+          "SILVER": "ranks above Standard listings, gets its own badge, and allows up to {maxImages} photos per listing — a balance of cost and reach.",
+          "GOLD": "ranks above Silver with a more eye-catching badge and up to {maxImages} photos per listing — for when you need more reach.",
+          "DIAMOND": "top placement with the most eye-catching badge for maximum attention, plus up to {maxImages} photos per listing — for listings that need to rent or sell fastest."
         },
         "perDay": "day",
         "priceShownPerDay": "Prices are shown per day",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1170,10 +1170,10 @@
         },
         "tierNotes": {
           "default": "Mỗi hạng tin khác nhau về mức độ ưu tiên hiển thị, badge và số ảnh tối đa — chọn hạng phù hợp với ngân sách và mục tiêu tiếp cận của bạn.",
-          "NORMAL": "Tin Thường: hiển thị theo thứ tự thời gian, dùng lượt đẩy tin để quay lại đầu danh sách, không có badge. Chi phí thấp nhất, phù hợp nếu bạn đăng không thường xuyên.",
-          "SILVER": "VIP Bạc: ưu tiên hiển thị trên tin Thường, có badge riêng và tối đa {maxImages} ảnh mỗi tin — cân bằng giữa chi phí và độ phủ.",
-          "GOLD": "VIP Vàng: hiển thị trên VIP Bạc, badge nổi bật hơn Bạc và tối đa {maxImages} ảnh mỗi tin — phù hợp khi cần tiếp cận nhiều người xem hơn.",
-          "DIAMOND": "VIP Kim Cương: hiển thị trên cùng, badge nổi bật nhất, thu hút sự chú ý cao nhất, độ phủ tối đa và tối đa {maxImages} ảnh mỗi tin — dành cho tin cần cho thuê/bán nhanh nhất."
+          "NORMAL": "hiển thị theo thứ tự thời gian, dùng lượt đẩy tin để quay lại đầu danh sách, không có badge. Chi phí thấp nhất, phù hợp nếu bạn đăng không thường xuyên.",
+          "SILVER": "ưu tiên hiển thị trên tin Thường, có badge riêng và tối đa {maxImages} ảnh mỗi tin — cân bằng giữa chi phí và độ phủ.",
+          "GOLD": "hiển thị trên VIP Bạc, badge nổi bật hơn Bạc và tối đa {maxImages} ảnh mỗi tin — phù hợp khi cần tiếp cận nhiều người xem hơn.",
+          "DIAMOND": "hiển thị trên cùng, badge nổi bật nhất, thu hút sự chú ý cao nhất, độ phủ tối đa và tối đa {maxImages} ảnh mỗi tin — dành cho tin cần cho thuê/bán nhanh nhất."
         },
         "perDay": "ngày",
         "priceShownPerDay": "Giá hiển thị theo ngày",


### PR DESCRIPTION
The note read as a wall of text with no visual anchor for which tier it described. Bold the tier name (sourced from the real tier data, not duplicated in the translation strings) so it stands out.