### PR TITLE
Simplify similar & recently viewed listing cards, show 5 per carousel

### DIFF
--- a/src/components/molecules/simplePropertyCard/index.tsx
+++ b/src/components/molecules/simplePropertyCard/index.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import classNames from 'classnames'
+import { Card, CardContent } from '@/components/atoms/card'
+import { Badge } from '@/components/atoms/badge'
+import { Typography } from '@/components/atoms/typography'
+import ImageAtom from '@/components/atoms/imageAtom'
+import SaveListingButton from '@/components/molecules/saveListingButton'
+import { basePath, DEFAULT_IMAGE } from '@/constants'
+import { useTranslations } from 'next-intl'
+import { Camera, Sparkles, MapPin } from 'lucide-react'
+import { ListingDetail } from '@/api/types'
+import { formatByLocale } from '@/utils/currency/convert'
+
+interface SimplePropertyCardProps {
+  listing: ListingDetail
+  onClick?: (listing: ListingDetail) => void
+  className?: string
+}
+
+const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
+  listing,
+  onClick,
+  className,
+}) => {
+  const t = useTranslations()
+  const { title, price, priceUnit, address, vipType, media } = listing
+
+  const images = media?.filter((m) => m.mediaType === 'IMAGE')
+  const mainImage = images?.[0]?.url
+  const totalImages = images?.length || 0
+
+  const { fullNewAddress: newAddress, fullAddress: legacyAddress } =
+    address || {}
+  const displayAddress = newAddress || legacyAddress
+
+  const showVipBadge = !!vipType && vipType !== 'NORMAL' && vipType !== 'SILVER'
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (onClick) {
+      e.stopPropagation()
+      onClick(listing)
+    }
+  }
+
+  return (
+    <Card
+      className={classNames(
+        'group/card cursor-pointer overflow-hidden transition-all duration-300 py-0',
+        'hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
+        'border-border/60 hover:border-primary/30 flex flex-col h-full',
+        className,
+      )}
+      onClick={onClick ? handleClick : undefined}
+    >
+      <div className='relative overflow-hidden aspect-[4/3] flex-shrink-0'>
+        <ImageAtom
+          src={mainImage || `${basePath}/images/default-image.jpg`}
+          defaultImage={DEFAULT_IMAGE}
+          alt={title}
+          className='w-full h-full object-cover object-center transition-transform duration-500 group-hover/card:scale-105'
+        />
+
+        <div className='absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black/40 to-transparent pointer-events-none' />
+
+        <div className='absolute top-2 right-2 z-10'>
+          <SaveListingButton
+            listingId={listing.listingId}
+            variant='icon'
+            className='bg-card/80 backdrop-blur-md rounded-full shadow-sm transition-all w-8 h-8'
+            iconClassName='w-3.5 h-3.5'
+          />
+        </div>
+
+        {showVipBadge && (
+          <div className='absolute top-2 left-2 z-10'>
+            <Badge className='bg-gradient-to-r from-primary to-primary/80 text-primary-foreground shadow-sm rounded-full text-2xs px-2 py-0.5 flex items-center gap-0.5 backdrop-blur-sm'>
+              <Sparkles className='w-2.5 h-2.5' />
+              {t('homePage.priorityBadge')}
+            </Badge>
+          </div>
+        )}
+
+        {totalImages > 0 && (
+          <div className='absolute bottom-1.5 left-1.5 flex items-center gap-1 bg-black/60 text-white rounded-full backdrop-blur-md text-2xs px-1.5 py-0.5'>
+            <Camera className='w-2.5 h-2.5' />
+            <span className='font-medium'>{totalImages}</span>
+          </div>
+        )}
+      </div>
+
+      <CardContent className='flex-1 flex flex-col p-3 space-y-1.5'>
+        <Typography
+          variant='h6'
+          className='text-foreground group-hover/card:text-primary transition-colors duration-200 leading-tight font-semibold line-clamp-2'
+        >
+          {title}
+        </Typography>
+
+        {displayAddress && (
+          <div className='flex items-start gap-1.5 min-w-0'>
+            <MapPin className='flex-shrink-0 text-muted-foreground mt-0.5 w-3 h-3' />
+            <Typography
+              variant='small'
+              className='text-muted-foreground line-clamp-1 leading-snug'
+            >
+              {displayAddress}
+            </Typography>
+          </div>
+        )}
+
+        <Typography
+          variant='h5'
+          className='text-primary font-bold tracking-tight mt-auto pt-1'
+        >
+          {formatByLocale(price, priceUnit)}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default SimplePropertyCard

--- a/src/components/organisms/apartmentDetail/RecentlyViewedSection.tsx
+++ b/src/components/organisms/apartmentDetail/RecentlyViewedSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
-import PropertyCard from '@/components/molecules/propertyCard'
+import SimplePropertyCard from '@/components/molecules/simplePropertyCard'
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed'
 import Link from 'next/link'
 import type { ListingDetail } from '@/api/types'
@@ -75,8 +75,6 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
         l.listingId > 0,
     ) as ListingDetail[]
 
-  const handleFavorite = () => {}
-
   const handleLinkClick = (e: React.MouseEvent) => {
     // Prevent navigation if clicking on action buttons
     const target = e.target as HTMLElement
@@ -107,10 +105,10 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
           setApi={setApi}
         >
           <CarouselContent>
-            {Array.from({ length: 3 }).map((_, index) => (
+            {Array.from({ length: 5 }).map((_, index) => (
               <CarouselItem
                 key={index}
-                className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+                className='basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 min-w-[160px]'
               >
                 <div className='space-y-2'>
                   <Skeleton className='aspect-[4/3] rounded-lg w-full' />
@@ -118,10 +116,6 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
                     <Skeleton className='h-4 w-3/4' />
                     <Skeleton className='h-3 w-1/2' />
                     <Skeleton className='h-5 w-1/3' />
-                    <div className='flex gap-2'>
-                      <Skeleton className='h-4 w-16' />
-                      <Skeleton className='h-4 w-16' />
-                    </div>
                   </div>
                 </div>
               </CarouselItem>
@@ -157,19 +151,14 @@ const RecentlyViewedSection: React.FC<RecentlyViewedSectionProps> = ({
           {listingsData.map((listing) => (
             <CarouselItem
               key={listing.listingId}
-              className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+              className='basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 min-w-[160px]'
             >
               <Link
                 href={`/listing-detail/${listing.listingId}`}
                 className='block h-full'
                 onClick={handleLinkClick}
               >
-                <PropertyCard
-                  listing={listing}
-                  onFavorite={handleFavorite}
-                  className='h-full'
-                  imageLayout='top'
-                />
+                <SimplePropertyCard listing={listing} className='h-full' />
               </Link>
             </CarouselItem>
           ))}

--- a/src/components/organisms/apartmentDetail/SimilarPropertiesSection.tsx
+++ b/src/components/organisms/apartmentDetail/SimilarPropertiesSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
-import PropertyCard from '@/components/molecules/propertyCard'
+import SimplePropertyCard from '@/components/molecules/simplePropertyCard'
 import {
   Carousel,
   CarouselContent,
@@ -51,8 +51,6 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
     })
   }, [api])
 
-  const handleFavorite = () => {}
-
   const handleLinkClick = (e: React.MouseEvent) => {
     // Prevent navigation if clicking on action buttons
     const target = e.target as HTMLElement
@@ -69,7 +67,7 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
   }
 
   if (isLoading) {
-    const skeletonItems = Array.from({ length: 4 })
+    const skeletonItems = Array.from({ length: 5 })
     return (
       <section className='mb-8 sm:mb-10'>
         <SectionHeading
@@ -85,7 +83,7 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
             {skeletonItems.map((_, index) => (
               <CarouselItem
                 key={index}
-                className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+                className='basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 min-w-[160px]'
               >
                 <div className='w-full space-y-2 md:space-y-3'>
                   <Skeleton className='aspect-[4/3] rounded-lg w-full' />
@@ -153,19 +151,14 @@ const SimilarPropertiesSection: React.FC<SimilarPropertiesSectionProps> = ({
           {validListings.map((listing) => (
             <CarouselItem
               key={listing.listingId}
-              className='basis-full sm:basis-1/2 lg:basis-1/3 min-w-[260px] sm:min-w-[280px] lg:min-w-0'
+              className='basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 min-w-[160px]'
             >
               <Link
                 href={`/listing-detail/${listing.listingId}`}
                 className='block h-full'
                 onClick={handleLinkClick}
               >
-                <PropertyCard
-                  listing={listing}
-                  onFavorite={handleFavorite}
-                  className='h-full'
-                  imageLayout='top'
-                />
+                <SimplePropertyCard listing={listing} className='h-full' />
               </Link>
             </CarouselItem>
           ))}


### PR DESCRIPTION
Add a lighter SimplePropertyCard (image, title, address, price only — no bed/bath/area stat pills, no owner avatar) for the similar-properties and recently-viewed carousels on the listing detail page, and widen the carousel breakpoints to surface 5 cards at once on large screens.