### PR TITLE
Darken VIP badge colors, shrink badge on detail-page card lists

### DIFF
--- a/src/components/molecules/CardListingAIMini/index.tsx
+++ b/src/components/molecules/CardListingAIMini/index.tsx
@@ -22,6 +22,7 @@ import { useToggleSaveListing } from '@/hooks/useSavedListings'
 import { useCompareStore } from '@/store/compare/useCompareStore'
 import type { ChatListing } from '@/api/types/ai.type'
 import type { ListingApi } from '@/api/types/property.type'
+import { getVipBadgeClassName, isVipTierShown } from '@/utils/property'
 import { toast } from 'sonner'
 
 export interface CardListingAIMiniProps {
@@ -104,17 +105,12 @@ export const CardListingAIMini: React.FC<CardListingAIMiniProps> = ({
               className='object-cover transition-transform duration-300 group-hover:scale-110'
               sizes='(max-width: 640px) 100vw, 128px'
             />
-            {vipType && vipType !== 'NORMAL' && (
+            {isVipTierShown(vipType) && (
               <div className='absolute top-2 left-2'>
                 <Badge
                   className={cn(
+                    getVipBadgeClassName(vipType),
                     'rounded-full shadow-md font-medium backdrop-blur-sm text-xs px-2.5 py-1',
-                    vipType === 'SILVER' &&
-                      'bg-gray-300/90 text-gray-800 dark:bg-gray-600/90 dark:text-gray-50',
-                    vipType === 'GOLD' &&
-                      'bg-yellow-400/90 text-yellow-950 dark:bg-yellow-500/90 dark:text-yellow-950',
-                    vipType === 'DIAMOND' &&
-                      'bg-blue-400/90 text-white dark:bg-blue-500/90 dark:text-white',
                   )}
                 >
                   {tVip(`vipTypes.${vipType}`)}

--- a/src/components/molecules/mapPropertyCard/index.tsx
+++ b/src/components/molecules/mapPropertyCard/index.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl'
 import { Bed, Bath, Square, Users, Camera, MapPin } from 'lucide-react'
 import { ListingDetail } from '@/api/types'
 import { formatByLocale } from '@/utils/currency/convert'
+import { getVipBadgeClassName, isVipTierShown } from '@/utils/property'
 
 interface MapPropertyCardProps {
   listing: ListingDetail
@@ -85,15 +86,7 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
   const userName = `${firstName || ''} ${lastName || ''}`.trim()
   const isProfessionalBroker =
     Boolean(user?.isBroker) || user?.brokerVerificationStatus === 'APPROVED'
-  // Badge background mirrors the VIP border ring color used on other cards.
-  const vipBadgeStyles: Record<string, string> = {
-    SILVER:
-      'bg-gray-300/90 text-gray-800 dark:bg-gray-600/90 dark:text-gray-50',
-    GOLD: 'bg-yellow-400/90 text-yellow-950 dark:bg-yellow-500/90 dark:text-yellow-950',
-    DIAMOND: 'bg-blue-400/90 text-white dark:bg-blue-500/90 dark:text-white',
-  }
-  const showVipBadge = !!vipType && vipType !== 'NORMAL'
-  const vipBadgeClassName = vipType ? vipBadgeStyles[vipType] || '' : ''
+  const showVipBadge = isVipTierShown(vipType)
 
   return (
     <div
@@ -141,7 +134,7 @@ const MapPropertyCardBase: React.FC<MapPropertyCardProps> = ({
             {showVipBadge && (
               <Badge
                 className={classNames(
-                  vipBadgeClassName,
+                  getVipBadgeClassName(vipType),
                   'text-[11px] rounded-full shadow-md backdrop-blur-sm',
                   compact ? 'px-1.5 py-0.5' : 'px-2.5 py-1',
                 )}

--- a/src/components/molecules/propertyCard/index.tsx
+++ b/src/components/molecules/propertyCard/index.tsx
@@ -31,6 +31,11 @@ import {
   getFurnishingTranslationKey,
 } from '@/utils/property'
 import BrokerAvatar from '@/components/molecules/brokerAvatar'
+import {
+  getVipBadgeClassName,
+  getVipBorderClassName,
+  isVipTierShown,
+} from '@/utils/property'
 
 interface PropertyCardProps {
   listing: ListingDetail
@@ -135,34 +140,15 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
   }
   const ProductTypeIcon = ProductTypeIconMap[productType || ''] || Home
 
-  // Badge background mirrors the card's VIP border ring color per tier.
-  const vipBadgeStyles: Record<string, string> = {
-    SILVER:
-      'bg-gray-300/90 text-gray-800 dark:bg-gray-600/90 dark:text-gray-50',
-    GOLD: 'bg-yellow-400/90 text-yellow-950 dark:bg-yellow-500/90 dark:text-yellow-950',
-    DIAMOND: 'bg-blue-400/90 text-white dark:bg-blue-500/90 dark:text-white',
-  }
-
   const getVipBadgeConfig = () => {
-    if (!vipType || vipType === 'NORMAL') return null
+    if (!isVipTierShown(vipType)) return null
     return {
       label: t(`apartmentDetail.property.vipTypes.${vipType}`),
-      className: vipBadgeStyles[vipType] || '',
+      className: getVipBadgeClassName(vipType),
     }
   }
 
   const vipBadgeConfig = getVipBadgeConfig()
-
-  // Get VIP card border style
-  const getVipCardBorder = () => {
-    if (!vipType || vipType === 'NORMAL') return ''
-    const borders: Record<string, string> = {
-      SILVER: 'ring-1 ring-gray-300/50',
-      GOLD: 'ring-1 ring-yellow-400/50',
-      DIAMOND: 'ring-1 ring-blue-400/50',
-    }
-    return borders[vipType] || ''
-  }
 
   const handlePrevImage = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -445,7 +431,7 @@ const PropertyCard: React.FC<PropertyCardProps> = (props) => {
         'group/card cursor-pointer overflow-hidden transition-all duration-300 py-0',
         'hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'border-border/60 hover:border-primary/30',
-        getVipCardBorder(),
+        getVipBorderClassName(vipType),
         isCompact
           ? isTopLayout
             ? 'flex flex-col h-full'

--- a/src/components/molecules/simplePropertyCard/index.tsx
+++ b/src/components/molecules/simplePropertyCard/index.tsx
@@ -11,6 +11,11 @@ import { useTranslations } from 'next-intl'
 import { Camera, MapPin } from 'lucide-react'
 import { ListingDetail } from '@/api/types'
 import { formatByLocale } from '@/utils/currency/convert'
+import {
+  getVipBadgeClassName,
+  getVipBorderClassName,
+  isVipTierShown,
+} from '@/utils/property'
 
 interface SimplePropertyCardProps {
   listing: ListingDetail
@@ -34,24 +39,10 @@ const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
     address || {}
   const displayAddress = newAddress || legacyAddress
 
-  // Badge background mirrors the card's VIP border ring color per tier.
-  const vipBorderStyles: Record<string, string> = {
-    SILVER: 'ring-1 ring-gray-300/50',
-    GOLD: 'ring-1 ring-yellow-400/50',
-    DIAMOND: 'ring-1 ring-blue-400/50',
-  }
-  const vipBadgeStyles: Record<string, string> = {
-    SILVER:
-      'bg-gray-300/90 text-gray-800 dark:bg-gray-600/90 dark:text-gray-50',
-    GOLD: 'bg-yellow-400/90 text-yellow-950 dark:bg-yellow-500/90 dark:text-yellow-950',
-    DIAMOND: 'bg-blue-400/90 text-white dark:bg-blue-500/90 dark:text-white',
-  }
-  const vipCardBorder = vipType ? vipBorderStyles[vipType] || '' : ''
-  const vipBadgeClassName = vipType ? vipBadgeStyles[vipType] || '' : ''
-  const vipBadgeLabel = vipType
+  const showVipBadge = isVipTierShown(vipType)
+  const vipBadgeLabel = showVipBadge
     ? t(`apartmentDetail.property.vipTypes.${vipType}`)
     : ''
-  const showVipBadge = !!vipType && vipType !== 'NORMAL'
 
   const handleClick = (e: React.MouseEvent) => {
     if (onClick) {
@@ -66,7 +57,7 @@ const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
         'group/card cursor-pointer overflow-hidden transition-all duration-300 py-0',
         'hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'border-border/60 hover:border-primary/30 flex flex-col h-full',
-        showVipBadge && vipCardBorder,
+        showVipBadge && getVipBorderClassName(vipType),
         className,
       )}
       onClick={onClick ? handleClick : undefined}
@@ -100,8 +91,8 @@ const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
           <div className='absolute top-2 left-2 z-10'>
             <Badge
               className={classNames(
-                vipBadgeClassName,
-                'shadow-sm rounded-full text-2xs px-2 py-0.5 backdrop-blur-sm',
+                getVipBadgeClassName(vipType),
+                'shadow-sm rounded-full text-micro px-1.5 py-0 leading-4 backdrop-blur-sm',
               )}
             >
               {vipBadgeLabel}

--- a/src/utils/property/index.ts
+++ b/src/utils/property/index.ts
@@ -19,3 +19,10 @@ export {
   PUBLICLY_VISIBLE_STATUSES,
 } from './listingVisibility'
 export type { ListingVisibilityFields } from './listingVisibility'
+export {
+  getVipBadgeClassName,
+  getVipBorderClassName,
+  isVipTierShown,
+  VIP_BADGE_CLASSNAMES,
+  VIP_BORDER_CLASSNAMES,
+} from './vipBadge'

--- a/src/utils/property/vipBadge.ts
+++ b/src/utils/property/vipBadge.ts
@@ -1,0 +1,25 @@
+import { VipType } from '@/api/types/property.type'
+
+// Solid, dark per-tier colors with white text — shared across every listing
+// card (PropertyCard, SimplePropertyCard, MapPropertyCard, CardListingAIMini)
+// so the VIP badge reads consistently wherever a listing card appears.
+export const VIP_BADGE_CLASSNAMES: Partial<Record<VipType, string>> = {
+  SILVER: 'bg-gray-600 text-white',
+  GOLD: 'bg-amber-700 text-white',
+  DIAMOND: 'bg-blue-700 text-white',
+}
+
+export const getVipBadgeClassName = (vipType?: string | null): string =>
+  vipType ? VIP_BADGE_CLASSNAMES[vipType as VipType] || '' : ''
+
+export const isVipTierShown = (vipType?: string | null): boolean =>
+  !!vipType && vipType !== 'NORMAL'
+
+export const VIP_BORDER_CLASSNAMES: Partial<Record<VipType, string>> = {
+  SILVER: 'ring-1 ring-gray-300/50',
+  GOLD: 'ring-1 ring-yellow-400/50',
+  DIAMOND: 'ring-1 ring-blue-400/50',
+}
+
+export const getVipBorderClassName = (vipType?: string | null): string =>
+  vipType ? VIP_BORDER_CLASSNAMES[vipType as VipType] || '' : ''


### PR DESCRIPTION
Extract the per-tier badge/border color map into a shared utils/property/vipBadge helper so PropertyCard, SimplePropertyCard, MapPropertyCard and CardListingAIMini stay in sync, switch every tier to a darker solid background with white text, and size the badge down on SimplePropertyCard (similar-properties / recently-viewed carousels) to match that card's smaller footprint.