### PR TITLE
Tune VIP badge palette off the brand primary, lighten gold

### DIFF
--- a/src/utils/property/vipBadge.ts
+++ b/src/utils/property/vipBadge.ts
@@ -1,12 +1,15 @@
 import { VipType } from '@/api/types/property.type'
 
-// Solid, dark per-tier colors with white text — shared across every listing
-// card (PropertyCard, SimplePropertyCard, MapPropertyCard, CardListingAIMini)
-// so the VIP badge reads consistently wherever a listing card appears.
+// Per-tier colors with white text — shared across every listing card
+// (PropertyCard, SimplePropertyCard, MapPropertyCard, CardListingAIMini) so
+// the VIP badge reads consistently wherever a listing card appears. DIAMOND
+// (the top tier) uses the brand primary color directly; SILVER/GOLD are
+// picked at a similar lightness so none of the three reads muddier or
+// louder than the others.
 export const VIP_BADGE_CLASSNAMES: Partial<Record<VipType, string>> = {
-  SILVER: 'bg-gray-600 text-white',
-  GOLD: 'bg-amber-700 text-white',
-  DIAMOND: 'bg-blue-700 text-white',
+  SILVER: 'bg-slate-500 text-white',
+  GOLD: 'bg-amber-500 text-white',
+  DIAMOND: 'bg-primary text-primary-foreground',
 }
 
 export const getVipBadgeClassName = (vipType?: string | null): string =>
@@ -16,9 +19,9 @@ export const isVipTierShown = (vipType?: string | null): boolean =>
   !!vipType && vipType !== 'NORMAL'
 
 export const VIP_BORDER_CLASSNAMES: Partial<Record<VipType, string>> = {
-  SILVER: 'ring-1 ring-gray-300/50',
-  GOLD: 'ring-1 ring-yellow-400/50',
-  DIAMOND: 'ring-1 ring-blue-400/50',
+  SILVER: 'ring-1 ring-slate-400/50',
+  GOLD: 'ring-1 ring-amber-400/50',
+  DIAMOND: 'ring-1 ring-primary/40',
 }
 
 export const getVipBorderClassName = (vipType?: string | null): string =>


### PR DESCRIPTION
Amber-700 read too dark/muddy for the GOLD badge. Rebalance the tier palette around the app's primary color instead of arbitrary shades: DIAMOND now uses bg-primary directly, SILVER/GOLD sit at a matching lightness (slate-500 / amber-500) so none of the three tiers looks heavier than the others. Border rings updated to match.