### PR TITLE
Give the similar/recently-viewed card badge a touch more room

### DIFF
--- a/src/components/molecules/simplePropertyCard/index.tsx
+++ b/src/components/molecules/simplePropertyCard/index.tsx
@@ -92,7 +92,7 @@ const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
             <Badge
               className={classNames(
                 getVipBadgeClassName(vipType),
-                'shadow-sm rounded-full text-micro px-1.5 py-0 leading-4 backdrop-blur-sm',
+                'shadow-sm rounded-full text-micro px-2 py-0.5 leading-none backdrop-blur-sm',
               )}
             >
               {vipBadgeLabel}


### PR DESCRIPTION
Text stays at the small text-micro token (white, unchanged) but the pill gets slightly more padding (px-2 py-0.5 vs px-1.5 py-0) so it doesn't look cramped, without growing back to PropertyCard's size.