### PR TITLE
Force white VIP badge text, shrink and plump the pill on small card l…

### DIFF
--- a/src/components/molecules/simplePropertyCard/index.tsx
+++ b/src/components/molecules/simplePropertyCard/index.tsx
@@ -92,7 +92,7 @@ const SimplePropertyCard: React.FC<SimplePropertyCardProps> = ({
             <Badge
               className={classNames(
                 getVipBadgeClassName(vipType),
-                'shadow-sm rounded-full text-micro px-2 py-0.5 leading-none backdrop-blur-sm',
+                'shadow-sm rounded-full text-nano font-semibold px-2.5 py-1 leading-none backdrop-blur-sm',
               )}
             >
               {vipBadgeLabel}

--- a/src/utils/property/vipBadge.ts
+++ b/src/utils/property/vipBadge.ts
@@ -7,9 +7,9 @@ import { VipType } from '@/api/types/property.type'
 // picked at a similar lightness so none of the three reads muddier or
 // louder than the others.
 export const VIP_BADGE_CLASSNAMES: Partial<Record<VipType, string>> = {
-  SILVER: 'bg-slate-500 text-white',
-  GOLD: 'bg-amber-500 text-white',
-  DIAMOND: 'bg-primary text-primary-foreground',
+  SILVER: 'bg-slate-500 !text-white',
+  GOLD: 'bg-amber-500 !text-white',
+  DIAMOND: 'bg-primary !text-white',
 }
 
 export const getVipBadgeClassName = (vipType?: string | null): string =>


### PR DESCRIPTION
…ists

Switch every tier to a literal !text-white (dropping the text-primary-foreground token dependency) so the label can't render dark under any theme. On SimplePropertyCard specifically (the similar-listings / recently-viewed carousels) drop the label to text-nano and give the pill a bit more padding so it reads as small text in a plumper, rounder badge instead of a cramped chip.