### PR TITLE
Simplify sidebar filter options to fetch once, no live counts

### DIFF
--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -324,20 +324,17 @@ export class ListingService {
   }
 
   /**
-   * Dynamic filter bucket options (price / area / bedrooms) for the public
-   * listings sidebar, each annotated with a live count under the current
-   * filter context. Same request shape as `search`.
-   * POST /v1/listings/filter-options
+   * Static filter bucket options (price / area / bedrooms) for the public
+   * listings sidebar. Same response for every caller — no request body.
+   * GET /v1/listings/filter-options
    */
   static async getFilterOptions(
-    request: ListingSearchApiRequest,
     instance?: AxiosInstance,
   ): Promise<ApiResponse<ListingFilterOptionsResponse>> {
     return apiRequest<ListingFilterOptionsResponse>(
       {
-        method: 'POST',
+        method: 'GET',
         url: PATHS.LISTING.FILTER_OPTIONS,
-        data: request,
         skipAuth: true, // Public API - không cần authentication
       },
       instance,

--- a/src/api/types/property.type.ts
+++ b/src/api/types/property.type.ts
@@ -669,20 +669,19 @@ export interface ListingSearchApiRequest {
 }
 
 /**
- * One selectable bucket of a dynamic sidebar filter (price/area/bedrooms),
- * with the live count of listings it would match under the current filter
- * context. `key` matches a `propertiesPage.filter.<group>.<key>` i18n label.
+ * One selectable bucket of a sidebar filter (price/area/bedrooms). `key`
+ * matches a `propertiesPage.filter.<group>.<key>` i18n label.
  */
 export interface FilterBucketOption {
   key: string
   min?: number | null
   max?: number | null
-  count: number
 }
 
 /**
- * Response for POST /v1/listings/filter-options — dynamic bucket options for
- * the public listings sidebar (price / area / bedrooms).
+ * Response for GET /v1/listings/filter-options — static bucket options for
+ * the public listings sidebar (price / area / bedrooms). Same for every
+ * caller; fetch once and cache indefinitely.
  */
 export interface ListingFilterOptionsResponse {
   priceOptions: FilterBucketOption[]

--- a/src/components/molecules/propertyFilterSidebar/index.tsx
+++ b/src/components/molecules/propertyFilterSidebar/index.tsx
@@ -6,7 +6,6 @@ import { Typography } from '@/components/atoms/typography'
 import { Checkbox } from '@/components/atoms/checkbox'
 import { Card } from '@/components/atoms/card'
 import { Skeleton } from '@/components/atoms/skeleton'
-import { cn } from '@/lib/utils'
 import type { FilterBucketOption, ListingFilterRequest } from '@/api/types'
 
 type FilterGroup = 'price' | 'area' | 'bedroom'
@@ -27,7 +26,9 @@ const PropertyFilterSidebar: React.FC = () => {
   const tPage = useTranslations('propertiesPage')
   const { filters, updateFilters } = useListContext<ListingFilterRequest>()
 
-  const { data, isPending, isError, refetch } = useListingFilterOptions(filters)
+  // Static options — fetched once, never refetched when the user toggles a
+  // checkbox: the buckets themselves don't depend on the current selection.
+  const { data, isPending, isError, refetch } = useListingFilterOptions()
 
   const isOptionSelected = (group: FilterGroup, option: FilterBucketOption) => {
     const { min: minKey, max: maxKey } = RANGE_FIELDS[group]
@@ -83,30 +84,20 @@ const PropertyFilterSidebar: React.FC = () => {
     <div className='space-y-2'>
       {options.map((option) => {
         const selected = isOptionSelected(group, option)
-        const disabled = option.count === 0 && !selected
 
         return (
           <label
             key={option.key}
-            className={cn(
-              'flex items-center gap-2 transition-colors',
-              disabled
-                ? 'cursor-not-allowed text-muted-foreground'
-                : 'cursor-pointer hover:text-primary',
-            )}
+            className='flex items-center gap-2 cursor-pointer hover:text-primary transition-colors'
           >
             <Checkbox
               checked={selected}
-              disabled={disabled}
               onCheckedChange={(checked) =>
                 handleOptionChange(group, option, checked as boolean)
               }
             />
             <Typography variant='small' className='text-sm'>
-              {t('optionWithCount', {
-                label: t(`${group}.${option.key}` as string),
-                count: option.count,
-              })}
+              {t(`${group}.${option.key}` as string)}
             </Typography>
           </label>
         )

--- a/src/hooks/useListings/useListingFilterOptions.ts
+++ b/src/hooks/useListings/useListingFilterOptions.ts
@@ -1,72 +1,27 @@
 import { useQuery } from '@tanstack/react-query'
 import { ListingService } from '@/api/services/listing.service'
-import { useDebounce } from '@/hooks/useDebounce'
-import { mapFrontendToBackendRequest } from '@/utils/property/mapListingResponse'
-import type {
-  ListingFilterOptionsResponse,
-  ListingFilterRequest,
-} from '@/api/types'
+import type { ListingFilterOptionsResponse } from '@/api/types'
 
 interface UseListingFilterOptionsOptions {
   enabled?: boolean
-  staleTime?: number
-  gcTime?: number
-  /** Debounce delay (ms) before a filter change triggers a refetch. */
-  debounceMs?: number
-}
-
-// page/size/sortBy/sortDirection never change bucket counts — dropped from the
-// query key so paging/sorting doesn't trigger a refetch of the sidebar.
-const PAGING_AND_SORT_KEYS: Array<keyof ListingFilterRequest> = [
-  'page',
-  'size',
-  'sortBy',
-  'sortDirection',
-]
-
-const omitPagingAndSort = (
-  filters: Partial<ListingFilterRequest>,
-): Partial<ListingFilterRequest> => {
-  const rest: Partial<ListingFilterRequest> = { ...filters }
-  PAGING_AND_SORT_KEYS.forEach((key) => {
-    delete rest[key]
-  })
-  return rest
 }
 
 /**
- * Dynamic bucket options (price / area / bedrooms) for the public listings
- * sidebar — POST /v1/listings/filter-options. Each bucket carries a live
- * count of listings matching every OTHER active filter, so the sidebar can
- * grey out empty buckets instead of letting the user click into a dead end.
- *
- * Refetches whenever any non-paging filter changes — including price/area/
- * bedrooms themselves, since a bucket's count depends on the OTHER two
- * dimensions' current selection (e.g. selecting an area range changes the
- * price buckets' counts).
- *
- * The filter context is debounced (default 300ms): each backend call runs
- * up to ~14 COUNT(*) queries, and the sidebar's checkboxes let a user toggle
- * several buckets in quick succession — without debouncing, every click
- * would fire its own request instead of settling on the final selection.
+ * Static bucket options (price / area / bedrooms) for the public listings
+ * sidebar — GET /v1/listings/filter-options. The response is the same for
+ * every caller (no request body, no per-filter counts), so it's fetched
+ * once and kept forever: selecting a bucket in the sidebar never refetches
+ * it, since the options themselves don't depend on what's currently selected.
  */
 export const useListingFilterOptions = (
-  filters: Partial<ListingFilterRequest>,
   options?: UseListingFilterOptionsOptions,
 ) => {
-  const {
-    enabled = true,
-    staleTime = 60 * 1000,
-    gcTime = 5 * 60 * 1000,
-    debounceMs = 300,
-  } = options || {}
-  const contextFilters = useDebounce(omitPagingAndSort(filters), debounceMs)
+  const { enabled = true } = options || {}
 
   return useQuery({
-    queryKey: ['listings', 'filter-options', contextFilters],
+    queryKey: ['listings', 'filter-options'],
     queryFn: async (): Promise<ListingFilterOptionsResponse> => {
-      const backendRequest = mapFrontendToBackendRequest(contextFilters)
-      const response = await ListingService.getFilterOptions(backendRequest)
+      const response = await ListingService.getFilterOptions()
 
       if (!response.success || !response.data) {
         throw new Error(response.message || 'Failed to load filter options')
@@ -75,7 +30,7 @@ export const useListingFilterOptions = (
       return response.data
     },
     enabled,
-    staleTime,
-    gcTime,
+    staleTime: Infinity,
+    gcTime: 24 * 60 * 60 * 1000,
   })
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3643,7 +3643,6 @@
     "errorDescription": "Something went wrong while loading listings. Please try again.",
     "retry": "Retry",
     "filter": {
-      "optionWithCount": "{label} ({count})",
       "error": "Failed to load filters",
       "price": {
         "title": "Filter by price range",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3641,7 +3641,6 @@
     "errorDescription": "Đã xảy ra lỗi khi tải danh sách. Vui lòng thử lại.",
     "retry": "Thử lại",
     "filter": {
-      "optionWithCount": "{label} ({count})",
       "error": "Không tải được bộ lọc",
       "price": {
         "title": "Lọc theo khoảng giá",


### PR DESCRIPTION
Matches the backend endpoint's new shape: GET /v1/listings/filter-options takes no request body and returns the same static bucket list for every caller, so useListingFilterOptions now fetches once (staleTime: Infinity) instead of refetching on every filter change. Drops the debounce logic and the per-option count display in the sidebar, since neither applies anymore.