### PR TITLE
Replace AI-looking Sparkles icon with Gem/Lightbulb

### DIFF
--- a/src/components/molecules/listSearchWithSuggestions/index.tsx
+++ b/src/components/molecules/listSearchWithSuggestions/index.tsx
@@ -22,7 +22,7 @@ import {
   ArrowRight,
   ArrowLeft,
   CornerDownLeft,
-  Sparkles,
+  Lightbulb,
   SpellCheck,
   AudioLines,
 } from 'lucide-react'
@@ -101,7 +101,7 @@ const TYPE_ICON: Record<SuggestionType, React.ElementType> = {
   TITLE: Building2,
   LOCATION: MapPin,
   POPULAR_QUERY: TrendingUp,
-  AI_INTENT: Sparkles,
+  AI_INTENT: Lightbulb,
   TYPO_CORRECTION: SpellCheck,
   PHONETIC: AudioLines,
 }

--- a/src/components/molecules/mapMarker/index.tsx
+++ b/src/components/molecules/mapMarker/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { VipType } from '@/api/types/property.type'
-import { Crown, Sparkles, Star, Home } from 'lucide-react'
+import { Crown, Gem, Star, Home } from 'lucide-react'
 
 interface MapMarkerProps {
   vipType: VipType
@@ -25,7 +25,7 @@ const getVipStyle = (vipType: VipType): VipStyle => {
         bg: 'bg-blue-600',
         hover: 'hover:bg-blue-700',
         arrow: 'border-t-blue-600',
-        icon: <Sparkles size={ICON_SIZE} />,
+        icon: <Gem size={ICON_SIZE} />,
       }
     case 'GOLD':
       return {

--- a/src/components/molecules/renewListingDialog/index.tsx
+++ b/src/components/molecules/renewListingDialog/index.tsx
@@ -4,8 +4,8 @@ import {
   CalendarPlus,
   Clock,
   Crown,
+  Gem,
   PackageOpen,
-  Sparkles,
   Tag,
   TriangleAlert,
 } from 'lucide-react'
@@ -45,7 +45,7 @@ const TIER_THEME: Record<
 > = {
   SILVER: { icon: Tag, pill: 'bg-gray-100 text-gray-700' },
   GOLD: { icon: Crown, pill: 'bg-yellow-100 text-yellow-700' },
-  DIAMOND: { icon: Sparkles, pill: 'bg-blue-100 text-blue-700' },
+  DIAMOND: { icon: Gem, pill: 'bg-blue-100 text-blue-700' },
 }
 
 const DAYS_ADDED = 30

--- a/src/components/molecules/repostListingDialog/index.tsx
+++ b/src/components/molecules/repostListingDialog/index.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl'
 import {
   CheckCircle2,
   Crown,
+  Gem,
   Info,
   PackageOpen,
   Sparkles,
@@ -96,7 +97,7 @@ const TIER_THEME: Record<
     currentBadge: 'bg-yellow-100 text-yellow-700',
   },
   DIAMOND: {
-    icon: Sparkles,
+    icon: Gem,
     selected: 'border-blue-400 bg-blue-400 text-white',
     unselected: 'border-blue-300 bg-background hover:border-blue-400',
     iconColor: 'text-blue-500',


### PR DESCRIPTION
The DIAMOND VIP tier (map marker, renew/repost dialogs) and the contextual search-suggestion group both used Sparkles, which reads as a generic AI icon rather than what they represent. DIAMOND tier now uses Gem (matching the icon already used for it in the create-post package section); the "Gợi ý theo ngữ cảnh" suggestion type uses Lightbulb.