### PR TITLE
Replace AI-looking Sparkles icon on STANDARD package tier

### DIFF
--- a/src/components/molecules/pricingPlanCard/index.tsx
+++ b/src/components/molecules/pricingPlanCard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { useTranslations } from 'next-intl'
-import { Leaf, Sparkles, Crown } from 'lucide-react'
+import { Leaf, Star, Crown } from 'lucide-react'
 import {
   Card,
   CardHeader,
@@ -51,7 +51,7 @@ export const getMembershipLevelIcon = (
       <Leaf className='size-7 text-emerald-600 dark:text-emerald-400' />
     ),
     [MembershipPackageLevel.STANDARD]: (
-      <Sparkles className='size-7 text-sky-600 dark:text-sky-400' />
+      <Star className='size-7 text-sky-600 dark:text-sky-400' />
     ),
     [MembershipPackageLevel.ADVANCED]: (
       <Crown className='size-7 text-primary' />


### PR DESCRIPTION
The membership register page (sellernet/membership/register) shows a Sparkles icon as the badge for the STANDARD package tier, which reads as generic AI branding rather than a package rank. Swapped for Star to keep the Leaf (basic) -> Star (standard) -> Crown (advanced) tier progression readable without the AI association.