### PR TITLE
fix: đổi placeholder tìm kiếm trên mobile từ "bất động sản" sang "phò…

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2502,7 +2502,7 @@
       "vnd": "VND",
       "usd": "USD"
     },
-    "searchPlaceholder": "Search residential properties...",
+    "searchPlaceholder": "Search rentals, boarding rooms...",
     "locationEnabled": "Searching near your location",
     "actions": {
       "search": "Search",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2262,7 +2262,7 @@
       "vnd": "đ",
       "usd": "Đô"
     },
-    "searchPlaceholder": "Tìm kiếm bất động sản nhà ở...",
+    "searchPlaceholder": "Tìm kiếm phòng trọ, nhà cho thuê...",
     "locationEnabled": "Đang tìm gần vị trí của bạn",
     "actions": {
       "search": "Tìm kiếm",


### PR DESCRIPTION
…ng trọ, nhà cho thuê"

Placeholder ô tìm kiếm trên mobile (residentialFilter.searchPlaceholder) đang dùng ngôn ngữ "bất động sản" không khớp định vị Thuê Nhà Trọ.