### PR TITLE
fix(ai-chat): surface chat failures with a distinct, retriable error …

### DIFF
--- a/src/components/molecules/aiChatBubble/index.tsx
+++ b/src/components/molecules/aiChatBubble/index.tsx
@@ -3,7 +3,14 @@ import { useTranslations } from 'next-intl'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Link from 'next/link'
-import { ArrowUpRight, LogIn, Maximize2, Phone } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  LogIn,
+  Maximize2,
+  Phone,
+  RotateCcw,
+} from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { TChatMessage } from '@/hooks/useChatAi'
@@ -30,6 +37,8 @@ type TAiChatBubbleProps = {
   onViewListingDetail?: (listingId: number) => void
   onOpenFullDetail?: (listingId: number) => void
   onSuggestionClick?: (query: string) => void
+  /** Re-send the failed question behind an error bubble (passed its id). */
+  onRetry?: (errorMessageId: string) => void
 }
 
 // Follow-up chips share a pill shape; only the fill differs — a deep-link chip
@@ -212,8 +221,10 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
   onViewListingDetail,
   onOpenFullDetail,
   onSuggestionClick,
+  onRetry,
 }) => {
   const isBot = message.sender === 'bot'
+  const isError = isBot && message.error === true
   // While a bot message is still streaming we render it as plain text and
   // defer markdown parsing until it settles. ReactMarkdown re-parses the
   // whole message on every token, so parsing per delta is O(n^2) over the
@@ -281,11 +292,40 @@ const AiChatBubble: FC<TAiChatBubbleProps> = ({
             : 'items-end max-w-[80%] md:max-w-[75%]',
         )}
       >
+        {/* Error bubble — a failed turn, styled distinctly (warning icon +
+            destructive tint) so it never reads as a normal reply, with an
+            optional Try-again that re-sends the question. */}
+        {isError && (
+          <div className='flex flex-col gap-1.5'>
+            <div className='flex items-start gap-2 rounded-2xl rounded-bl-md border border-destructive/30 bg-destructive/10 px-4 py-2.5 shadow-sm'>
+              <AlertTriangle
+                className='mt-0.5 h-4 w-4 flex-shrink-0 text-destructive'
+                aria-hidden='true'
+              />
+              <p className='whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground'>
+                {message.content}
+              </p>
+            </div>
+            {message.retryContent && onRetry && (
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                className='h-8 gap-1.5 self-start border-destructive/40 px-3 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive'
+                onClick={() => onRetry(message.id)}
+              >
+                <RotateCcw className='h-3.5 w-3.5' aria-hidden='true' />
+                {tAi('retry')}
+              </Button>
+            )}
+          </div>
+        )}
+
         {/* Message Bubble — hide for bot when there's no text (e.g. agent
             returned only listings without a prose answer). User bubbles
             always render. The asymmetric corner ("tail") visually anchors
             the bubble to its speaker. */}
-        {(!isBot || message.content.trim().length > 0) && (
+        {!isError && (!isBot || message.content.trim().length > 0) && (
           <div
             className={cn(
               'rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden break-words',
@@ -506,6 +546,7 @@ export default memo(AiChatBubble, (prev, next) => {
     prev.isLast === next.isLast &&
     prev.onViewListingDetail === next.onViewListingDetail &&
     prev.onOpenFullDetail === next.onOpenFullDetail &&
-    prev.onSuggestionClick === next.onSuggestionClick
+    prev.onSuggestionClick === next.onSuggestionClick &&
+    prev.onRetry === next.onRetry
   )
 })

--- a/src/components/organisms/aiChatInterface/index.tsx
+++ b/src/components/organisms/aiChatInterface/index.tsx
@@ -26,6 +26,8 @@ type TAiChatInterfaceProps = {
   onScrollToBottom: () => void
   onInputChange: (value: string) => void
   onSendMessage: (value: string) => void
+  /** Re-send a failed turn from its error bubble's Try-again button. */
+  onRetryMessage?: (errorMessageId: string) => void
   onViewListingDetail?: (listingId: number) => void
   /** Cancel the in-flight SSE stream — wired through to the typing
    * indicator's × button. */
@@ -50,6 +52,7 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
   onScrollToBottom,
   onInputChange,
   onSendMessage,
+  onRetryMessage,
   onViewListingDetail,
   onStopStreaming,
   guestLimitReached = false,
@@ -156,6 +159,7 @@ const AiChatInterface: FC<TAiChatInterfaceProps> = ({
                       onViewListingDetail={onViewListingDetail}
                       onOpenFullDetail={setFullDetailListingId}
                       onSuggestionClick={onSendMessage}
+                      onRetry={onRetryMessage}
                     />
                   </div>
                 )

--- a/src/components/organisms/aiChatWidget/index.tsx
+++ b/src/components/organisms/aiChatWidget/index.tsx
@@ -54,6 +54,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
     isAtBottom,
     scrollToBottom,
     sendMessage,
+    retryMessage,
     viewListingDetail,
     cancelStream,
     handleInputChange,
@@ -176,6 +177,7 @@ const AiChatWidget: FC<TAiChatWidgetProps> = ({
                 onScrollToBottom={scrollToBottom}
                 onInputChange={handleInputChange}
                 onSendMessage={sendMessage}
+                onRetryMessage={retryMessage}
                 onViewListingDetail={viewListingDetail}
                 onStopStreaming={cancelStream}
                 guestLimitReached={guestLimitReached}

--- a/src/hooks/useChatAi/useChatLogic.errorHandling.test.ts
+++ b/src/hooks/useChatAi/useChatLogic.errorHandling.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { AiService } from '@/api/services/ai.service'
+import { useChatLogic } from './useChatLogic'
+
+// --- Dependency isolation (auth state, DOM-coupled scroll, network, i18n) ---
+// Mirrors useChatLogic.guestQuota.test.ts so both suites stub the same seams.
+
+const { authRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      isAuthenticated: true,
+      user: { userId: 'u1' } as { userId: string } | null,
+    },
+  },
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => authRef.current,
+}))
+
+vi.mock('next-intl', () => {
+  const t = ((key: string) => key) as ((key: string) => string) & {
+    raw: (key: string) => unknown
+  }
+  t.raw = () => []
+  return { useTranslations: () => t, useLocale: () => 'en' }
+})
+
+vi.mock('./useChatScroll', () => ({
+  useChatScroll: () => ({
+    scrollRef: { current: null },
+    bottomRef: { current: null },
+    contentRef: { current: null },
+    isAtBottom: true,
+    reservedSpace: 0,
+    scrollToMessage: vi.fn(),
+    scrollToBottom: vi.fn(),
+    anchorMessageToTop: vi.fn(),
+    finalizeReservedSpace: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api/services/chatbot.service', () => ({
+  streamChat: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/services/ai.service', () => ({
+  AiService: { chat: vi.fn() },
+}))
+
+const chatMock = AiService.chat as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  sessionStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('useChatLogic error handling (blocking path)', () => {
+  it('surfaces a retriable error message when the API call fails', async () => {
+    // apiRequest never throws — on any network/timeout/HTTP error it resolves
+    // with { success: false }. The hook must detect that and show an error.
+    chatMock.mockResolvedValue({ success: false })
+
+    const { result } = renderHook(() => useChatLogic())
+
+    await act(async () => {
+      await result.current.sendMessage('find me a room')
+    })
+
+    const errorMsg = result.current.messages.find(
+      (m) => m.sender === 'bot' && m.error === true,
+    )
+    expect(errorMsg).toBeDefined()
+    expect(errorMsg?.retryContent).toBe('find me a room')
+    // Never leaves the UI stuck in a loading/typing state.
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isTyping).toBe(false)
+  })
+
+  it('does not treat a failed response carrying partial data as a real reply', async () => {
+    // A failed envelope may still carry a data.message field; success:false
+    // must win so it is not rendered as a normal answer.
+    chatMock.mockResolvedValue({
+      success: false,
+      data: { message: { content: 'stale partial content' } },
+    })
+
+    const { result } = renderHook(() => useChatLogic())
+
+    await act(async () => {
+      await result.current.sendMessage('anything')
+    })
+
+    expect(
+      result.current.messages.some(
+        (m) => m.sender === 'bot' && m.content === 'stale partial content',
+      ),
+    ).toBe(false)
+    expect(
+      result.current.messages.some(
+        (m) => m.sender === 'bot' && m.error === true,
+      ),
+    ).toBe(true)
+  })
+
+  it('retry re-sends the failed message and clears the error on success', async () => {
+    chatMock.mockResolvedValueOnce({ success: false }).mockResolvedValueOnce({
+      success: true,
+      data: {
+        message: { content: 'Here you go' },
+        listings: null,
+        metadata: { tools_used: [] },
+      },
+    })
+
+    const { result } = renderHook(() => useChatLogic())
+
+    await act(async () => {
+      await result.current.sendMessage('find me a room')
+    })
+
+    const errorMsg = result.current.messages.find((m) => m.error === true)
+    expect(errorMsg).toBeDefined()
+
+    await act(async () => {
+      await result.current.retryMessage(errorMsg!.id)
+    })
+
+    // Error bubble gone, success reply present.
+    expect(result.current.messages.some((m) => m.error === true)).toBe(false)
+    expect(
+      result.current.messages.some(
+        (m) => m.sender === 'bot' && m.content === 'Here you go',
+      ),
+    ).toBe(true)
+    // Exactly one user bubble for the retried question — no duplicate.
+    expect(
+      result.current.messages.filter(
+        (m) => m.sender === 'user' && m.content === 'find me a room',
+      ),
+    ).toHaveLength(1)
+    expect(chatMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/hooks/useChatAi/useChatLogic.ts
+++ b/src/hooks/useChatAi/useChatLogic.ts
@@ -41,6 +41,12 @@ export type TChatMessage = {
    *  bubble renders plain text during streaming and defers markdown parsing
    *  until the stream settles, avoiding a full re-parse on every token. */
   isStreaming?: boolean
+  /** Marks a bot message that reports a failed turn. Rendered with a distinct
+   *  error style (warning icon + destructive tint) instead of a normal reply. */
+  error?: boolean
+  /** The user text that triggered this error, so a Try-again action can
+   *  re-send it. Absent when retrying can't help (e.g. login required). */
+  retryContent?: string
 }
 
 export type TChatState = {
@@ -185,10 +191,14 @@ export const useChatLogic = () => {
 
   //Init event handle
   const sendMessage = useCallback(
-    async (content: string) => {
+    async (content: string, options?: { isRetry?: boolean }) => {
       if (!content.trim() || isLoading) return
 
       const trimmedContent = content.trim()
+      // A retry re-runs the last (failed) turn: the user bubble is already in
+      // the transcript, so we reuse it instead of adding a duplicate and we
+      // don't bill the guest quota a second time.
+      const isRetry = options?.isRetry === true
 
       if (!isAuthenticated) {
         // At the limit the input is already disabled; this guards the
@@ -196,22 +206,29 @@ export const useChatLogic = () => {
         // CTA is surfaced by the effect below, not here.
         if (guestLimitReached) return
         // Under the limit — consume one guest turn and fall through to send.
-        incrementGuestQuota()
+        if (!isRetry) incrementGuestQuota()
       }
 
       // Cancel any prior in-flight stream before starting a new one
       abortRef.current?.abort()
 
-      const userMessage: TChatMessage = {
-        id: generateMessageId(),
-        content: trimmedContent,
-        sender: 'user',
-        timestamp: new Date(),
+      // On a retry, anchor to the existing user bubble; on a fresh send, add a
+      // new user message and anchor to it.
+      let anchorId: string | undefined
+      if (isRetry) {
+        anchorId = [...messages].reverse().find((m) => m.sender === 'user')?.id
+      } else {
+        const userMessage: TChatMessage = {
+          id: generateMessageId(),
+          content: trimmedContent,
+          sender: 'user',
+          timestamp: new Date(),
+        }
+        addMessage(userMessage)
+        setInputValue('')
+        anchorId = userMessage.id
       }
 
-      // Add user message using session method
-      addMessage(userMessage)
-      setInputValue('')
       setIsLoading(true)
       setIsTyping(true)
       setStreamingStatus(null)
@@ -219,19 +236,26 @@ export const useChatLogic = () => {
       // Anchor the just-sent message near the top of the viewport (reserving a
       // viewport of space below) so the question stays visible while the
       // answer streams in beneath it.
-      anchorMessageToTop(userMessage.id)
+      if (anchorId) anchorMessageToTop(anchorId)
 
       const conversationHistory: ChatMessage[] = messages
-        .filter((msg) => msg.sender === 'user' || msg.sender === 'bot')
+        .filter(
+          (msg) =>
+            (msg.sender === 'user' || msg.sender === 'bot') && !msg.error,
+        )
         .map((msg) => ({
           role: msg.sender === 'user' ? 'user' : 'assistant',
           content: msg.content,
         }))
 
-      conversationHistory.push({
-        role: 'user',
-        content: trimmedContent,
-      })
+      // On a fresh send the new user turn isn't in `messages` yet, so append
+      // it. On a retry the failed user bubble is already present above.
+      if (!isRetry) {
+        conversationHistory.push({
+          role: 'user',
+          content: trimmedContent,
+        })
+      }
 
       // Build last_listings from the most recent bot message that had listings
       const lastListings = buildLastListings(messages)
@@ -239,6 +263,24 @@ export const useChatLogic = () => {
       const requestPayload = {
         messages: conversationHistory,
         ...(lastListings.length > 0 && { last_listings: lastListings }),
+      }
+
+      // Add a visible, distinctly-styled error bubble and settle the loading
+      // UI so a failed turn never silently hangs. Offers a Try-again unless the
+      // failure is a login requirement (which a retry can't fix).
+      const surfaceError = (isUnauthorized = false) => {
+        setIsTyping(false)
+        setIsLoading(false)
+        setStreamingStatus(null)
+        addMessage({
+          id: generateMessageId(),
+          content: getChatErrorContent(locale, t, isUnauthorized),
+          sender: 'bot',
+          timestamp: new Date(),
+          error: true,
+          retryContent: isUnauthorized ? undefined : trimmedContent,
+        })
+        finalizeReservedSpace()
       }
 
       if (ENV.CHAT_STREAMING_ENABLED) {
@@ -320,6 +362,11 @@ export const useChatLogic = () => {
                     ...m,
                     content: m.content || msg || getChatErrorContent(locale, t),
                     isStreaming: false,
+                    // A partial answer stays a (settled) reply; only flag as an
+                    // error bubble when nothing streamed in.
+                    ...(m.content
+                      ? {}
+                      : { error: true, retryContent: trimmedContent }),
                   }))
                 } else {
                   addMessage({
@@ -327,6 +374,8 @@ export const useChatLogic = () => {
                     content: msg || getChatErrorContent(locale, t),
                     sender: 'bot',
                     timestamp: new Date(),
+                    error: true,
+                    retryContent: trimmedContent,
                   })
                 }
                 setIsTyping(false)
@@ -373,6 +422,15 @@ export const useChatLogic = () => {
       try {
         const response = await AiService.chat(requestPayload)
 
+        // apiRequest never throws — on any network/timeout/HTTP error it
+        // resolves with { success: false } (the catch below only covers a
+        // genuinely unexpected throw). Detect that explicitly so a failed turn
+        // can't be mistaken for a real answer even if it carries partial data.
+        if (!response.success) {
+          surfaceError()
+          return
+        }
+
         const chatResponse = response.data
 
         const aiMessage = chatResponse?.message
@@ -380,17 +438,7 @@ export const useChatLogic = () => {
         const toolsUsed = chatResponse?.metadata?.tools_used || []
 
         if (!aiMessage || !aiMessage.content) {
-          const errorMessage: TChatMessage = {
-            id: generateMessageId(),
-            content: getChatErrorContent(locale, t),
-            sender: 'bot',
-            timestamp: new Date(),
-          }
-
-          setIsTyping(false)
-          setIsLoading(false)
-          addMessage(errorMessage)
-          finalizeReservedSpace()
+          surfaceError()
           return
         }
         // Check if listings exist and have data
@@ -420,7 +468,8 @@ export const useChatLogic = () => {
         addMessage(botMessage)
         finalizeReservedSpace()
       } catch (error: unknown) {
-        // Handle network errors or actual exceptions
+        // Defensive: apiRequest normally swallows errors into { success:false }
+        // above, but a genuinely unexpected throw still lands here.
         console.error('[useChatLogic] Chat API error:', error)
 
         const errorStatus = error as {
@@ -430,17 +479,7 @@ export const useChatLogic = () => {
         const isUnauthorized =
           errorStatus?.response?.status === 401 || errorStatus?.status === 401
 
-        const errorMessage: TChatMessage = {
-          id: generateMessageId(),
-          content: getChatErrorContent(locale, t, isUnauthorized),
-          sender: 'bot',
-          timestamp: new Date(),
-        }
-
-        setIsTyping(false)
-        setIsLoading(false)
-        addMessage(errorMessage)
-        finalizeReservedSpace()
+        surfaceError(isUnauthorized)
       }
     },
     [
@@ -479,6 +518,20 @@ export const useChatLogic = () => {
     [locale, sendMessage],
   )
 
+  // Re-run a failed turn: drop the error bubble and re-send the question that
+  // produced it. Reuses the original user bubble (no duplicate) via the
+  // isRetry path in sendMessage.
+  const retryMessage = useCallback(
+    (errorMessageId: string) => {
+      const errorMsg = messages.find((m) => m.id === errorMessageId)
+      const content = errorMsg?.retryContent
+      if (!content) return
+      removeMessage(errorMessageId)
+      sendMessage(content, { isRetry: true })
+    },
+    [messages, removeMessage, sendMessage],
+  )
+
   const cancelStream = useCallback(() => {
     abortRef.current?.abort()
     abortRef.current = null
@@ -512,6 +565,7 @@ export const useChatLogic = () => {
     reservedSpace,
     scrollToBottom,
     sendMessage,
+    retryMessage,
     viewListingDetail,
     cancelStream,
     handleInputChange,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -41,6 +41,7 @@
     "send": "Send message",
     "typing": "Bot is typing",
     "stop": "Stop generating",
+    "retry": "Try again",
     "clearHistory": "Clear chat history",
     "close": "Close chat",
     "openChat": "Open chat",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -41,6 +41,7 @@
     "send": "Gửi tin nhắn",
     "typing": "Bot đang nhập",
     "stop": "Dừng tạo phản hồi",
+    "retry": "Thử lại",
     "clearHistory": "Xóa lịch sử chat",
     "close": "Đóng chat",
     "openChat": "Mở chat",


### PR DESCRIPTION
…state

The chat's blocking JSON path relied on AiService.chat throwing to trigger its error handling, but apiRequest swallows every error and resolves with { success: false } instead. As a result the catch block was dead code and a failed turn either rendered as a plain (indistinguishable) bubble or, when a failed envelope carried partial data, as a normal reply — so failures looked like nothing happened.

- useChatLogic: detect response.success === false explicitly in the blocking path (and guard the partial-data case), always resetting isLoading/isTyping so a failed turn can't hang.
- Add error/retryContent to TChatMessage; exclude error bubbles from the AI conversation history.
- Add retryMessage + an isRetry send path that reuses the existing user bubble (no duplicate) and doesn't double-bill the guest quota.
- aiChatBubble: render error messages with a destructive tint + warning icon and a "Try again" action wired through aiChatInterface/aiChatWidget.
- i18n: add aiChat.retry (en + vi).
- Tests: cover failed-response, partial-data-not-a-reply, and retry flows.


Claude-Session: https://claude.ai/code/session_015V6DVgCjg4pgon5fSpvRCY