### PR TITLE
fix: xoá dòng mô tả ưu tiên quyền lợi thành viên trong khối gói tin

### DIFF
--- a/src/components/organisms/createPostSections/packageConfigSection.tsx
+++ b/src/components/organisms/createPostSections/packageConfigSection.tsx
@@ -493,14 +493,8 @@ const PackageConfigSection: React.FC<PackageConfigSectionProps> = ({
           canOpenBenefits && (
             <div className='flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-primary/30 bg-primary/5 px-4 py-3'>
               <Gift className='w-4 h-4 shrink-0 text-primary' />
-              <Typography className='text-sm font-medium'>
+              <Typography className='flex-1 text-sm font-medium'>
                 {t('membershipPriorityTitle')}
-              </Typography>
-              <Typography
-                variant='muted'
-                className='min-w-[10rem] flex-1 text-sm'
-              >
-                {t('membershipPriorityDescription')}
               </Typography>
               <Button
                 type='button'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1148,7 +1148,6 @@
         "description": "Select a membership or push voucher package to optimize visibility",
         "selectPackageType": "Select package type",
         "membershipPriorityTitle": "You have an available membership package",
-        "membershipPriorityDescription": "Use your membership benefit first to post for free — no need to buy an extra package.",
         "orBuyDirectly": "Or buy a package directly",
         "selectDuration": "Post longer, save more!",
         "packages": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1148,7 +1148,6 @@
         "description": "Chọn gói hội viên hoặc gói đẩy tin phù hợp để tối ưu hiển thị",
         "selectPackageType": "Chọn loại tin",
         "membershipPriorityTitle": "Bạn đang có gói hội viên khả dụng",
-        "membershipPriorityDescription": "Ưu tiên sử dụng quyền lợi thành viên để đăng tin miễn phí, không cần mua thêm gói.",
         "orBuyDirectly": "Hoặc mua gói lẻ",
         "selectDuration": "Đăng dài ngày hơn, hiệu kiệm hơn!",
         "packages": {


### PR DESCRIPTION
Bỏ text "Ưu tiên sử dụng quyền lợi thành viên để đăng tin miễn phí, không cần mua thêm gói" khỏi packageConfigSection, đồng thời dọn key i18n membershipPriorityDescription không còn dùng ở cả hai locale.